### PR TITLE
when cancelling an apprequest, we don't receive a cancel, but we don't receive a post_id neither

### DIFF
--- a/src/FBDialog.m
+++ b/src/FBDialog.m
@@ -460,6 +460,8 @@ params   = _params;
             } else {
                 [self dialogDidCancel:url];
             }
+        } else if ([url query] == nil || [[url query] rangeOfString:@"post_id="].location == NSNotFound) {
+            [self dialogDidCancel:url];
         } else {
             if (_frictionlessSettings.enabled) {
                 [self dialogSuccessHandleFrictionlessResponses:url];


### PR DESCRIPTION
to reproduce the problem, I have to call -[Facebook dialog:andParams:andDelegate:], with @"apprequests". If the user click on cancel, we receive @"fbconnect://success" (or this is not a success). This is the work around for that problem
