### PR TITLE
Properly initialize FBDialog

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -287,7 +287,7 @@ params   = _params;
 // NSObject
 
 - (id)init {
-    if (self == [super initWithFrame:CGRectZero]) {
+    if ((self = [super initWithFrame:CGRectZero])) {
         _delegate = nil;
         _loadingURL = nil;
         _orientation = UIDeviceOrientationUnknown;


### PR DESCRIPTION
The FBDialog initializer was not properly setting 'self', revealed by static analyzer.
