### PR TITLE
Fix warnings: UIDeviceOrientation, prototype func.

### DIFF
--- a/src/FBDialog.h
+++ b/src/FBDialog.h
@@ -33,7 +33,7 @@
   UIWebView* _webView;
   UIActivityIndicatorView* _spinner;
   UIButton* _closeButton;
-  UIDeviceOrientation _orientation;
+  UIInterfaceOrientation _orientation;
   BOOL _showingKeyboard;
 
   // Ensures that UI elements behind the dialog are disabled.

--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -31,7 +31,7 @@ static CGFloat kBorderWidth = 10;
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-BOOL FBIsDeviceIPad() {
+static BOOL FBIsDeviceIPad() {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 30200
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
         return YES;
@@ -129,14 +129,14 @@ params   = _params;
     CGColorSpaceRelease(space);
 }
 
-- (BOOL)shouldRotateToOrientation:(UIDeviceOrientation)orientation {
+- (BOOL)shouldRotateToOrientation:(UIInterfaceOrientation)orientation {
     if (orientation == _orientation) {
         return NO;
     } else {
-        return orientation == UIDeviceOrientationLandscapeLeft
-        || orientation == UIDeviceOrientationLandscapeRight
-        || orientation == UIDeviceOrientationPortrait
-        || orientation == UIDeviceOrientationPortraitUpsideDown;
+        return orientation == UIInterfaceOrientationPortrait
+        || orientation == UIInterfaceOrientationPortraitUpsideDown
+        || orientation == UIInterfaceOrientationLandscapeLeft
+        || orientation == UIInterfaceOrientationLandscapeRight;
     }
 }
 
@@ -290,7 +290,6 @@ params   = _params;
     if (self == [super initWithFrame:CGRectZero]) {
         _delegate = nil;
         _loadingURL = nil;
-        _orientation = UIDeviceOrientationUnknown;
         _showingKeyboard = NO;
         
         self.backgroundColor = [UIColor clearColor];
@@ -419,7 +418,7 @@ params   = _params;
 // UIDeviceOrientationDidChangeNotification
 
 - (void)deviceOrientationDidChange:(void*)object {
-    UIDeviceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
     if (!_showingKeyboard && [self shouldRotateToOrientation:orientation]) {
         [self updateWebOrientation];
         


### PR DESCRIPTION
This fixes a couple warnings:
1. Use UIInterfaceOrientation instead of UIDeviceOrientation
2. http://stackoverflow.com/questions/7076345/no-previous-prototype-for-function-warning
