### PR TITLE
fixing bug with launching dialog from UIAlertView

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -409,10 +409,8 @@ params   = _params;
 
 // Display the dialog's WebView with a slick pop-up animation	
 - (void)showWebView {	
-    UIWindow* window = [UIApplication sharedApplication].keyWindow;	
-    if (!window) {	
-        window = [[UIApplication sharedApplication].windows objectAtIndex:0];	
-    }	
+    UIWindow* window = [[UIApplication sharedApplication].windows objectAtIndex:0];	
+
     _modalBackgroundView.frame = window.frame;	
     [_modalBackgroundView addSubview:self];	
     [window addSubview:_modalBackgroundView];	


### PR DESCRIPTION
## This commit fixes the following bug:

Steps:
Have an application launch a Facebook dialog immediately after the user clicks on a UIAlertView button. (e.g. from the `- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex` method. Launch the alert view and then click said button.

Expected Result:
A Facebook dialog pops up.

Actual Result:
## The dialog pops up for a fraction of a second, and then is immediately dismissed.
