### PR TITLE
Fixed so that non-json `false` response does not automatically fail with 

### DIFF
--- a/src/FBRequest.m
+++ b/src/FBRequest.m
@@ -184,13 +184,16 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
   if ([responseString isEqualToString:@"true"]) {
     return [NSDictionary dictionaryWithObject:@"true" forKey:@"result"];
   } else if ([responseString isEqualToString:@"false"]) {
-    if (error != nil) {
+    if (*error == nil) {
+      return [NSDictionary dictionaryWithObject:@"false" forKey:@"result"];
+    }
+    else {
       *error = [self formError:kGeneralErrorCode
                       userInfo:[NSDictionary
                                 dictionaryWithObject:@"This operation can not be completed"
                                 forKey:@"error_msg"]];
+      return nil;
     }
-    return nil;
   }
 
 


### PR DESCRIPTION
I'm not sure this fix is how it should be done, but I needed to make the pages.isFan call works also for `false` responses. See also Issue #210.
