### PR TITLE
Using 'stringWithString:' with a literal is redundant.

### DIFF
--- a/src/FBRequest.m
+++ b/src/FBRequest.m
@@ -152,8 +152,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
                 [self utfAppendBody:body
                                data:[NSString stringWithFormat:
                                      @"Content-Disposition: form-data; filename=\"%@\"\r\n", key]];
-                [self utfAppendBody:body
-                               data:[NSString stringWithString:@"Content-Type: image/png\r\n\r\n"]];
+                [self utfAppendBody:body data:@"Content-Type: image/png\r\n\r\n"];
                 [body appendData:imageData];
             } else {
                 NSAssert([dataParam isKindOfClass:[NSData class]],
@@ -161,8 +160,7 @@ static const NSTimeInterval kTimeoutInterval = 180.0;
                 [self utfAppendBody:body
                                data:[NSString stringWithFormat:
                                      @"Content-Disposition: form-data; filename=\"%@\"\r\n", key]];
-                [self utfAppendBody:body
-                               data:[NSString stringWithString:@"Content-Type: content/unknown\r\n\r\n"]];
+                [self utfAppendBody:body data:@"Content-Type: content/unknown\r\n\r\n"];
                 [body appendData:(NSData*)dataParam];
             }
             [self utfAppendBody:body data:endLine];


### PR DESCRIPTION
Ran the static analyzer on Xcode 4.5 - DP1 to pick this up.
