### PR TITLE
Fix memory corruption on low memory.

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -592,13 +592,13 @@ params   = _params;
      frictionlessSettings: (FBFrictionlessRequestSettings*) frictionlessSettings
          delegate: (id <FBDialogDelegate>) delegate {
     
-    self = [self init];
-    _serverURL = [serverURL retain];
-    _params = [params retain];    
-    _delegate = delegate;
-    _isViewInvisible = isViewInvisible;
-    _frictionlessSettings = [frictionlessSettings retain];
-    
+    if (self = [self init]) {
+        _serverURL = [serverURL retain];
+        _params = [params retain];
+        _delegate = delegate;
+        _isViewInvisible = isViewInvisible;
+        _frictionlessSettings = [frictionlessSettings retain];
+    }
     return self;
 }
 

--- a/src/FBLoginDialog.m
+++ b/src/FBLoginDialog.m
@@ -31,10 +31,11 @@
       loginParams:(NSMutableDictionary*) params 
          delegate:(id <FBLoginDialogDelegate>) delegate{
     
-    self = [super init];
-    _serverURL = [loginURL retain];
-    _params = [params retain];
-    _loginDelegate = delegate;
+    if (self = [super init]) {
+        _serverURL = [loginURL retain];
+        _params = [params retain];
+        _loginDelegate = delegate;
+    }
     return self;
 }
 


### PR DESCRIPTION
The change fixes initialization handling such that memory would not be corrupted when self is nil (i.e. under low memory).
