### PR TITLE
Fix: Empty @discussion blocks cause warnings with -Wdocumentation

### DIFF
--- a/src/FBAppEvents.h
+++ b/src/FBAppEvents.h
@@ -25,8 +25,6 @@
  @abstract
  Control when <FBAppEvents> sends log events to the server
 
- @discussion
-
  */
 typedef enum {
 

--- a/src/FBError.h
+++ b/src/FBError.h
@@ -157,8 +157,6 @@ typedef enum FBNativeApplicationErrorCode {
  @typedef FBErrorCategory enum
 
  @abstract Indicates the Facebook SDK classification for the error
-
- @discussion
  */
 typedef enum {
     /*! Indicates that the error category is invalid and likely represents an error that

--- a/src/FBFriendPickerViewController.h
+++ b/src/FBFriendPickerViewController.h
@@ -28,8 +28,6 @@
  @typedef FBFriendSortOrdering enum
 
  @abstract Indicates the order in which friends should be listed in the friend picker.
-
- @discussion
  */
 typedef enum {
     /*! Sort friends by first, middle, last names. */
@@ -42,8 +40,6 @@ typedef enum {
  @typedef FBFriendDisplayOrdering enum
 
  @abstract Indicates whether friends should be displayed first-name-first or last-name-first.
-
- @discussion
  */
 typedef enum {
     /*! Display friends as First Middle Last. */

--- a/src/FBProfilePictureView.h
+++ b/src/FBProfilePictureView.h
@@ -21,8 +21,6 @@
 
  @abstract
  Type used to specify the cropping treatment of the profile picture.
-
- @discussion
  */
 typedef enum {
 

--- a/src/FBRequestConnection.h
+++ b/src/FBRequestConnection.h
@@ -186,8 +186,8 @@ typedef void (^FBRequestHandler)(FBRequestConnection *connection,
  @attribute beta true
 
  @abstract Set the automatic error handling behaviors.
- @discussion
 
+ @discussion
  This must be set before any requests are added.
 
  When using retry behaviors, note the FBRequestConnection instance

--- a/src/FBSession.h
+++ b/src/FBSession.h
@@ -46,8 +46,6 @@ extern NSString *const FBSessionDidBecomeClosedActiveSessionNotification;
  @typedef FBSessionState enum
 
  @abstract Passed to handler block each time a session state changes
-
- @discussion
  */
 typedef enum {
     /*! One of two initial states indicating that no valid cached token was found */
@@ -210,7 +208,6 @@ typedef FBSessionRequestPermissionResultHandler FBSessionReauthorizeResultHandle
  @typedef
 
  @abstract Block type used to define blocks called for system credential renewals.
- @discussion
  */
 typedef void (^FBSessionRenewSystemCredentialsHandler)(ACAccountCredentialRenewResult result, NSError *error) ;
 

--- a/src/FBSettings.h
+++ b/src/FBSettings.h
@@ -51,7 +51,6 @@ extern NSString *const FBLoggingBehaviorDeveloperErrors;
  @typedef
 
  @abstract Block type used to get install data that is returned by server when publishInstall is called
- @discussion
  */
 typedef void (^FBInstallResponseDataHandler)(FBGraphObject *response, NSError *error);
 


### PR DESCRIPTION
Clang 3.2 (Xcode 5) adds support for the `-Wdocumentation` flag, which creates a incredibly helpful reminder to update documentation when methods change.

At the moment, `#include`ing Facebook SDK headers causes project warnings with this flag. This pull request fixes those warnings.

Fixes https://developers.facebook.com/bugs/566203590121364 .
