### PR TITLE
Fix memory leak after [FBSession handleOpenURL:]

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -1229,7 +1229,7 @@ static FBSession *g_activeSession = nil;
         // and this to assure we notice when we have been called three times
         __block int callsPending = 3;
         
-        void (^handleBatch)(id<FBGraphUser>,id) = [^(id<FBGraphUser> user,
+        __block void (^handleBatch)(id<FBGraphUser>,id) = [^(id<FBGraphUser> user,
                                                      id permissions) {
             
             // here we accumulate state from the various callbacks
@@ -1263,6 +1263,7 @@ static FBSession *g_activeSession = nil;
                 [fbid release];
                 [fbid2 release];
                 [permissionsRefreshed release];
+                [handleBatch release];
             }
         } copy];
                 


### PR DESCRIPTION
The handleBatch block in [FBSession handleOpenURLReauthorize:accessToken:] is copied to have it moved to the heap from the stack, but the copied object was never released.
