### PR TITLE
Get project to build with no warnings on Xcode 4.2 / iOS 5

### DIFF
--- a/sample/Hackbook/Hackbook/APICallsViewController.m
+++ b/sample/Hackbook/Hackbook/APICallsViewController.m
@@ -559,6 +559,7 @@
                               otherButtonTitles:nil,
                               nil];
     [alertView show];
+    [alertView release];
 }
 
 /*
@@ -697,6 +698,8 @@
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                    img, @"picture",
                                    nil];
+    [img release];
+    
     [[delegate facebook] requestWithGraphPath:@"me/photos"
                           andParams:params
                       andHttpMethod:@"POST"
@@ -995,15 +998,17 @@
             NSMutableArray *friendsWithApp = [[NSMutableArray alloc] initWithCapacity:1];
             // Many results
             if ([result isKindOfClass:[NSArray class]]) {
-                friendsWithApp = [[NSMutableArray alloc] initWithArray:result copyItems:YES];
+                [friendsWithApp addObjectsFromArray:result];
             } else if ([result isKindOfClass:[NSDecimalNumber class]]) {
-                friendsWithApp = [[NSMutableArray alloc] initWithObjects:[result stringValue], nil];
+                [friendsWithApp addObject: [result stringValue]];
             }
+            
             if ([friendsWithApp count] > 0) {
                 [self apiDialogRequestsSendToUsers:friendsWithApp];
             } else {
                 [self showMessage:@"None of your friends are using the app."];
             }
+            
             [friendsWithApp release];
             break;
         }

--- a/sample/Hackbook/Hackbook/APIResultsViewController.m
+++ b/sample/Hackbook/Hackbook/APIResultsViewController.m
@@ -290,9 +290,6 @@
  *      didReceiveResponse:(NSURLResponse *)response
  */
 - (void)request:(FBRequest *)request didLoad:(id)result {
-    if ([result isKindOfClass:[NSArray class]]) {
-        result = [result objectAtIndex:0];
-    }
     [self showMessage:@"Checked in successfully"];
 }
 

--- a/sample/Hackbook/Hackbook/RootViewController.m
+++ b/sample/Hackbook/Hackbook/RootViewController.m
@@ -373,8 +373,9 @@
 
 #pragma mark - FBRequestDelegate Methods
 /**
- * Called when the Facebook API request has returned a response. This callback
- * gives you access to the raw response. It's called before
+ * Called when the Facebook API request has returned a response.
+ *
+ * This callback gives you access to the raw response. It's called before
  * (void)request:(FBRequest *)request didLoad:(id)result,
  * which is passed the parsed response object.
  */
@@ -384,9 +385,11 @@
 
 /**
  * Called when a request returns and its response has been parsed into
- * an object. The resulting object may be a dictionary, an array, a string,
- * or a number, depending on the format of the API response. If you need access
- * to the raw response, use:
+ * an object.
+ *
+ * The resulting object may be a dictionary, an array or a string, depending
+ * on the format of the API response. If you need access to the raw response,
+ * use:
  *
  * (void)request:(FBRequest *)request
  *      didReceiveResponse:(NSURLResponse *)response
@@ -426,10 +429,10 @@
         UIGraphicsBeginImageContext(CGSizeMake(px, px));
         UIRectClip(clipRect);
         [image drawInRect:clipRect];
-        UIImage *imgThumb =   UIGraphicsGetImageFromCurrentImageContext();
-        [imgThumb retain];
-        
+        UIImage *imgThumb = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
         [profilePhotoImageView setImage:imgThumb];
+        
         [self apiGraphUserPermissions];
     } else {
         // Processing permissions information

--- a/scripts/build_facebook_ios_sdk_static_lib.sh
+++ b/scripts/build_facebook_ios_sdk_static_lib.sh
@@ -19,8 +19,15 @@ die() {
 }
 
 # The Xcode bin path
-XCODEBUILD_PATH=/Developer/usr/bin
+if [ -d "/Developer/usr/bin" ]; then
+   # < XCode 4.3.1
+  XCODEBUILD_PATH=/Developer/usr/bin
+else
+  # >= XCode 4.3.1, or from App store
+  XCODEBUILD_PATH=/Applications/XCode.app/Contents/Developer/usr/bin
+fi
 XCODEBUILD=$XCODEBUILD_PATH/xcodebuild
+test -x "$XCODEBUILD" || die "Could not find xcodebuild in $XCODEBUILD_PATH"
 
 # Get the script path and set the relative directories used
 # for compilation

--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -367,6 +367,11 @@ params   = _params;
         
         _spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:
                     UIActivityIndicatorViewStyleWhiteLarge];
+        if ([_spinner respondsToSelector:@selector(setColor:)]) {
+            [_spinner setColor:[UIColor grayColor]];
+        } else {
+            [_spinner setActivityIndicatorViewStyle:UIActivityIndicatorViewStyleGray];
+        }
         _spinner.autoresizingMask =
         UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin
         | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
@@ -495,7 +500,12 @@ params   = _params;
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     // 102 == WebKitErrorFrameLoadInterruptedByPolicyChange
-    if (!([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102)) {
+    // -999 == "Operation could not be completed", note -999 occurs when the user clicks away before
+    // the page has completely loaded, if we find cases where we want this to result in dialog failure
+    // (usually this just means quick-user), then we should add something more robust here to account
+    // for differences in application needs
+    if (!(([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -999) ||
+          ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
         [self dismissWithError:error animated:YES];
     }
 }

--- a/src/FBRequest.h
+++ b/src/FBRequest.h
@@ -105,7 +105,11 @@ typedef NSUInteger FBRequestState;
 - (void)requestLoading:(FBRequest *)request;
 
 /**
- * Called when the server responds and begins to send back data.
+ * Called when the Facebook API request has returned a response.
+ *
+ * This callback gives you access to the raw response. It's called before
+ * (void)request:(FBRequest *)request didLoad:(id)result,
+ * which is passed the parsed response object.
  */
 - (void)request:(FBRequest *)request didReceiveResponse:(NSURLResponse *)response;
 
@@ -118,8 +122,12 @@ typedef NSUInteger FBRequestState;
  * Called when a request returns and its response has been parsed into
  * an object.
  *
- * The resulting object may be a dictionary, an array, a string, or a number,
- * depending on thee format of the API response.
+ * The resulting object may be a dictionary, an array or a string, depending
+ * on the format of the API response. If you need access to the raw response,
+ * use:
+ *
+ * (void)request:(FBRequest *)request
+ *      didReceiveResponse:(NSURLResponse *)response
  */
 - (void)request:(FBRequest *)request didLoad:(id)result;
 

--- a/src/FBRequest.m
+++ b/src/FBRequest.m
@@ -85,8 +85,8 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
     
     NSMutableArray* pairs = [NSMutableArray array];
     for (NSString* key in [params keyEnumerator]) {
-        if (([[params valueForKey:key] isKindOfClass:[UIImage class]])
-            ||([[params valueForKey:key] isKindOfClass:[NSData class]])) {
+        if (([[params objectForKey:key] isKindOfClass:[UIImage class]])
+            ||([[params objectForKey:key] isKindOfClass:[NSData class]])) {
             if ([httpMethod isEqualToString:@"GET"]) {
                 NSLog(@"can not use GET to upload a file");
             }
@@ -127,10 +127,10 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
     
     for (id key in [_params keyEnumerator]) {
         
-        if (([[_params valueForKey:key] isKindOfClass:[UIImage class]])
-            ||([[_params valueForKey:key] isKindOfClass:[NSData class]])) {
+        if (([[_params objectForKey:key] isKindOfClass:[UIImage class]])
+            ||([[_params objectForKey:key] isKindOfClass:[NSData class]])) {
             
-            [dataDictionary setObject:[_params valueForKey:key] forKey:key];
+            [dataDictionary setObject:[_params objectForKey:key] forKey:key];
             continue;
             
         }
@@ -139,14 +139,14 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
                        data:[NSString
                              stringWithFormat:@"Content-Disposition: form-data; name=\"%@\"\r\n\r\n",
                              key]];
-        [self utfAppendBody:body data:[_params valueForKey:key]];
+        [self utfAppendBody:body data:[_params objectForKey:key]];
         
         [self utfAppendBody:body data:endLine];
     }
     
     if ([dataDictionary count] > 0) {
         for (id key in dataDictionary) {
-            NSObject *dataParam = [dataDictionary valueForKey:key];
+            NSObject *dataParam = [dataDictionary objectForKey:key];
             if ([dataParam isKindOfClass:[UIImage class]]) {
                 NSData* imageData = UIImagePNGRepresentation((UIImage*)dataParam);
                 [self utfAppendBody:body
@@ -189,7 +189,6 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
     NSString* responseString = [[[NSString alloc] initWithData:data
                                                       encoding:NSUTF8StringEncoding]
                                 autorelease];
-    SBJSON *jsonParser = [[SBJSON new] autorelease];
     if ([responseString isEqualToString:@"true"]) {
         return [NSDictionary dictionaryWithObject:@"true" forKey:@"result"];
     } else if ([responseString isEqualToString:@"false"]) {
@@ -203,9 +202,15 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
     }
     
     
+    SBJSON *jsonParser = [[SBJSON alloc] init];
     id result = [jsonParser objectWithString:responseString];
-    
-    if (![result isKindOfClass:[NSArray class]]) {
+    [jsonParser release];
+
+    if (result == nil) {
+        return responseString;
+    }
+
+    if ([result isKindOfClass:[NSDictionary class]]) {
         if ([result objectForKey:@"error"] != nil) {
             if (error != nil) {
                 *error = [self formError:kGeneralErrorCode
@@ -272,7 +277,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
                 [self failWithError:error];
             } else if ([_delegate respondsToSelector:
                         @selector(request:didLoad:)]) {
-                [_delegate request:self didLoad:(result == nil ? data : result)];
+                [_delegate request:self didLoad:result];
             }
             
         }

--- a/src/Facebook.h
+++ b/src/Facebook.h
@@ -16,8 +16,8 @@
 
 #import "FBLoginDialog.h"
 #import "FBRequest.h"
-#import "FBFrictionlessRequestSettings.h"
 
+@class FBFrictionlessRequestSettings;
 @protocol FBSessionDelegate;
 
 /**
@@ -37,6 +37,7 @@
     NSString* _urlSchemeSuffix;
     NSArray* _permissions;
     BOOL _isExtendingAccessToken;
+    FBRequest *_requestExtendingAccessToken;
     NSDate* _lastAccessTokenUpdate;
     FBFrictionlessRequestSettings* _frictionlessRequestSettings;
 }

--- a/src/facebook-ios-sdk.xcodeproj/project.pbxproj
+++ b/src/facebook-ios-sdk.xcodeproj/project.pbxproj
@@ -265,6 +265,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					"$(ARCHS_STANDARD_32_BIT)",
+					armv6,
+				);
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/facebook_ios_sdk.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -284,6 +288,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					"$(ARCHS_STANDARD_32_BIT)",
+					armv6,
+				);
 				DSTROOT = /tmp/facebook_ios_sdk.dst;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
Updated project removing obsolete settings (incl. prebinding)
Configured project to build for both armv6 and armv7 on Release configuration. 
Set Deployment Target to 3.0.
Reset Base SDK to latest. 
Configured target to inherit from project settings.
Removed UIDeviceOrientation/UIInterfaceOrientation warnings in FBDialog with a simple cast.
