### PR TITLE
Fix for device orientation warnings

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -172,7 +172,7 @@ params   = _params;
     CGFloat width = floor(scale_factor * frame.size.width) - kPadding * 2;
     CGFloat height = floor(scale_factor * frame.size.height) - kPadding * 2;
     
-    _orientation = [UIApplication sharedApplication].statusBarOrientation;
+    _orientation = [[UIDevice currentDevice] orientation];
     if (UIInterfaceOrientationIsLandscape(_orientation)) {
         self.frame = CGRectMake(kPadding, kPadding, height, width);
     } else {
@@ -419,7 +419,8 @@ params   = _params;
 // UIDeviceOrientationDidChangeNotification
 
 - (void)deviceOrientationDidChange:(void*)object {
-    UIDeviceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+    UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+
     if (!_showingKeyboard && [self shouldRotateToOrientation:orientation]) {
         [self updateWebOrientation];
         


### PR DESCRIPTION
FBDialog.m had compiler warning: Implicit conversion from enumeration type 'UIInterfaceOrientation' to different enumeration type 'UIDeviceOrientation'.  Replaced call to [UIApplication sharedApplication].statusBarOrientation to [[UIDevice currentDevice] orientation] to return expected type of UIDeviceOrientation.
