### PR TITLE
fix dialog:didFailWithError on deauthorized token

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -397,9 +397,10 @@ BOOL FBIsDeviceIPad() {
   NSURL* url = request.URL;
 
   if ([url.scheme isEqualToString:@"fbconnect"]) {
-    if ([[url.resourceSpecifier substringToIndex:8] isEqualToString:@"//cancel"]) {
-      NSString * errorCode = [self getStringFromUrl:[url absoluteString] needle:@"error_code="];
-      NSString * errorStr = [self getStringFromUrl:[url absoluteString] needle:@"error_msg="];
+	NSString * errorCode = [self getStringFromUrl:[url absoluteString] needle:@"error_code="];
+    NSString * errorStr = [self getStringFromUrl:[url absoluteString] needle:@"error_msg="];
+    if ([[url.resourceSpecifier substringToIndex:8] isEqualToString:@"//cancel"] ||
+		([[url.resourceSpecifier substringToIndex:9] isEqualToString:@"//success"] && errorCode && errorStr)) {
       if (errorCode) {
         NSDictionary * errorData = [NSDictionary dictionaryWithObject:errorStr forKey:@"error_msg"];
         NSError * error = [NSError errorWithDomain:@"facebookErrDomain"


### PR DESCRIPTION
when a user deauthorizes her token from the facebook privacy settings, an application doesn't necessarily know about this.  

when the application calls a dialog, the server responds with the url "fbconnect://success/?error_code=190&amp;error_msg=Error+validating+access+token.", which does not result in a call to dialog:didFailWithError because of the "//success".  this is most likely an error with the api responding with "//success" instead of "//cancel", but i have put in a temporary workaround so that i can find out when the token has been dauthed
