### PR TITLE
Fix crasher when delegate has been deallocated

### DIFF
--- a/src/FBFrictionlessRequestSettings.m
+++ b/src/FBFrictionlessRequestSettings.m
@@ -147,6 +147,7 @@
 // NSObject
 
 - (void)dealloc {    
+    [[self.activeRequest connection] cancel];
     self.activeRequest = nil;
     self.allowedRecipients = nil;
     [super dealloc];


### PR DESCRIPTION
Fixes crasher when delegate has been deallocated.  Race condition where network response may come affecter deallocation.
