### PR TITLE
FBProfilePictureView can clear image before refresh

### DIFF
--- a/src/FBProfilePictureView.h
+++ b/src/FBProfilePictureView.h
@@ -61,6 +61,18 @@ typedef enum {
 
 /*!
  @abstract
+ When set to YES sets the image in view to nil or to supplied Place Holder image.
+ */
+@property (nonatomic) BOOL clearImageBeforeRefresh;
+
+/*!
+ @abstract
+ Place Holder image to be set until the profile image is fetched.
+ */
+@property (copy, nonatomic) NSString *placeHolderImageName;
+
+/*!
+ @abstract
  Initializes and returns a profile view object.
  */
 - (id)init;

--- a/src/FBProfilePictureView.m
+++ b/src/FBProfilePictureView.m
@@ -23,6 +23,7 @@
 @interface FBProfilePictureView()
 
 @property (readonly, nonatomic) NSString *imageQueryParamString;
+@property (readonly, nonatomic) UIImage *blankImage;
 @property (retain, nonatomic) NSString *previousImageQueryParamString;
 
 @property (retain, nonatomic) FBURLConnection *connection;
@@ -92,6 +93,16 @@
 
 #pragma mark -
 
+- (UIImage *)blankImage {
+    BOOL isSquare = (self.pictureCropping == FBProfilePictureCroppingSquare);
+    
+    NSString *blankImageName =
+    [NSString
+     stringWithFormat:@"FacebookSDKResources.bundle/FBProfilePictureView/images/fb_blank_profile_%@.png",
+     isSquare ? @"square" : @"portrait"];
+    return [UIImage imageNamed:blankImageName];
+}
+
 - (NSString *)imageQueryParamString  {
     
     static CGFloat screenScaleFactor = 0.0;
@@ -149,9 +160,11 @@
         // But we still may need to adjust the contentMode.
         [self ensureImageViewContentMode];
         return;
-    }      
+    }
     
-    self.imageView.image = nil;
+    if (self.clearImageBeforeRefresh)
+        self.imageView.image = self.placeHolderImageName ? [UIImage imageNamed:self.placeHolderImageName] : self.blankImage;
+    
     if (self.profileID) {
         
         [self.connection cancel];
@@ -178,14 +191,7 @@
                                               completionHandler:handler]
                            autorelease];
     } else {
-        BOOL isSquare = (self.pictureCropping == FBProfilePictureCroppingSquare);
-
-        NSString *blankImageName = 
-            [NSString 
-                stringWithFormat:@"FacebookSDKResources.bundle/FBProfilePictureView/images/fb_blank_profile_%@.png",
-                isSquare ? @"square" : @"portrait"];
-
-        self.imageView.image = [UIImage imageNamed:blankImageName];
+        self.imageView.image = self.blankImage;
         [self ensureImageViewContentMode];
     }
     


### PR DESCRIPTION
This solved a bug when using the FBProfilePictureView in a tableview cell and when scrolling up/down the table fast enough , the wrong profile image would be displayed until the new one is fetched

This pull request does change the existing behavior to use one should set the:
`@property (nonatomic) BOOL clearImageBeforeRefresh` to `YES`;
