### PR TITLE
Update FBNativeDialogs.m

### DIFF
--- a/src/FBNativeDialogs.m
+++ b/src/FBNativeDialogs.m
@@ -167,7 +167,7 @@
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     userInfo[FBErrorNativeDialogReasonKey] = reason;
     if (session) {
-        userInfo[FBErrorSessionKey] = session;
+        [userInfo setObject:session forKey:FBErrorSessionKey];
     }
     NSError *error = [NSError errorWithDomain:FacebookSDKDomain
                                          code:FBErrorNativeDialog


### PR DESCRIPTION
Operator [] for a dictionary isn't implemented on firmware less than 6 and a crash can occur. Please check the following bugs: https://developers.facebook.com/bugs/346207278814744 and https://developers.facebook.com/bugs/230266263783283
