### PR TITLE
Facebook class leaks the observers it registers on _tokenCachingStrategy

### DIFF
--- a/src/Facebook.m
+++ b/src/Facebook.m
@@ -143,6 +143,9 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
     _requestExtendingAccessToken.delegate = nil;
 
     [_session release];
+    
+    [_tokenCaching removeObserver:self forKeyPath:FBaccessTokenPropertyName];
+    [_tokenCaching removeObserver:self forKeyPath:FBexpirationDatePropertyName];
     [_tokenCaching release];
 
     for (FBRequest* _request in _requests) {


### PR DESCRIPTION
Facebook adds two observers to _tokenCaching in `-initWithAppId:urlSchemeSuffix:andDelegate:` and
does not remove them during deallocation. Fixed that.
