### PR TITLE
Fix clang warning in FBRequest.m

### DIFF
--- a/src/FBRequest.m
+++ b/src/FBRequest.m
@@ -153,7 +153,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
                                data:[NSString stringWithFormat:
                                      @"Content-Disposition: form-data; filename=\"%@\"\r\n", key]];
                 [self utfAppendBody:body
-                               data:[NSString stringWithString:@"Content-Type: image/png\r\n\r\n"]];
+                               data:@"Content-Type: image/png\r\n\r\n"];
                 [body appendData:imageData];
             } else {
                 NSAssert([dataParam isKindOfClass:[NSData class]],
@@ -162,7 +162,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
                                data:[NSString stringWithFormat:
                                      @"Content-Disposition: form-data; filename=\"%@\"\r\n", key]];
                 [self utfAppendBody:body
-                               data:[NSString stringWithString:@"Content-Type: content/unknown\r\n\r\n"]];
+                               data:@"Content-Type: content/unknown\r\n\r\n"];
                 [body appendData:(NSData*)dataParam];
             }
             [self utfAppendBody:body data:endLine];


### PR DESCRIPTION
... about redundantly doing [NSString stringWithString:@""] rather than @""
