### PR TITLE
Clear delegate when invalidating request (FIXES COMMON CRASH)

### DIFF
--- a/src/FBFrictionlessRequestSettings.m
+++ b/src/FBFrictionlessRequestSettings.m
@@ -23,7 +23,7 @@
 @interface FBFrictionlessRequestSettings ()
 
 @property (readwrite, retain) NSArray *     allowedRecipients;
-@property (readwrite, retain) FBRequest*    activeRequest;
+@property (nonatomic, readwrite, retain) FBRequest*    activeRequest;
 
 @end
 
@@ -158,5 +158,14 @@
 
 @synthesize allowedRecipients = _allowedRecipients;
 @synthesize activeRequest = _activeRequest;
+- (void)setActiveRequest:(FBRequest *)activeRequest;
+{
+    if (_activeRequest == activeRequest)
+        return;
+        
+    _activeRequest.delegate = nil;
+    [_activeRequest release];
+    _activeRequest = [activeRequest retain];
+}
 
 @end


### PR DESCRIPTION
If the request is outstanding, it will callback to FBFrictionlessRequestSettings even
after it has been deallocated. If you have a short-lived Facebook instance in your app
(e g for just enabling SSO), this means you crash maybe every fifth SSO.
