### PR TITLE
Fix static lib build script to work with Xcode installs that aren't in /Developer/

### DIFF
--- a/scripts/build_facebook_ios_sdk_static_lib.sh
+++ b/scripts/build_facebook_ios_sdk_static_lib.sh
@@ -19,7 +19,8 @@ die() {
 }
 
 # The Xcode bin path
-XCODEBUILD_PATH=/Developer/usr/bin
+XCODEBUILD_PATH=`xcode-select -print-path`
+XCODEBUILD_PATH=$XCODEBUILD_PATH/usr/bin
 XCODEBUILD=$XCODEBUILD_PATH/xcodebuild
 
 # Get the script path and set the relative directories used


### PR DESCRIPTION
Change XCODEBUILD_PATH to use xcode-select to find the path the Xcode
cli files are in.  This should work when Xcode is installed from the AppStore in /Applications/, from previous installs in /Developer/, and any custom installs.
