### PR TITLE
Fix crashing bug in FBLoginView when deallocated and session.state changes.

### DIFF
--- a/src/FBLoginView.m
+++ b/src/FBLoginView.m
@@ -117,8 +117,11 @@ CGSize g_imageSize;
 
 - (void)dealloc {
     
-    // removes all observers for self
+    // Remove self as observer for global notifications
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    // Remove self as observer for KVO notifications on self.session
+    [self unwireViewForSession];
     
     // if we have an outstanding request, cancel
     [self.request cancel];


### PR DESCRIPTION
FBLoginView now removes KVO observing from self.session.
Previously, a crash would occur when:
1) An FBLoginView was associated with a session.
2) That FBLoginView was deallocated.
3) session.state changed.

(Note: I have signed the CLA).
