### PR TITLE
forward declare FBFrictionlessRequestSettings

### DIFF
--- a/src/Facebook.h
+++ b/src/Facebook.h
@@ -16,7 +16,8 @@
 
 #import "FBLoginDialog.h"
 #import "FBRequest.h"
-#import "FBFrictionlessRequestSettings.h"
+
+@class FBFrictionlessRequestSettings;
 
 @protocol FBSessionDelegate;
 

--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -15,6 +15,7 @@
  */
 
 #import "Facebook.h"
+#import "FBFrictionlessRequestSettings.h"
 #import "FBLoginDialog.h"
 #import "FBRequest.h"
 #import "JSON.h"


### PR DESCRIPTION
It seems as though FBFrictionlessRequest settings is not meant to be a public
class. As such, it should be forward declared and imported in the .m file(s)
where it is needed.
