### PR TITLE
Updating .gitignore for Xcode4 and updating base SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,17 @@
 sample/DemoApp/build/
 sample/DemoApp/DemoApp.xcodeproj/*.pbxuser
 sample/DemoApp/DemoApp.xcodeproj/*.mode*
+sample/DemoApp/DemoApp.xcodeproj/*.xcworkspace/
+sample/DemoApp/DemoApp.xcodeproj/xcuserdata/
 sample/theRunAround/build/
 sample/theRunAround/theRunAround.xcodeproj/*.pbxuser
 sample/theRunAround/theRunAround.xcodeproj/*.mode*
+sample/theRunAround/theRunAround.xcodeproj/*.xcworkspace/
+sample/theRunAround/theRunAround.xcodeproj/xcuserdata/
 src/facebook-ios-sdk.xcodeproj/*.pbxuser
 src/facebook-ios-sdk.xcodeproj/*.mode*
+src/facebook-ios-sdk.xcodeproj/*.xcworkspace/
+src/facebook-ios-sdk.xcodeproj/xcuserdata/
 src/build/
 test/UnitTest/UnitTest.xcodeproj/*.pbxuser
 test/UnitTest/UnitTest.xcodeproj/*.mode*

--- a/src/facebook-ios-sdk.xcodeproj/project.pbxproj
+++ b/src/facebook-ios-sdk.xcodeproj/project.pbxproj
@@ -197,7 +197,11 @@
 			isa = PBXProject;
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "facebook-ios-sdk" */;
 			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				en,
+			);
 			mainGroup = 0867D691FE84028FC02AAC07 /* facebook-ios-sdk */;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
@@ -271,7 +275,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphoneos3.2;
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -284,7 +288,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PREBINDING = NO;
-				SDKROOT = iphoneos3.2;
+				SDKROOT = iphoneos;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Adding xcworkspace and xcuserdata to the .gitignore. These are new ignorable files from Xcode4.
Setting target to Latest iOS (iphoneos). Previously it was iphoneos3.2 which would cause a warning on current SDKs.
