### PR TITLE
Update FBAccessTokenData.m

### DIFF
--- a/src/FBAccessTokenData.m
+++ b/src/FBAccessTokenData.m
@@ -92,12 +92,12 @@
 }
 
 + (FBAccessTokenData *) createTokenFromDictionary:(NSDictionary *)dictionary {
-    NSString *dictionaryToken = dictionary[FBTokenInformationTokenKey];
-    NSDate *dictionaryExpirationDate = dictionary[FBTokenInformationExpirationDateKey];
-    NSArray *dictionaryPermissions = dictionary[FBTokenInformationPermissionsKey];
-    FBSessionLoginType dictionaryLoginType = [dictionary[FBTokenInformationLoginTypeLoginKey] intValue];
-    BOOL dictionaryIsFacebookLoginType = [dictionary[FBTokenInformationIsFacebookLoginKey] boolValue];
-    NSDate *dictionaryRefreshDate = dictionary[FBTokenInformationRefreshDateKey];
+    NSString *dictionaryToken = [dictionary objectForKey:FBTokenInformationTokenKey];//dictionary[FBTokenInformationTokenKey];
+    NSDate *dictionaryExpirationDate = [dictionary objectForKey:FBTokenInformationExpirationDateKey];//dictionary[FBTokenInformationExpirationDateKey];
+    NSArray *dictionaryPermissions = [dictionary objectForKey:FBTokenInformationPermissionsKey];//dictionary[FBTokenInformationPermissionsKey];
+    FBSessionLoginType dictionaryLoginType = [[dictionary objectForKey:FBTokenInformationLoginTypeLoginKey] intValue];//[dictionary[FBTokenInformationLoginTypeLoginKey] intValue];
+    BOOL dictionaryIsFacebookLoginType = [[dictionary objectForKey:FBTokenInformationIsFacebookLoginKey] boolValue];//[dictionary[FBTokenInformationIsFacebookLoginKey] boolValue];
+    NSDate *dictionaryRefreshDate = [dictionary objectForKey:FBTokenInformationRefreshDateKey];//dictionary[FBTokenInformationRefreshDateKey];
     
     if (dictionaryIsFacebookLoginType && dictionaryLoginType == FBSessionLoginTypeNone) {
         // The internal isFacebookLogin has been removed but to support backwards compatibility,


### PR DESCRIPTION
Operator [] for a dictionary isn't implemented on firmware less than 6 and a crash can occur. Please check the following bugs: https://developers.facebook.com/bugs/346207278814744 and https://developers.facebook.com/bugs/230266263783283
