### PR TITLE
fix crash in FBRequest

### DIFF
--- a/src/FBRequest.h
+++ b/src/FBRequest.h
@@ -32,7 +32,7 @@
 }
 
 
-@property(nonatomic,assign) id<FBRequestDelegate> delegate;
+@property(nonatomic,retain) id<FBRequestDelegate> delegate;
 
 /**
  * The URL which will be contacted to execute the request.

--- a/src/FBRequest.m
+++ b/src/FBRequest.m
@@ -237,6 +237,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
   if ([_delegate respondsToSelector:@selector(request:didFailWithError:)]) {
     [_delegate request:self didFailWithError:error];
   }
+  self.delegate = nil;
 }
 
 /*
@@ -262,7 +263,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
     }
 
   }
-
+  self.delegate = nil;
 }
 
 
@@ -311,6 +312,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
  * Free internal structure
  */
 - (void)dealloc {
+  self.delegate = nil;
   [_connection cancel];
   [_connection release];
   [_responseText release];


### PR DESCRIPTION
See: https://github.com/facebook/facebook-ios-sdk/issues/55

fix crash when FBRequest delegate is released before request finishes. Fixes #55.
