### PR TITLE
FBFrictionlessRequestSettings added

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,3 +1,8 @@
+Fork Notes
+==========
+Added FrictionlessRequestSettings to the project. (JYK)
+
+
 Facebook iOS SDK
 ===========================
 

--- a/src/facebook-ios-sdk.xcodeproj/project.pbxproj
+++ b/src/facebook-ios-sdk.xcodeproj/project.pbxproj
@@ -108,19 +108,19 @@
 		08FB77AEFE84172EC02AAC07 /* FBConnect */ = {
 			isa = PBXGroup;
 			children = (
-				22297EAF14FC1412003CE798 /* FBFrictionlessRequestSettings.h */,
-				22297EB014FC1412003CE798 /* FBFrictionlessRequestSettings.m */,
-				AE3FC32211F19C18001C05F3 /* FBDialog.bundle */,
-				AEA93B1311D52959000A4545 /* JSON */,
-				AEA93B0111D5293B000A4545 /* FBConnect.h */,
-				AEA93B0211D5293B000A4545 /* FBRequest.h */,
-				AEA93B0311D5293B000A4545 /* FBRequest.m */,
-				AEA93B0411D5293B000A4545 /* Facebook.m */,
 				AEA93B0511D5293B000A4545 /* Facebook.h */,
-				AEA93B0611D5293B000A4545 /* FBLoginDialog.h */,
-				AEA93B0711D5293B000A4545 /* FBLoginDialog.m */,
+				AEA93B0411D5293B000A4545 /* Facebook.m */,
+				AEA93B0111D5293B000A4545 /* FBConnect.h */,
+				AE3FC32211F19C18001C05F3 /* FBDialog.bundle */,
 				AEA93B0811D5293B000A4545 /* FBDialog.h */,
 				AEA93B0911D5293B000A4545 /* FBDialog.m */,
+				22297EAF14FC1412003CE798 /* FBFrictionlessRequestSettings.h */,
+				22297EB014FC1412003CE798 /* FBFrictionlessRequestSettings.m */,
+				AEA93B0611D5293B000A4545 /* FBLoginDialog.h */,
+				AEA93B0711D5293B000A4545 /* FBLoginDialog.m */,
+				AEA93B0211D5293B000A4545 /* FBRequest.h */,
+				AEA93B0311D5293B000A4545 /* FBRequest.m */,
+				AEA93B1311D52959000A4545 /* JSON */,
 			);
 			name = FBConnect;
 			sourceTree = "<group>";


### PR DESCRIPTION
Hey,

For some reason FBFrictionlessRequestSettings is not included in the static lib build.  I included it on the lastest version.

Other people have been having this problem for about a month. 

http://stackoverflow.com/questions/9450300/linker-error-building-project-with-facebook-sdk

Cheers,
Joe
