### PR TITLE
Fix removing button target when dialog gets closed.

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -381,6 +381,10 @@ params   = _params;
     [_params release];
     [_serverURL release];
     [_spinner release];
+    [_closeButton removeFromSuperview];
+    [_closeButton removeTarget:self
+                        action:NULL
+              forControlEvents:UIControlEventTouchUpInside];
     [_closeButton release];
     [_loadingURL release];
     [_modalBackgroundView release];


### PR DESCRIPTION
This fix was derived from a rather generic crash log report so it is not possible to tell which button caused the crash. All buttons in the app received treatment similar to the suggested fix.

Exception Type: EXC_BAD_ACCESS Code: KERN_INVALID_ADDRESS at 0x1374697186
0com.apple.main-thread Crashed
0    libobjc.A.dylib     objc_msgSend + 15
1    UIKit   -[UIApplication sendAction:to:from:forEvent:] + 70
2    UIKit   -[UIApplication sendAction:toTarget:fromSender:forEvent:] + 30
3    UIKit   -[UIControl sendAction:to:forEvent:] + 44
4    UIKit   -[UIControl(Internal) _sendActionsForEvents:withEvent:] + 502
5    UIKit   -[UIControl touchesEnded:withEvent:] + 488
6    UIKit   -[UIWindow _sendTouchesForEvent:] + 524
7    UIKit   -[UIApplication sendEvent:] + 380
8    UIKit   _UIApplicationHandleEvent + 6198
9    GraphicsServices    _PurpleEventCallback + 590
10   GraphicsServices    PurpleEventCallback + 34
11 ...   CoreFoundation  __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE1_PERFORM_FUNCTION__ + 34
17   UIKit   UIApplicationMain + 1120
18   StatusShuffleLite  
main.m line 14
main
