### PR TITLE
Prevent FBSession.loginHandler from being called multiple times.

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -1437,11 +1437,10 @@ static FBSession *g_activeSession = nil;
     // release the object's count on the handler, but copy (not retain, since it is a block)
     // a stack ref to use as our callback outside of the lock
     FBSessionStateHandler handler = [self.loginHandler retain];
+    self.loginHandler = nil;
 
     // the moment we transition to a terminal state, we release our handlers, and possibly fail-call reauthorize
     if (didTransition && FB_ISSESSIONSTATETERMINAL(self.state)) {
-        self.loginHandler = nil;
-
         NSError *error = [FBSession errorLoginFailedWithReason:FBErrorReauthorizeFailedReasonSessionClosed
                                                      errorCode:nil
                                                     innerError:nil];


### PR DESCRIPTION
FBSession.loginHandler was previously not always cleared, even if it was called. This could (and did) result the same handler being called multiple times for different requests.

(Note: I have signed the CLA).
