### PR TITLE
Check all URL Schemes instead of just first one

### DIFF
--- a/src/FBUtility.m
+++ b/src/FBUtility.m
@@ -375,12 +375,16 @@ static NSError *g_fetchedAppSettingsError = nil;
 
 + (BOOL)isRegisteredURLScheme:(NSString *)urlScheme {
     static dispatch_once_t fetchBundleOnce;
-    static NSArray *urlSchemes = nil;
+    static NSArray *urlTypes = nil;
     
     dispatch_once(&fetchBundleOnce, ^{
-        urlSchemes = [[[[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleURLTypes"] objectAtIndex:0] valueForKey:@"CFBundleURLSchemes"];
+        urlTypes = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleURLTypes"];
     });
-    return [urlSchemes containsObject:urlScheme];
+    for (NSDictionary *urlSchemes in urlTypes) {
+        if ([[urlSchemes valueForKey:@"CFBundleURLSchemes"] containsObject:urlScheme])
+            return YES;
+    }
+    return NO;
 }
 
 @end


### PR DESCRIPTION
During the authentication, the SDK tries to launch either the facebook app or safari using the fast app switching. 

The app should register the URL scheme fb[APP_ID][suffix] and this is checked before launching other apps. However, only the first URL scheme of the app is checked for the required URL scheme. This commit is fixing that issue.

https://developers.facebook.com/bugs/139615736223566?browse=search_5172fae96224d8105491767 
