### PR TITLE
include armv6 arch when building static lib

### DIFF
--- a/src/facebook-ios-sdk.xcodeproj/project.pbxproj
+++ b/src/facebook-ios-sdk.xcodeproj/project.pbxproj
@@ -248,7 +248,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					"$(ARCHS_STANDARD_32_BIT)",
+					armv6,
+				);
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/facebook_ios_sdk.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -268,7 +271,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = (
+					"$(ARCHS_STANDARD_32_BIT)",
+					armv6,
+				);
 				DSTROOT = /tmp/facebook_ios_sdk.dst;
 				GCC_MODEL_TUNING = G5;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
The definition of $(ARCHS_STANDARD_32_BIT) no longer includes the arm6
architecture. It should be added explicitly to avoid warnings and/or
compilation errors like "Undefined symbols for architecture armv6:
  .........
ld: symbol(s) not found for architecture armv6"
