### PR TITLE
Reference error constants by name instead of hardcoding

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -500,11 +500,11 @@ params   = _params;
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     // 102 == WebKitErrorFrameLoadInterruptedByPolicyChange
-    // -999 == "Operation could not be completed", note -999 occurs when the user clicks away before
+    // NSURLErrorCancelled == "Operation could not be completed", note this occurs when the user clicks away before
     // the page has completely loaded, if we find cases where we want this to result in dialog failure
     // (usually this just means quick-user), then we should add something more robust here to account
     // for differences in application needs
-    if (!(([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -999) ||
+    if (!(([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) ||
           ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
         [self dismissWithError:error animated:YES];
     }

--- a/src/FBLoginDialog.m
+++ b/src/FBLoginDialog.m
@@ -82,7 +82,7 @@
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
-    if (!(([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -999) ||
+    if (!(([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) ||
           ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
         [super webView:webView didFailLoadWithError:error];
         if ([_loginDelegate respondsToSelector:@selector(fbDialogNotLogin:)]) {


### PR DESCRIPTION
Use NSURLErrorDomain instead of @"NSURLErrorDomain" and NSURLErrorCancelled instead of -999.

Unfortunately I don't think WebKitErrorDomain and WebKitErrorFrameLoadInterruptedByPolicyChange (-102) are exposed in the public iOS API so we can't do the same with those.
