### PR TITLE
Xcode can tell us where Xcode is

### DIFF
--- a/scripts/build_facebook_ios_sdk_static_lib.sh
+++ b/scripts/build_facebook_ios_sdk_static_lib.sh
@@ -19,7 +19,10 @@ die() {
 }
 
 # The Xcode bin path
-if [ -d "/Developer/usr/bin" ]; then
+if [ -x "/usr/bin/xcode-select" ]; then
+   # Use what Xcode tells us
+  XCODEBUILD_PATH=`/usr/bin/xcode-select -print-path`/usr/bin
+elif [ -d "/Developer/usr/bin" ]; then
    # < XCode 4.3.1
   XCODEBUILD_PATH=/Developer/usr/bin
 else


### PR DESCRIPTION
The script as it currently stands gets the Xcode path wrong for me - MacRuby has deposited files in /Developer/usr/bin so that path exists even though Xcode is in /Applications. This change uses `xcode-select` to find out where Xcode is.
