### PR TITLE
Update FBGraphObjectPagingLoader.m

### DIFF
--- a/src/FBGraphObjectPagingLoader.m
+++ b/src/FBGraphObjectPagingLoader.m
@@ -277,9 +277,9 @@
 
     if (!error && !data) {
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-        userInfo[FBErrorParsedJSONResponseKey] = result;
+        [userInfo setObject:result forKey:FBErrorParsedJSONResponseKey];
         if (self.session) {
-            userInfo[FBErrorSessionKey] = self.session;
+            [userInfo setObject:self.session forKey:FBErrorSessionKey];
         }
         error = [[[NSError alloc] initWithDomain:FacebookSDKDomain
                                             code:FBErrorProtocolMismatch


### PR DESCRIPTION
Operator [] for a dictionary isn't implemented on firmware less than 6 and a crash can occur. Please check the following bugs: https://developers.facebook.com/bugs/346207278814744 and https://developers.facebook.com/bugs/230266263783283
