### PR TITLE
Fix static build script for cases where path contains spaces

### DIFF
--- a/scripts/build_facebook_ios_sdk_static_lib.sh
+++ b/scripts/build_facebook_ios_sdk_static_lib.sh
@@ -33,7 +33,7 @@ test -x "$XCODEBUILD" || die "Could not find xcodebuild in $XCODEBUILD_PATH"
 # for compilation
 cd $(dirname $0)
 SCRIPTPATH=`pwd`
-cd $SCRIPTPATH/../
+cd "$SCRIPTPATH/../"
 
 # The home directory where the SDK is installed
 PROJECT_HOME=`pwd`
@@ -47,42 +47,42 @@ SRCPATH=$PROJECT_HOME/src
 BUILDDIR=$PROJECT_HOME/build
 
 # The directory where the library output will be placed
-LIBOUTPUTDIR=$PROJECT_HOME/lib/facebook-ios-sdk
+LIBOUTPUTDIR="$PROJECT_HOME/lib/facebook-ios-sdk"
 
 echo "Start Universal facebook-ios-sdk SDK Generation"
 
 echo "Step 1 : facebook-ios-sdk SDK Build Library for simulator and device architecture"
 
-cd $SRCPATH
+cd "$SRCPATH"
 
-$XCODEBUILD -target "facebook-ios-sdk" -sdk "iphonesimulator" -configuration "Release" SYMROOT=$BUILDDIR clean build || die "iOS Simulator build failed"
-$XCODEBUILD -target "facebook-ios-sdk" -sdk "iphoneos" -configuration "Release" SYMROOT=$BUILDDIR clean build || die "iOS Device build failed"
+$XCODEBUILD -target "facebook-ios-sdk" -sdk "iphonesimulator" -configuration "Release" SYMROOT="$BUILDDIR" clean build || die "iOS Simulator build failed"
+$XCODEBUILD -target "facebook-ios-sdk" -sdk "iphoneos" -configuration "Release" SYMROOT="$BUILDDIR" clean build || die "iOS Device build failed"
 
 echo "Step 2 : Remove older SDK Directory"
 
-\rm -rf $LIBOUTPUTDIR
+\rm -rf "$LIBOUTPUTDIR"
 
 echo "Step 3 : Create new SDK Directory Version"
 
-mkdir -p $LIBOUTPUTDIR
+mkdir -p "$LIBOUTPUTDIR"
 
 echo "Step 4 : Create combine lib files for various platforms into one"
 
 # combine lib files for various platforms into one
-lipo -create $BUILDDIR/Release-iphonesimulator/libfacebook_ios_sdk.a $BUILDDIR/Release-iphoneos/libfacebook_ios_sdk.a -output $LIBOUTPUTDIR/libfacebook_ios_sdk.a || die "Could not create static output library"
+lipo -create "$BUILDDIR/Release-iphonesimulator/libfacebook_ios_sdk.a" "$BUILDDIR/Release-iphoneos/libfacebook_ios_sdk.a" -output "$LIBOUTPUTDIR/libfacebook_ios_sdk.a" || die "Could not create static output library"
 
 echo "Step 5 : Copy headers Needed"
-\cp $SRCPATH/*.h $LIBOUTPUTDIR/
-\cp $SRCPATH/JSON/*.h $LIBOUTPUTDIR/
+\cp "$SRCPATH"/*.h "$LIBOUTPUTDIR/"
+\cp "$SRCPATH"/JSON/*.h "$LIBOUTPUTDIR/"
 
 echo "Step 6 : Copy other file needed like bundle"
-\cp -r $SRCPATH/*.bundle $LIBOUTPUTDIR
+\cp -r "$SRCPATH"/*.bundle "$LIBOUTPUTDIR"
 
 echo "Finished Universal facebook-ios-sdk SDK Generation"
 echo ""
 echo "You can now use the static library that can be found at:"
 echo ""
-echo $LIBOUTPUTDIR
+echo "$LIBOUTPUTDIR"
 echo ""
 echo "Just drag the facebook-ios-sdk directory into your project to include the Facebook iOS SDK static library"
 echo ""


### PR DESCRIPTION
Fixes the static build script so that it will correctly build if the
Facebook SDK is placed in a directory that contains spaces in the name.
