### PR TITLE
Added consistent error handling for NSURLErrorCancelled in dialogs

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -494,7 +494,8 @@ params   = _params;
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
     // 102 == WebKitErrorFrameLoadInterruptedByPolicyChange
-    if (!([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102)) {
+    if (!(([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) ||
+          ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
         [self dismissWithError:error animated:YES];
     }
 }

--- a/src/FBLoginDialog.m
+++ b/src/FBLoginDialog.m
@@ -82,7 +82,8 @@
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error {
-    if (!(([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -999) ||
+    // 102 == WebKitErrorFrameLoadInterruptedByPolicyChange
+    if (!(([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) ||
           ([error.domain isEqualToString:@"WebKitErrorDomain"] && error.code == 102))) {
         [super webView:webView didFailLoadWithError:error];
         if ([_loginDelegate respondsToSelector:@selector(fbDialogNotLogin:)]) {


### PR DESCRIPTION
Problem:
Dialogs were closed reported errors under various conditions when a web view reported an NSURLErrorCancelled error (e.g. when the user cancelled the dialog manually or sometimes when the dialog navigated internally).
Some dialogs were not usable at all because they close once they received that error.

Solution:
Aligned the behavior in case of an NSURLErrorCancelled error with the master branch by simply ignoring it.
