### PR TITLE
Fix broken accessToken for in-app auth re #249

### DIFF
--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -574,7 +574,8 @@ static NSString* kSDKVersion = @"2";
  * Set the authToken and expirationDate after login succeed
  */
 - (void)fbDialogLogin:(NSString *)token expirationDate:(NSDate *)expirationDate {
-  self.accessToken = token;
+  NSString *pcenToken = [(NSString *)CFURLCreateStringByAddingPercentEscapes(NULL, (CFStringRef) token, NULL, (CFStringRef) @"!*'();:@&=+$,/?%#[]", kCFStringEncodingUTF8) autorelease];
+  self.accessToken = pcenToken;
   self.expirationDate = expirationDate;
   if ([self.sessionDelegate respondsToSelector:@selector(fbDidLogin)]) {
     [_sessionDelegate fbDidLogin];


### PR DESCRIPTION
re #249

The in-app dialog returns an access token different to the one from using a web browser or FB app (like you would on a multi-tasking device). This results in an accessToken that's not useable.
