### PR TITLE
Minor syntax change in README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -77,7 +77,7 @@ When the user wants to stop using Facebook integration with your application, yo
 Accessing the Graph API
 -----------------------
 
-The (http://developers.facebook.com/docs/api)[Facebook Graph API] presents a simple, consistent view of the Facebook social graph, uniformly representing objects in the graph (e.g., people, photos, events, and fan pages) and the connections between them (e.g., friend relationships, shared content, and photo tags).
+The [Facebook Graph API](http://developers.facebook.com/docs/api) presents a simple, consistent view of the Facebook social graph, uniformly representing objects in the graph (e.g., people, photos, events, and fan pages) and the connections between them (e.g., friend relationships, shared content, and photo tags).
 
 You can access the Graph API by passing the Graph Path to the ''request'' method. For example, to access information about the logged in user, call
 


### PR DESCRIPTION
The existing markdown README had (link)[description] instead of [description](link) for the Facebook Graph API link
