### PR TITLE
Facebook.expirationDate property updates the session if the getter was called instead of using the setter

### DIFF
--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -336,11 +336,11 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 
 -(NSDate*)expirationDate {
     return self.tokenCaching.expirationDate;
-    self.hasUpdatedAccessToken = YES;
 }
 
 -(void)setExpirationDate:(NSDate *)expirationDate {
     self.tokenCaching.expirationDate = expirationDate;
+    self.hasUpdatedAccessToken = YES;
 }
 
 /**


### PR DESCRIPTION
hasUpdatedAccessToken was set to YES by the getter of expirationDate instead of by the setter
