### PR TITLE
Update FBSession.m

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -1531,15 +1531,19 @@ static FBSession *g_activeSession = nil;
     // capture reason and nested code as user info
     NSMutableDictionary* userinfo = [[NSMutableDictionary alloc] init];
     if (errorReason) {
-        userinfo[FBErrorLoginFailedReason] = errorReason;
+        [userinfo setObject:errorReason forKey:FBErrorLoginFailedReason];
+        //userinfo[FBErrorLoginFailedReason] = errorReason;
     }
     if (errorCode) {
-        userinfo[FBErrorLoginFailedOriginalErrorCode] = errorCode;
+        [userinfo setObject:errorCode forKey:FBErrorLoginFailedOriginalErrorCode];
+        //userinfo[FBErrorLoginFailedOriginalErrorCode] = errorCode;
     }
     if (innerError) {
-        userinfo[FBErrorInnerErrorKey] = innerError;
+        [userinfo setObject:innerError forKey:FBErrorInnerErrorKey];
+        //userinfo[FBErrorInnerErrorKey] = innerError;
     }
-    userinfo[FBErrorSessionKey] = self;
+    [userinfo setObject:self forKey:FBErrorSessionKey];
+    //userinfo[FBErrorSessionKey] = self;
    
     // create error object
     NSError *err = [NSError errorWithDomain:FacebookSDKDomain


### PR DESCRIPTION
Operator [] for a dictionary isn't implemented on firmware less than 6 and a crash can occur. Please check the following bugs: https://developers.facebook.com/bugs/346207278814744 and https://developers.facebook.com/bugs/230266263783283
