### PR TITLE
When using facebook-ios-sdk as a submodule, it would be ideal to ignore ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test/UnitTest/build/
 *#
 .arcconfig
 xcuserdata/
+.DS_Store


### PR DESCRIPTION
...Xcode's xcuserdata. Otherwise we get "facebook-ios-sdk (untracked content)" errors in the submodule.
