### PR TITLE
downgraded session exceptions to just errors.

### DIFF
--- a/src/FBSession.m
+++ b/src/FBSession.m
@@ -322,10 +322,13 @@ static FBSession *g_activeSession = nil;
     if (!(self.state == FBSessionStateCreated ||
           self.state == FBSessionStateCreatedTokenLoaded)) {
         // login may only be called once, and only from one of the two initial states
-        [[NSException exceptionWithName:FBInvalidOperationException
-                                 reason:@"FBSession: an attempt was made to open an already opened or closed session"
-                               userInfo:nil]
-         raise];
+        if(handler)
+        {
+            handler(self, self.state, [NSError errorWithDomain:FacebookSDKDomain
+                                                           code:FBErrorSystemAPI
+                                                       userInfo:@{ NSLocalizedDescriptionKey : @"FBSession: an attempt was made to open an already opened or closed session" }]);
+        }
+        return;
     }
     if (handler != nil) {
         if (self.loginHandler == nil) {
@@ -1449,20 +1452,25 @@ static FBSession *g_activeSession = nil;
                  completionHandler:(FBSessionRequestPermissionResultHandler)handler {
     
     if (!self.isOpen) {
-        // session must be open in order to reauthorize
-        [[NSException exceptionWithName:FBInvalidOperationException
-                                 reason:@"FBSession: an attempt was made reauthorize permissions on an unopened session"
-                               userInfo:nil]
-         raise];
+        if(handler)
+        {
+            // session must be open in order to reauthorize
+            handler(self, [NSError errorWithDomain:FacebookSDKDomain
+                                             code:FBErrorSystemAPI
+                                         userInfo:@{ NSLocalizedDescriptionKey : @"FBSession: an attempt was made reauthorize permissions on an unopened session" }]);
+        }
+        return;
     }
     
     if (self.reauthorizeHandler) {
-        // block must be cleared (meaning it has been called back) before a reauthorize can happen again
-        [[NSException exceptionWithName:FBInvalidOperationException
-                                 reason:@"FBSession: It is not valid to reauthorize while a previous "
-          @"reauthorize call has not yet completed."
-                               userInfo:nil]
-         raise];
+        if(handler)
+        {
+            // block must be cleared (meaning it has been called back) before a reauthorize can happen again
+            handler(self, [NSError errorWithDomain:FacebookSDKDomain
+                                              code:FBErrorSystemAPI
+                                          userInfo:@{ NSLocalizedDescriptionKey : @"FBSession: It is not valid to reauthorize while a previous reauthorize call has not yet completed." }]);
+        }
+        return;
     }
     
     // is everything in good order argument-wise?
@@ -1787,13 +1795,14 @@ static FBSession *g_activeSession = nil;
     // and ONLY in that case.
     if (!(self.state == FBSessionStateCreated)) {
         if (raiseException) {
-            [[NSException exceptionWithName:FBInvalidOperationException
-                                     reason:@"FBSession: cannot open a session from token data from its current state"
-                                   userInfo:nil]
-             raise];
-        } else {
-            return NO;
+            if(handler)
+            {
+                handler(self, self.state, [NSError errorWithDomain:FacebookSDKDomain
+                                                              code:FBErrorSystemAPI
+                                                          userInfo:@{ NSLocalizedDescriptionKey : @"FBSession: cannot open a session from token data from its current state" }]);
+            }
         }
+        return NO;
     }
     
     BOOL result = NO;

--- a/src/FBSystemAccountStoreAdapter.m
+++ b/src/FBSystemAccountStoreAdapter.m
@@ -152,12 +152,13 @@ static FBSystemAccountStoreAdapter* _singletonInstance = nil;
     if (!audience && isReauthorize) {
         for (NSString *p in permissions) {
             if ([p hasPrefix:@"publish"]) {
-                [[NSException exceptionWithName:FBInvalidOperationException
-                                         reason:@"FBSession: One or more publish permission was requested "
-                  @"without specifying an audience; use FBSessionDefaultAudienceJustMe, "
-                  @"FBSessionDefaultAudienceFriends, or FBSessionDefaultAudienceEveryone"
-                                       userInfo:nil]
-                 raise];
+                if(handler)
+                {
+                    handler(nil, [NSError errorWithDomain:FacebookSDKDomain
+                                                     code:FBErrorSystemAPI
+                                                 userInfo:@{ NSLocalizedDescriptionKey : @"FBSession: One or more publish permission was requested without specifying an audience; use FBSessionDefaultAudienceJustMe, FBSessionDefaultAudienceFriends, or FBSessionDefaultAudienceEveryone" }]);
+                }
+                return;
             }
         }
     }


### PR DESCRIPTION
Some of the NSExceptions thrown by FBSession are totally recoverable and should instead just be NSError. There is also no mention in the documentation that these methods can throw exceptions.  Its also super weird that these methods will throw exceptions when they takes in a completionHandler that has an error property. 

A typical usage is a button that asks the user to post a message double clicking this button would result in an app crash since two calls to reauthorizeWithPermissions before the first one has finished would trigger an exception. Since the reauthorizeHandler property is not public the app has to internally track if the first call has finished or not, this can get messy.  Instead its much simpilar if the second call simply returns an error, the application can then see that it was and move forward.
