### PR TITLE
Support NSJSONSerialization

### DIFF
--- a/src/FBConnect.h
+++ b/src/FBConnect.h
@@ -19,4 +19,6 @@
 #include "FBDialog.h"
 #include "FBLoginDialog.h"
 #include "FBRequest.h"
-#include "SBJSON.h"
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 50000
+#import "SBJSON.h"
+#endif


### PR DESCRIPTION
iOS5 has native JSON parser which is faster and leaner than SBJSON. I hacked FBRequest.{h,m} that uses NSJSONSerialization if it's available, otherwise, uses SBJSON. If your project deployment target is higher than iOS5, you can remove SBJSON code from your project.

I also fixed a crash bug of - (id)parseJsonResponse:(NSData _)data error:(NSError *_)error. (The code assume that result is either NSArray or NSDictionary, but NSJSONSerialization returns NSString as well.)
