### PR TITLE
Fix exception thrown when there is no facebook system account

### DIFF
--- a/src/FBSystemAccountStoreAdapter.m
+++ b/src/FBSystemAccountStoreAdapter.m
@@ -203,10 +203,11 @@ static FBSystemAccountStoreAdapter* _singletonInstance = nil;
                  NSString *oauthToken = nil;
                  if (granted) {
                      NSArray *fbAccounts = [self.accountStore accountsWithAccountType:self.accountTypeFB];
-                     id account = [fbAccounts objectAtIndex:0];
-                     id credential = [account credential];
-                     
-                     oauthToken = [credential oauthToken];
+                     if (fbAccounts && [fbAccounts count]) {
+                         id account = [fbAccounts objectAtIndex:0];
+                         id credential = [account credential];
+                         oauthToken = [credential oauthToken];
+                     }
                  }
                  
                  if (!accountStoreError && !oauthToken){


### PR DESCRIPTION
The fix derived from this crash report (using 3.5.2)
Fatal Exception NSRangeException
**\* -[__NSArrayI objectAtIndex:]: index 0 beyond bounds for empty array
0    CoreFoundation  __exceptionPreprocess + 162
1    libobjc.A.dylib     objc_exception_throw + 30
2    CoreFoundation  -[__NSArrayI objectAtIndex:] + 164
3    StatusShuffle  
FBSystemAccountStoreAdapter.m line 205
__119-[FBSystemAccountStoreAdapter requestAccessToFacebookAccountStore:defaultAudience:isReauthorize:appID:session:handler:]_block_invoke_3
4    libdispatch.dylib   _dispatch_call_block_and_release + 10
5    libdispatch.dylib   _dispatch_client_callout + 22
6    libdispatch.dylib   _dispatch_main_queue_callback_4CF$VARIANT$up + 226
7    CoreFoundation  __CFRunLoopRun + 1290
8    CoreFoundation  CFRunLoopRunSpecific + 356
9    CoreFoundation  CFRunLoopRunInMode + 104
10   GraphicsServices    GSEventRunModal + 74
11   UIKit   UIApplicationMain + 1120
