### PR TITLE
Fixed a potential crash after loading a feed dialog in some cases

### DIFF
--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -141,6 +141,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
     [_tokenCaching release];
     for (FBRequest* _request in _requests) {
         [_request removeObserver:self forKeyPath:requestFinishedKeyPath];
+        _request.delegate = nil;
     }
     [_lastAccessTokenUpdate release];
     [_requests release];


### PR DESCRIPTION
Following the code posted on
https://developers.facebook.com/docs/howtos/feed-dialog-using-ios-sdk/

If ARC is enabled (but weak reference isn't enabled), by the end of the method, the facebook object is deallocated (as facebook is a local variable that exists only within the scope of this method). When the FBRequestConnection is calling completeDeprecatedWithData, the app crashes because local variable delegate refers to a zombie Facebook object.
