### PR TITLE
 - Rename SBJSONErrorDomain to FBSBJSONErrorDomain. Seems to be a left o...

### DIFF
--- a/src/JSON/FBSBJsonBase.h
+++ b/src/JSON/FBSBJsonBase.h
@@ -29,7 +29,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString * SBJSONErrorDomain;
+extern NSString * FBSBJSONErrorDomain;
 
 
 enum {

--- a/src/JSON/FBSBJsonBase.m
+++ b/src/JSON/FBSBJsonBase.m
@@ -28,7 +28,7 @@
  */
 
 #import "FBSBJsonBase.h"
-NSString * SBJSONErrorDomain = @"org.brautaset.JSON.ErrorDomain";
+NSString * FBSBJSONErrorDomain = @"org.brautaset.JSON.ErrorDomain";
 
 
 @implementation FBSBJsonBase
@@ -61,7 +61,7 @@ NSString * SBJSONErrorDomain = @"org.brautaset.JSON.ErrorDomain";
                     nil];
     }
     
-    NSError *error = [NSError errorWithDomain:SBJSONErrorDomain code:code userInfo:userInfo];
+    NSError *error = [NSError errorWithDomain:FBSBJSONErrorDomain code:code userInfo:userInfo];
 
     [self willChangeValueForKey:@"errorTrace"];
     [errorTrace addObject:error];


### PR DESCRIPTION
...ver from previous attempts to rename SBJson to FBSBJson.
