### PR TITLE
One-line fix for Issue #96

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -409,7 +409,8 @@ params   = _params;
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     // 102 == WebKitErrorFrameLoadInterruptedByPolicyChange
-    if (!([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102)) {
+    if (!(([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -999) ||
+        ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
         [self dismissWithError:error animated:YES];
     }
 }


### PR DESCRIPTION
This pull request is the patch from #96 all it does is port the error-code checking done in FBLoginDialog::webView:didFailLoadWithError to FBDialog::webView:didFailLoadWithError to avoid the '-999' errors (which indicate the user accidentally double-tapped a link something that is desirable to ignore).

It appears someone added this check to FBLoginDialog to avoid this problem, but forgot to add it to FBDialog too. This request simply adds it there too.
