### PR TITLE
Fix incorrect use of publish permissions for read permissions.

### DIFF
--- a/src/FBLoginView.m
+++ b/src/FBLoginView.m
@@ -376,7 +376,7 @@ CGSize g_imageSize;
                                                allowLoginUI:YES
                                           completionHandler:nil];
             } else if (![self.publishPermissions count]) {
-                [FBSession openActiveSessionWithReadPermissions:self.publishPermissions
+                [FBSession openActiveSessionWithReadPermissions:self.readPermissions
                                                    allowLoginUI:YES
                                               completionHandler:nil];
             } else {

--- a/src/FBUserSettingsViewController.m
+++ b/src/FBUserSettingsViewController.m
@@ -328,7 +328,7 @@
                                        allowLoginUI:YES
                                   completionHandler:handler];
     } else if (![self.publishPermissions count]) {
-        [FBSession openActiveSessionWithReadPermissions:self.publishPermissions
+        [FBSession openActiveSessionWithReadPermissions:self.readPermissions
                                            allowLoginUI:YES
                                       completionHandler:handler];
     } else {


### PR DESCRIPTION
This one bit us pretty hard, as we pass the auth token from the app to our server to expedite signup, and new auth tokens had insufficient permissions because the requested read permissions had been dropped entirely.

(I now see that #504 made a similar change; but missed an instance and included an unrelated patch).
