### PR TITLE
Updated for iOS 5.0, Xcode 4.2, LLVM 3.0

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -172,7 +172,7 @@ params   = _params;
     CGFloat width = floor(scale_factor * frame.size.width) - kPadding * 2;
     CGFloat height = floor(scale_factor * frame.size.height) - kPadding * 2;
     
-    _orientation = [UIApplication sharedApplication].statusBarOrientation;
+    _orientation = (UIDeviceOrientation)[UIApplication sharedApplication].statusBarOrientation;
     if (UIInterfaceOrientationIsLandscape(_orientation)) {
         self.frame = CGRectMake(kPadding, kPadding, height, width);
     } else {
@@ -287,7 +287,7 @@ params   = _params;
 // NSObject
 
 - (id)init {
-    if (self == [super initWithFrame:CGRectZero]) {
+    if ((self = [super initWithFrame:CGRectZero])) {
         _delegate = nil;
         _loadingURL = nil;
         _orientation = UIDeviceOrientationUnknown;
@@ -419,7 +419,7 @@ params   = _params;
 // UIDeviceOrientationDidChangeNotification
 
 - (void)deviceOrientationDidChange:(void*)object {
-    UIDeviceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    UIDeviceOrientation orientation = (UIDeviceOrientation)[UIApplication sharedApplication].statusBarOrientation;
     if (!_showingKeyboard && [self shouldRotateToOrientation:orientation]) {
         [self updateWebOrientation];
         


### PR DESCRIPTION
- fix all static analyzer warnings
- there was a self comparison (self == init)  when it should have been an assignment ((self = init))
