### PR TITLE
Update SCViewController.m

### DIFF
--- a/samples/Scrumptious/scrumptious/SCViewController.m
+++ b/samples/Scrumptious/scrumptious/SCViewController.m
@@ -672,17 +672,23 @@
 
 #pragma mark - CLLocationManagerDelegate methods and related
 
-- (void)locationManager:(CLLocationManager *)manager 
-    didUpdateToLocation:(CLLocation *)newLocation 
-           fromLocation:(CLLocation *)oldLocation {
-    if (!oldLocation ||
-        (oldLocation.coordinate.latitude != newLocation.coordinate.latitude && 
-         oldLocation.coordinate.longitude != newLocation.coordinate.longitude &&
-         newLocation.horizontalAccuracy <= 100.0)) {
+- (void)locationManager:(CLLocationManager *)manager didUpdateLocations:(NSArray *)locations
+{
+    if([locations count]>1)
+    {
+       CLLocation *newLocation = (CLLocation*)[locations lastObject];
+       CLLocation *oldLocation = (CLLocation*)locations[0];
+       //If there is more than one object at locations NSArray, oldLocation won't be empty. 
+        if (oldLocation.coordinate.latitude != newLocation.coordinate.latitude &&
+             oldLocation.coordinate.longitude != newLocation.coordinate.longitude &&
+             newLocation.horizontalAccuracy <= 100.0)
+        {
             // Fetch data at this new location, and remember the cache descriptor.
             [self setPlaceCacheDescriptorForCoordinates:newLocation.coordinate];
             [self.placeCacheDescriptor prefetchAndCacheForSession:FBSession.activeSession];
-    }
+        }
+        
+    }    
 }
 
 - (void)locationManager:(CLLocationManager *)manager 


### PR DESCRIPTION
The delegate protocol method
- (void)locationManager:(CLLocationManager *)manager didUpdateToLocation:(CLLocation *)newLocation 
  fromLocation:(CLLocation *)oldLocation
  is deprecated in iOS 6. I propose replacing it with  - (void)locationManager:(CLLocationManager *)manager 
  didUpdateLocations:(NSArray *)locations

http://developer.apple.com/library/ios/#documentation/CoreLocation/Reference/CLLocationManagerDelegate_Protocol/CLLocationManagerDelegate/CLLocationManagerDelegate.html
