### PR TITLE
Differentiate between a login failure and cancellation.

### DIFF
--- a/src/FBLoginDialog.h
+++ b/src/FBLoginDialog.h
@@ -41,7 +41,7 @@
 
 - (void) fbDialogLogin:(NSString *) token expirationDate:(NSDate *) expirationDate;
 
-- (void) fbDialogNotLogin;
+- (void) fbDialogNotLogin:(BOOL)cancelled;
 
 @end
 

--- a/src/FBLoginDialog.m
+++ b/src/FBLoginDialog.m
@@ -76,8 +76,8 @@
  */
 - (void)dialogDidCancel:(NSURL *)url {
   [self dismissWithSuccess:NO animated:YES];
-  if ([_loginDelegate respondsToSelector:@selector(fbDialogNotLogin)]) {
-    [_loginDelegate fbDialogNotLogin];
+  if ([_loginDelegate respondsToSelector:@selector(fbDialogNotLogin:)]) {
+    [_loginDelegate fbDialogNotLogin:YES];
   }
 }
 
@@ -85,8 +85,8 @@
   if (!(([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -999) ||
         ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
     [super webView:webView didFailLoadWithError:error];
-    if ([_loginDelegate respondsToSelector:@selector(fbDialogNotLogin)]) {
-      [_loginDelegate fbDialogNotLogin];
+	if ([_loginDelegate respondsToSelector:@selector(fbDialogNotLogin:)]) {
+	  [_loginDelegate fbDialogNotLogin:NO];
     }
   }
 }

--- a/src/Facebook.h
+++ b/src/Facebook.h
@@ -96,7 +96,7 @@
 /**
  * Called when the user dismiss the dialog without login
  */
-- (void)fbDidNotLogin;
+- (void)fbDidNotLogin:(BOOL)cancelled;
 
 /**
  * Called when the user is logged out

--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -411,9 +411,9 @@ static NSString* kSDKVersion = @"ios";
 /**
  * Did not login call the not login delegate
  */
-- (void) fbDialogNotLogin {
-  if ([self.sessionDelegate respondsToSelector:@selector(fbDidNotLogin)]) {
-    [_sessionDelegate fbDidNotLogin];
+- (void) fbDialogNotLogin:(BOOL)cancelled {
+  if ([self.sessionDelegate respondsToSelector:@selector(fbDidNotLogin:)]) {
+    [_sessionDelegate fbDidNotLogin:cancelled];
   }
 }
 


### PR DESCRIPTION
We've extended the fbDidNotLogin selector with a new 'cancellation' flag indicating whether or not the login attempt failed due to a connection failure or because the dialog was canceled by the user.
