### PR TITLE
Replaced 'id' property in FBGraphUser.h and FBGraphPlace.h with 'userID'...

### DIFF
--- a/samples/HelloFacebookSample/HelloFacebookSample/HFViewController.m
+++ b/samples/HelloFacebookSample/HelloFacebookSample/HFViewController.m
@@ -118,7 +118,7 @@
     self.labelFirstName.text = [NSString stringWithFormat:@"Hello %@!", user.first_name];
     // setting the profileID property of the FBProfilePictureView instance
     // causes the control to fetch and display the profile picture for the user
-    self.profilePic.profileID = user.id;
+    self.profilePic.profileID = user.userID;
     self.loggedInUser = user;
 }
 

--- a/samples/SwitchUserSample/SwitchUserSample/SUUserManager.m
+++ b/samples/SwitchUserSample/SwitchUserSample/SUUserManager.m
@@ -127,8 +127,8 @@ static NSString *const SUUserNameKeyFormat = @"SUUserName%d";
 
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     if (user != nil ) {
-        NSLog(@"SUUserManager updating slot %d: fbid = %@, name = %@", slot, user.id, user.name);
-        [defaults setObject:user.id forKey:idKey];
+        NSLog(@"SUUserManager updating slot %d: fbid = %@, name = %@", slot, user.userID, user.name);
+        [defaults setObject:user.userID forKey:idKey];
         [defaults setObject:user.name forKey:nameKey];
     } else {
         NSLog(@"SUUserManager clearing slot %d", slot);

--- a/samples/SwitchUserSample/SwitchUserSample/SUUsingViewController.m
+++ b/samples/SwitchUserSample/SwitchUserSample/SUUsingViewController.m
@@ -80,7 +80,7 @@
             }
             
             self.nameLabel.text = [NSString stringWithFormat:@"Hello, %@!", user.first_name];
-            self.picView.profileID = user.id;
+            self.picView.profileID = user.userID;
             if (user.birthday.length > 0) {
                 self.birthdayLabel.text = [NSString stringWithFormat:@"Your birthday is: %@", user.birthday];        
             } else {

--- a/src/FBGraphObject.m
+++ b/src/FBGraphObject.m
@@ -284,6 +284,10 @@ typedef enum _SelectorInferredImplType {
 }
 
 - (id)objectForKey:(id)key {
+    // we expose `userId` and `placeId` but the internal key representation is `id`
+    if ([key isEqualToString:@"userID"] || [key isEqualToString:@"placeID"]) {
+        key = @"id";
+    }
     return [self graphObjectifyAtKey:key];
 }
 
@@ -293,7 +297,11 @@ typedef enum _SelectorInferredImplType {
 }
 
 - (void)setObject:(id)object forKey:(id)key {
-    return [_jsonObject setObject:object forKey:key];    
+    // we expose `userId` and `placeId` but the internal key representation is `id`
+    if ([key isEqualToString:@"userId"] || [key isEqualToString:@"placeId"]) {
+        key = @"id";
+    }
+    return [_jsonObject setObject:object forKey:key];
 }
 
 - (void)removeObjectForKey:(id)key {

--- a/src/FBGraphPlace.h
+++ b/src/FBGraphPlace.h
@@ -37,7 +37,7 @@
  @property
  @abstract Typed access to the place ID.
  */
-@property (retain, nonatomic) NSString *id;
+@property (retain, nonatomic) NSString *placeID;
 
 /*!
  @property

--- a/src/FBGraphUser.h
+++ b/src/FBGraphUser.h
@@ -37,7 +37,7 @@
  @property
  @abstract Typed access to the user's ID.
  */
-@property (retain, nonatomic) NSString *id;
+@property (retain, nonatomic) NSString *userID;
 
 /*!
  @property


### PR DESCRIPTION
... and 'placeID' respectively. This solves false positive warnings about usage of private APIs during App Store submission, which may lead to rejection.

This is a know issue and is still not fixed with the current release
https://developers.facebook.com/bugs/143882255765923/

More on the subject:
http://www.codepills.net/blog/2013/09/25/facebook-sdk-causes-warnings-in-app-store-submission-why-and-how-to-fix-it
