### PR TITLE
Fix clang warnings when target iOS6+

### DIFF
--- a/src/FBCacheIndex.m
+++ b/src/FBCacheIndex.m
@@ -358,7 +358,10 @@ static void releaseStatement(sqlite3_stmt* statement, sqlite3* database)
 - (void)_updateEntryInDatabaseForKey:(NSString*)key
     entry:(FBCacheEntityInfo*)entry 
 {
-    NSAssert(dispatch_get_current_queue() == _databaseQueue, @"");    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSAssert(dispatch_get_current_queue() == _databaseQueue, @"");
+#pragma clang diagnostic pop
     initializeStatement(_database, &_updateStatement, updateQuery);
 
     CHECK_SQLITE_SUCCESS(sqlite3_bind_text(
@@ -392,8 +395,10 @@ static void releaseStatement(sqlite3_stmt* statement, sqlite3* database)
 
 - (void)_writeEntryInDatabase:(FBCacheEntityInfo*)entry 
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSAssert(dispatch_get_current_queue() == _databaseQueue, @"");
-    
+#pragma clang diagnostic pop
     FBCacheEntityInfo* existing = [self _readEntryFromDatabase:entry.key];
     if (existing) {
         
@@ -440,7 +445,10 @@ static void releaseStatement(sqlite3_stmt* statement, sqlite3* database)
 
 - (FBCacheEntityInfo*)_readEntryFromDatabase:(NSString*)key
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSAssert(dispatch_get_current_queue() == _databaseQueue, @"");
+#pragma clang diagnostic pop
     initializeStatement(_database, &_selectByKeyStatement, selectByKeyQuery);
   
     CHECK_SQLITE_SUCCESS(sqlite3_bind_text(
@@ -456,7 +464,10 @@ static void releaseStatement(sqlite3_stmt* statement, sqlite3* database)
 - (NSMutableArray*) _readEntriesFromDatabase:(NSString*)keyFragment
                            excludingFragment:(BOOL)exclude
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSAssert(dispatch_get_current_queue() == _databaseQueue, @"");
+#pragma clang diagnostic pop
     
     sqlite3_stmt* selectStatement;
     const char* query;
@@ -517,7 +528,10 @@ static void releaseStatement(sqlite3_stmt* statement, sqlite3* database)
 
 - (void)_fetchCurrentDiskUsage
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSAssert(dispatch_get_current_queue() == _databaseQueue, @"");
+#pragma clang
     
     sqlite3_stmt* sizeStatement = nil;
     initializeStatement(_database, &sizeStatement, selectStorageSizeQuery);

--- a/src/FBDialogs.m
+++ b/src/FBDialogs.m
@@ -119,7 +119,14 @@ FBInsightsEventParameterDialogOutcome : (cancelled
                       valueToSum:1.0
                       parameters:@{ @"render_type" : @"Native" }
                          session:session];
-    [viewController presentModalViewController:composeViewController animated:YES];
+	if([viewController respondsToSelector: @selector(presentViewController:animated:completion:)]) {
+		[viewController presentViewController: composeViewController animated: YES completion: nil];
+	}
+#if __IPHONE_OS_VERSION_MIN_REQUIRED <= __IPHONE_5_1
+	else {
+		[viewController presentModalViewController:composeViewController animated:YES];
+	}
+#endif
     
     return YES;
 }

--- a/src/FBLoginView.m
+++ b/src/FBLoginView.m
@@ -252,7 +252,12 @@ CGSize g_imageSize;
     // add a label that will appear over the button
     self.label = [[[UILabel alloc] init] autorelease];
     self.label.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED <= __IPHONE_5_1
     self.label.textAlignment = UITextAlignmentCenter;
+#else
+	self.label.textAlignment = NSTextAlignmentCenter;;
+#endif
+	
     self.label.backgroundColor = [UIColor clearColor];
     self.label.font = [UIFont boldSystemFontOfSize:16.0];
     self.label.textColor = [UIColor whiteColor];

--- a/src/FBUserSettingsViewController.m
+++ b/src/FBUserSettingsViewController.m
@@ -189,7 +189,11 @@
                                                 containerView.frame.size.width,
                                                 20);
     self.connectedStateLabel.backgroundColor = [UIColor clearColor];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED <= __IPHONE_5_1
     self.connectedStateLabel.textAlignment = UITextAlignmentCenter;
+#else
+	self.connectedStateLabel.textAlignment = NSTextAlignmentCenter;
+#endif
     self.connectedStateLabel.numberOfLines = 0;
     self.connectedStateLabel.font = [UIFont boldSystemFontOfSize:16.0];
     self.connectedStateLabel.shadowColor = [UIColor blackColor];
@@ -263,8 +267,10 @@
 
 - (BOOL)shouldAutorotate {
     UIInterfaceOrientation orientation = [[UIDevice currentDevice] orientation];
-    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return [self shouldAutorotateToInterfaceOrientation:orientation];
+#pragma clang diagnostic pop
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/src/FBViewController.m
+++ b/src/FBViewController.m
@@ -145,7 +145,10 @@
     if ([viewController respondsToSelector:@selector(presentViewController:animated:completion:)]) {
         [viewController presentViewController:self animated:animated completion:nil];
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [viewController presentModalViewController:self animated:animated];
+#pragma clang diagnostic pop
     }
     
     // Set this here because we always revert to NO in viewDidLoad.
@@ -210,7 +213,11 @@
             label.font = [UIFont fontWithName:@"Helvetica-Bold" size:20];
             label.backgroundColor = [UIColor clearColor];
             label.textColor = [UIColor colorWithRed:255.0/255.0 green:255.0/255.0 blue:255.0/255.0 alpha:1.0];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED <= __IPHONE_5_1
             label.textAlignment = UITextAlignmentCenter;
+#else
+			label.textAlignment = NSTextAlignmentCenter;
+#endif
             label.shadowColor = [UIColor colorWithWhite:0.0 alpha:0.5];
 
             self.titleLabel = [[[UIBarButtonItem alloc] initWithCustomView:label] autorelease];
@@ -294,7 +301,16 @@
         return [self presentingViewController];
     } else {
         UIViewController *parentViewController = [self parentViewController];
-        if (self == [parentViewController modalViewController]) {
+		UIViewController *modalController = nil;
+		if([parentViewController respondsToSelector: @selector(presentedViewController)]) {
+			modalController = [parentViewController presentedViewController];
+		} else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			modalController = [parentViewController modalViewController];
+#pragma clang diagnostic pop
+		}
+        if (self == modalController) {
             return parentViewController;
         }
     }
@@ -313,7 +329,10 @@
         if ([presentingViewController respondsToSelector:@selector(dismissViewControllerAnimated:completion:)]) {
             [presentingViewController dismissViewControllerAnimated:self.dismissAnimated completion:nil];
         } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [presentingViewController dismissModalViewControllerAnimated:self.dismissAnimated];
+#pragma clang diagnostic pop
         }
         
         [self logInsights:YES];
@@ -333,7 +352,10 @@
         if ([presentingViewController respondsToSelector:@selector(dismissViewControllerAnimated:completion:)]) {
             [presentingViewController dismissViewControllerAnimated:self.dismissAnimated completion:nil];
         } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             [presentingViewController dismissModalViewControllerAnimated:self.dismissAnimated];
+#pragma clang diagnostic push
         }
         
         [self logInsights:NO];


### PR DESCRIPTION
Hi,

This pull request fixes all clang warning when targetting iOS 6+.
They fell in two categories:
- UIViewController present methods. I've added the relevant respondsToSelector checks, and used __IPHONE_OS_VERSION_MIN_REQUIRED to figure out when to call the older version
- UITextAlignment vs NSTextAlignment. I've used the __IPHONE_OS_VERSION_MIN_REQUIRED macro to figure out which one to use.
- dispatch_get_current_queue were for asserts, which get removed on release builds, so I simply added the relevant #pragmas to them too.

Let me know if I should change anything to comply with project coding standards or whatever.
I did sign the CLA
