### PR TITLE
requestWithURLString method added

### DIFF
--- a/src/Facebook.h
+++ b/src/Facebook.h
@@ -75,6 +75,9 @@
                      andHttpMethod:(NSString *)httpMethod
                        andDelegate:(id <FBRequestDelegate>)delegate;
 
+- (void)requestWithURLString:(NSString *)fullURL
+                 andDelegate:(id <FBRequestDelegate>)delegate;
+
 - (void)dialog:(NSString *)action
    andDelegate:(id<FBDialogDelegate>)delegate;
 

--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -559,6 +559,20 @@ static NSString* kSDKVersion = @"2";
 }
 
 /**
+ * Make a request to the Facebook Graph API with the given URL.
+ *
+ * @param fullURL
+ *            URL to the graph API that we get from paging
+ * @param delegate
+ *            Callback interface for notifying the calling application when
+ *            the request has received response
+ */
+- (void)requestWithURLString:(NSString *)fullURL
+                 andDelegate:(id <FBRequestDelegate>)delegate {
+    [self openUrl:fullURL params:nil httpMethod:@"GET" delegate:delegate];
+}
+
+/**
  * Generate a UI dialog for the request action.
  *
  * @param action


### PR DESCRIPTION
 I thought a lot of people will need this method because Graph API often gives URL string for the next request page. For example when you're requesting say, photos, it'll only show the first few and then gives us a URL to go to the next few. We can then just pass this URL with the new method.
