### PR TITLE
Allow using JSONKit instead of SBJSON

### DIFF
--- a/src/FBConnect.h
+++ b/src/FBConnect.h
@@ -19,4 +19,3 @@
 #include "FBDialog.h"
 #include "FBLoginDialog.h"
 #include "FBRequest.h"
-#include "SBJSON.h"

--- a/src/FBRequest.m
+++ b/src/FBRequest.m
@@ -15,7 +15,11 @@
  */
 
 #import "FBRequest.h"
+#ifdef FB_USE_JSONKIT
+#import "JSONKit.h"
+#else
 #import "JSON.h"
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // global
@@ -180,7 +184,6 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
   NSString* responseString = [[[NSString alloc] initWithData:data
                                                     encoding:NSUTF8StringEncoding]
                               autorelease];
-  SBJSON *jsonParser = [[SBJSON new] autorelease];
   if ([responseString isEqualToString:@"true"]) {
     return [NSDictionary dictionaryWithObject:@"true" forKey:@"result"];
   } else if ([responseString isEqualToString:@"false"]) {
@@ -193,8 +196,12 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
     return nil;
   }
 
-
+#ifdef FB_USE_JSONKIT
+  id result = [responseString objectFromJSONString];
+#else
+  SBJSON *jsonParser = [[SBJSON new] autorelease];
   id result = [jsonParser objectWithString:responseString];
+#endif
 
   if (![result isKindOfClass:[NSArray class]]) {
     if ([result objectForKey:@"error"] != nil) {


### PR DESCRIPTION
Allow using JSONKit instead of SBJSON if you specify the FB_USE_JSONKIT define using -DFB_USE_JSONKIT. Very small change, just a few lines.
