### PR TITLE
Un-set request delegates on teardown

### DIFF
--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -120,6 +120,7 @@ static void *finishedContext = @"finishedContext";
     // this is the one case where the delegate is this object
     _requestExtendingAccessToken.delegate = nil;
     for (FBRequest* _request in _requests) {
+        _request.delegate = nil;
         [_request removeObserver:self forKeyPath:requestFinishedKeyPath];
     }
     [_lastAccessTokenUpdate release];


### PR DESCRIPTION
So that, if you are tearing down your Facebook instance, a request can't sneak up on you
and suddenly try to deliver a message to a now dead delegate.

This could also be done by every client saving outstanding FBRequests and making sure to
nil'ing the delegate on them if the delegate is torn down, but that could be a lot of code
and this feels both simpler and correct.
