### PR TITLE
Fixed iOS 4.0 compatibility issue in FBDataDiskCache

### DIFF
--- a/src/FBDataDiskCache.m
+++ b/src/FBDataDiskCache.m
@@ -54,7 +54,7 @@ static NSString* const kCacheInfoFile = @"CacheInfo";
             error:nil];
         
         dispatch_queue_t bgPriQueue = 
-            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0);
         _fileQueue = dispatch_queue_create(
             "File Cache Queue", 
             DISPATCH_QUEUE_SERIAL);


### PR DESCRIPTION
'DISPATCH_QUEUE_PRIORITY_BACKGROUND' is not supported in iOS 4.0, only 5.0. It has been changed to 'DISPATCH_QUEUE_PRIORITY_LOW'
