### PR TITLE
Correctly invoke handler on -[FBURLConnection cancel]

### DIFF
--- a/src/FBURLConnection.m
+++ b/src/FBURLConnection.m
@@ -125,7 +125,7 @@ static NSArray* _cdnHosts;
              response:(NSURLResponse *)response 
          responseData:(NSData *)responseData 
 {
-    if (self.handler == nil) {
+    if (handler == nil) {
         return;
     }
 


### PR DESCRIPTION
Problem:
Client's completion block is not called on a FBURLConnection when that
connection is terminated by -cancel such as when a timeout fires in the client's code.

Cause:
-cancel sets _self.handler_ to nil before calling invokeHandler. The
cancel method retains a copy of _handler_ before calling
invokeHandler.

While invokeHandler uses the _handler_ parameter for calling, it was
checking _self.handler_ for non-nil before doing so.

All other calls to invokeHandler are made with _self.handler_ as the
parameter so the issue wasn't apparent in 'normal' use.
