### PR TITLE
UIApplicationExitsOnSuspend conditional added to prevent app exit when app is set to exit on suspend.

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -907,6 +907,7 @@ static FBSession *g_activeSession = nil;
     // her credentials in order to authorize the application.
     UIDevice *device = [UIDevice currentDevice];
     if (!didAuthNWithSystemAccount &&
+    	!([[[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIApplicationExitsOnSuspend"] boolValue]) &&
         [device respondsToSelector:@selector(isMultitaskingSupported)] &&
         [device isMultitaskingSupported] &&
         !TEST_DISABLE_MULTITASKING_LOGIN) {


### PR DESCRIPTION
Added condition in if statement on line 909, checking whether the app is set to exit on suspend. If so, we can't allow the app to suspend to get fb credentials. We have to do it within the fb built in dialogs.

On apps with UIApplicationExitsOnSuspend set to true, FBSession is lost when fast-app-switching to either the Facebook app or mobile safari. Returning to the app results in a new session being created and a failure to cache the access-token returned.

The behavior has been changed such that the FBLoginDialog is used when the system account couldn't be used.
