### PR TITLE
Fix crashes due to access to deallocated memory

### DIFF
--- a/src/FBDataDiskCache.m
+++ b/src/FBDataDiskCache.m
@@ -78,8 +78,11 @@ static NSString *const kAccessTokenKey = @"access_token";
     if (_fileQueue) {
         dispatch_release(_fileQueue);
     }
-
-    [_cacheIndex release];
+    if (_cacheIndex) {
+        _cacheIndex.delegate = nil;
+        [_cacheIndex release];
+        _cacheIndex = nil;
+    }
     [_dataCachePath release];
     [_inMemoryCache release];
     [super dealloc];

--- a/src/FBWebDialogs.m
+++ b/src/FBWebDialogs.m
@@ -67,7 +67,10 @@ static NSString* dialogBaseURL = @"https://m." FB_BASE_URL "/dialog/";
 
 - (void)dealloc {
     self.handler = nil;
-    self.dialog = nil;
+    if (self.dialog) {
+        self.dialog.delegate = nil;
+        self.dialog = nil;
+    }
     self.dialogMethod = nil;
     self.parameters = nil;
     self.session = nil;
@@ -90,7 +93,10 @@ static NSString* dialogBaseURL = @"https://m." FB_BASE_URL "/dialog/";
 - (void)releaseSelfIfNeeded {
     self.handler = nil; // insurance
     self.delegate = nil; // insurance
-    self.dialog = nil;
+    if (self.dialog) {
+        self.dialog.delegate = nil;
+        self.dialog = nil;
+    }
     if (_isSelfRetained) {
         [self autorelease];
         _isSelfRetained = NO;


### PR DESCRIPTION
Crashes occur at FBDialog.m, lines 701 and 686 at attempt to detect 'respondsToSelector' in something like
     if ([_delegate respondsToSelector:@selector(dialogCompleteWithUrl:)]) {
            [_delegate dialogCompleteWithUrl:url];
    }

Fixed by zeroing delegate pointers when a delegate is being deallocated.
