### PR TITLE
Fix infinite notification loop in LoginView.

### DIFF
--- a/src/FBLoginView.m
+++ b/src/FBLoginView.m
@@ -315,7 +315,8 @@ CGSize g_imageSize;
     // anytime we find that our session is created with an available token
     // we open it on the spot
     if (self.session.state == FBSessionStateCreatedTokenLoaded) {
-        [FBSession openActiveSessionWithAllowLoginUI:NO];
+        [self.session openWithBehavior:FBSessionLoginBehaviorUseSystemAccountIfPresent
+                     completionHandler:nil];
     }    
 }
 


### PR DESCRIPTION
[FBLoginView wireViewForSession:] would be called by the global notification of
a new active session.  However, if the session state was
FBSessionStateCreatedTokenLoaded, it would call [FBSession
openActiveSession...], which would create and set a _new_ activesession,
creating a new notification, etc.

Instead, in that case we use openWithBehaviour directly on that session rather
than forcing a new one to be created; I believe this was the intended
behaviour.
