### PR TITLE
Made Facebook->parseURLParams: a public method

### DIFF
--- a/src/Facebook.h
+++ b/src/Facebook.h
@@ -47,7 +47,9 @@
 @property(nonatomic, assign) id<FBSessionDelegate> sessionDelegate;
 @property(nonatomic, copy) NSString* urlSchemeSuffix;
 @property(nonatomic, readonly, getter=isFrictionlessRequestsEnabled) 
-    BOOL isFrictionlessRequestsEnabled;
+BOOL isFrictionlessRequestsEnabled;
+
+- (NSDictionary*)parseURLParams:(NSString *)query;
 
 - (id)initWithAppId:(NSString *)appId
         andDelegate:(id<FBSessionDelegate>)delegate;


### PR DESCRIPTION
This makes it easier to parse URL parameters from the URL handed to an App in the application:handleOpenURL: method so we do not need to implement our own methods.

In my case I was sharing URLs to websites, but when you click on it in the Facebook iOS App it always opens my App, but I want it to open in Safari.
