### PR TITLE
Fix for bug 1430769643813743

### DIFF
--- a/src/FBAppEvents.m
+++ b/src/FBAppEvents.m
@@ -1089,7 +1089,7 @@ const int MAX_IDENTIFIER_LENGTH                      = 40;
 }
 
 + (NSString *)persistenceFilePath {
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
     NSString *docDirectory = [paths objectAtIndex:0];
     return [docDirectory stringByAppendingPathComponent:FBAppEventsPersistedEventsFilename];
 }


### PR DESCRIPTION
FB events are now persisted to the ~/Library path instead of polluting the app's ~/Documents folder.

Reference: https://developers.facebook.com/bugs/1430769643813743
