### PR TITLE
Fix for incorrect type being passed into KeyValueActionHandler

### DIFF
--- a/src/FBRequestConnection.m
+++ b/src/FBRequestConnection.m
@@ -860,8 +860,9 @@ typedef enum FBRequestConnectionState {
                 action(key, subValue);
             }
         }
-    } else if ([value isKindOfClass:[NSString class]] ||
-               [value isKindOfClass:[NSNumber class]]) {
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+        action(key, [(NSNumber *)value stringValue]);
+    } else if ([value isKindOfClass:[NSString class]]) {
         // Just serialize these.
         action(key, value);
     } else if ([value isKindOfClass:[NSArray class]]) {


### PR DESCRIPTION
In FBRequestConnection, processGraphObjectPropertyKey:value:action:passByValue would pass NSNumber objects into KeyValueActionHandler blocks. This caused a crash later on when it would try to call NSString instance method dataUsingEncoding: on a NSNumber.
