### PR TITLE
Don't attempt native iOS login on pre-iOS 6 devices.

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -861,6 +861,11 @@ static FBSession *g_activeSession = nil;
                                    FBLoginUXIOS, FBLoginUXSDK,
                                    nil];
 
+    // Don't use native login below 6.x; it deadlocks in the 5.1 simulator.
+    NSString *version = [[UIDevice currentDevice] systemVersion];
+    if([version compare:@"6" options:NSNumericSearch] < 0)
+        tryIntegratedAuth = NO;
+
     NSString *loginDialogURL = [FBDialogBaseURL stringByAppendingString:FBLoginDialogMethod];
 
     if (permissions != nil) {


### PR DESCRIPTION
Calling [accountStore accountTypeWithAccountTypeIdentifier:@"com.apple.facebook"]
from the iPad 5.1 simulator causes the application to hang with this stack (tested
with JustRequestSample):

```
frame #0: 0x91918c5e libsystem_kernel.dylib`semaphore_wait_trap + 10
frame #1: 0x011b9022 libdispatch.dylib`_dispatch_semaphore_wait_slow + 108
frame #2: 0x011b90fa libdispatch.dylib`dispatch_semaphore_wait + 36
frame #3: 0x0011b35d Accounts`-[ACAccountStore accountTypeWithAccountTypeIdentifier:] + 199
frame #4: 0x00014140 JustRequestSample`-[FBSession authorizeWithPermissions:defaultAudience:integratedAuth:FBAppAuth:safariAuth:fallback:isReauthorize:] + 529 at FBSession.m:893
frame #5: 0x00013f27 JustRequestSample`-[FBSession authorizeWithPermissions:behavior:defaultAudience:isReauthorize:] + 118 at FBSession.m:839
frame #6: 0x00012c22 JustRequestSample`-[FBSession openWithBehavior:completionHandler:] + 518 at FBSession.m:365
frame #7: 0x000166e6 JustRequestSample`+[FBSession openActiveSessionWithPermissions:allowLoginUI:allowSystemAccount:isRead:defaultAudience:completionHandler:] + 270 at FBSession.m:1563
frame #8: 0x000133a8 JustRequestSample`+[FBSession openActiveSessionWithReadPermissions:allowLoginUI:completionHandler:] + 82 at FBSession.m:533
frame #9: 0x000028e1 JustRequestSample`-[JRViewController buttonRequestClickHandler:] + 289 at JRViewController.m:103
```

This makes it impossible to test apps in the 5.1 simulator.  Work around this by clearing tryIntegratedAuth on pre-6.x devices, where it's never supported anyway.

This isn't an issue on real 5.1 devices, but being able to test in the simulator for various versions is critical.

Tested on iPad 3 in iOS 5.1 and 6, and in the iOS 4.3, 5.1 and 6.0 simulators.
