### PR TITLE
Allow disabling single sign on when that's required

### DIFF
--- a/src/Facebook.h
+++ b/src/Facebook.h
@@ -49,6 +49,7 @@
     urlSchemeSuffix:(NSString *)urlSchemeSuffix
         andDelegate:(id<FBSessionDelegate>)delegate;
 
+- (void)authorize:(NSArray *)permissions tryingSingleSignOn:(BOOL)singleSignOn;
 - (void)authorize:(NSArray *)permissions;
 
 - (BOOL)handleOpenURL:(NSURL *)url;

--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -293,11 +293,16 @@ static void *finishedContext = @"finishedContext";
  *            Callback interface for notifying the calling application when
  *            the user has logged in.
  */
-- (void)authorize:(NSArray *)permissions {
+- (void)authorize:(NSArray *)permissions tryingSingleSignOn:(BOOL)singleSignOn {
   self.permissions = permissions;
 
-  [self authorizeWithFBAppAuth:YES safariAuth:YES];
+  [self authorizeWithFBAppAuth:singleSignOn safariAuth:singleSignOn];
 }
+
+- (void)authorize:(NSArray *)permissions {
+    [self authorize:permissions tryingSingleSignOn:YES];
+}
+
 
 /**
  * This function processes the URL the Facebook application or Safari used to


### PR DESCRIPTION
Here is a simple optional extra API call that allows disabling the single sign on cleanly. We've found this useful, others might also.
