### PR TITLE
Fixed crash happening when parsing URL params for an empty query

### DIFF
--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -286,11 +286,13 @@ static void *finishedContext = @"finishedContext";
 	NSMutableDictionary *params = [[[NSMutableDictionary alloc] init] autorelease];
 	for (NSString *pair in pairs) {
 		NSArray *kv = [pair componentsSeparatedByString:@"="];
-		NSString *val =
-    [[kv objectAtIndex:1]
-     stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    if ([kv count] >= 2) {
+      NSString *val =
+      [[kv objectAtIndex:1]
+       stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 
-		[params setObject:val forKey:[kv objectAtIndex:0]];
+      [params setObject:val forKey:[kv objectAtIndex:0]];
+    }
 	}
   return params;
 }


### PR DESCRIPTION
This happens when our iOS app is launched from Facebook but no access token is sent to the app. In that case the URL being passed to the app delegate (in application:handleOpenURL:) is 

fbAPPID://authorize#

which will crash inside Facebook::handleOpenURL: trying to parse the query params.
