### PR TITLE
Avoid Fake Positive UDID check on AppStore Submission

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -1147,9 +1147,8 @@ static FBSession *g_activeSession = nil;
 }
 
 - (BOOL)isMultitaskingSupported {
-    UIDevice *device = [UIDevice currentDevice];
-    return [device respondsToSelector:@selector(isMultitaskingSupported)] &&
-        [device isMultitaskingSupported];
+    return [[UIDevice currentDevice] respondsToSelector:@selector(isMultitaskingSupported)] &&
+        [[UIDevice currentDevice] isMultitaskingSupported];
 }
 
 - (BOOL)authorizeUsingFacebookNativeLoginWithPermissions:(NSArray*)permissions


### PR DESCRIPTION
Related Defects :
https://developers.facebook.com/bugs/571648349546673
https://developers.facebook.com/bugs/193119420841692

As you probably know and starting May 1st, Apple enforced their submission policies to avoid the use of UDID (aka Unique Device Identifier) to prevents privacy issues towards their customer.

To ensure that this rule is strictly respected, Apple blacklist this API and performs automatic check on every apps during submission, like any others "private" API. The check is done by reading exported symbols on the binary while they don't have access to the source code.

Regarding the UDID check, recommendations from Apple are the following:

"While you may have removed access and usage of UDIDs from your app, the invalid binary message indicates that your app uses or accesses UDIDs. Please check your source code for any occurrence of the "uniqueIdentifier" method; this is the method that returns a device's UDID.
Additionally, if you are linking an external framework, such as an advertising library, these third party libraries may be accessing and using UDIDs. We encourage you to update your libraries to the most recent versions and use the "nm" tool to determine if the libraries are calling this method.
For more information on the "nm" tool, please see the manual page for the "nm" tool in Xcode Tools:
https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/nm.1.html
Additionally, if you do not have access to the libraries's source, you may be able to search the compiled binary using "strings" or "otool" command line tools. The "strings" tool can output a list of the methods that the library calls and "otool -ov" will output the Objective-C class structures and their defined methods. These techniques can help you narrow down where the problematic code resides."

We faced today some issues during the submission of one of our app that embeds Facebook iOS SDK. Our conclusions are that the SDK effectively don't call  this API (mean don't use the UDID -> [UIDevice uniqueIdentifier]) but we found that the way they use another API ( [UIDevice isMultiTaskingSupported]) forces the compiler to export the entire symbols of the UIDevice Class. That export includes "uniqueIdentifier" and then trigger a fake positive.

This fix will avoid the failed validation and doesn't modify functional aspects of the SDK, it is just a compilation trick ;)
