### PR TITLE
Fix for getting correct window.

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -403,8 +403,12 @@ params   = _params;
 // Display the dialog's WebView with a slick pop-up animation	
 - (void)showWebView {	
     UIWindow* window = [UIApplication sharedApplication].keyWindow;	
-    if (!window) {	
-        window = [[UIApplication sharedApplication].windows objectAtIndex:0];	
+    if (window.windowLevel != UIWindowLevelNormal) {
+        NSArray *windows = [UIApplication sharedApplication].windows;
+        for(window in windows) {
+            if (window.windowLevel == UIWindowLevelNormal)
+                break;
+        }
     }	
     _modalBackgroundView.frame = window.frame;	
     [_modalBackgroundView addSubview:self];	


### PR DESCRIPTION
At the moment the UIWindow could be an UIAlertView, which can't have a subview.
Now instead of the UIAlertView the correct window is used.
