### PR TITLE
Fixed bug where dialogDidCancel wasn't getting called when Cancel button pressed

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -444,7 +444,12 @@ params   = _params;
     NSURL* url = request.URL;
     
     if ([url.scheme isEqualToString:@"fbconnect"]) {
-        if ([[url.resourceSpecifier substringToIndex:8] isEqualToString:@"//cancel"]) {
+        if ([[url.resourceSpecifier substringToIndex:8] isEqualToString:@"//success?"]) {
+            if (_frictionlessSettings.enabled) {
+                [self dialogSuccessHandleFrictionlessResponses:url];
+            }
+            [self dialogDidSucceed:url];
+        } else {
             NSString * errorCode = [self getStringFromUrl:[url absoluteString] needle:@"error_code="];
             NSString * errorStr = [self getStringFromUrl:[url absoluteString] needle:@"error_msg="];
             if (errorCode) {
@@ -456,11 +461,6 @@ params   = _params;
             } else {
                 [self dialogDidCancel:url];
             }
-        } else {
-            if (_frictionlessSettings.enabled) {
-                [self dialogSuccessHandleFrictionlessResponses:url];
-            }
-            [self dialogDidSucceed:url];
         }
         return NO;
     } else if ([_loadingURL isEqual:url]) {


### PR DESCRIPTION
Pressing either the Send or Cancel button on the Request Dialog would always result in the dialogDidComplete delegate method being called. This change fixes is so that when the Cancel button is pressed, the dialogDidCancel delegate method is called instead of the dialogDidComplete.

Thanks!
