### PR TITLE
Fix FBImageResourceLoader to return the non-retina image rather than nil when retina is preferred but not available.

### DIFF
--- a/src/FBImageResourceLoader.m
+++ b/src/FBImageResourceLoader.m
@@ -33,7 +33,7 @@
                      length:(NSUInteger)length
             fromRetinaBytes:(const Byte *)retinaBytes
                retinaLength:(NSUInteger)retinaLength {
-    if ([FBUtility isRetinaDisplay]) {
+    if (retinaBytes && [FBUtility isRetinaDisplay]) {
         return [FBImageResourceLoader loadImageFromBytes:retinaBytes length:retinaLength scale:2.0];
     } else {
         return [FBImageResourceLoader loadImageFromBytes:bytes length:length scale:1.0];


### PR DESCRIPTION
The 'blank' images used by FBProfilePictureView, for example, have no retina versions.
i.e. FBProfilePictureViewBlankProfileSquarePNG
