### PR TITLE
added double parens in if ((self = [super something_here])) because LLVM 

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -293,7 +293,7 @@ BOOL FBIsDeviceIPad() {
 // NSObject
 
 - (id)init {
-  if (self = [super initWithFrame:CGRectZero]) {
+  if ((self = [super initWithFrame:CGRectZero])) {
     _delegate = nil;
     _loadingURL = nil;
     _orientation = UIDeviceOrientationUnknown;


### PR DESCRIPTION
added double parens in if ((self = [super something_here])) because LLVM complains when there are only single parens
