### PR TITLE
[FIX] Convert int to NSInteger to avoid any problems in 64 bits archs

### DIFF
--- a/src/tests/FBTestBlocker.m
+++ b/src/tests/FBTestBlocker.m
@@ -24,8 +24,8 @@
 @end
 
 @implementation FBTestBlocker {
-    int _signalsRemaining;
-    int _expectedSignalCount;
+    NSInteger _signalsRemaining;
+    NSInteger _expectedSignalCount;
 }
 
 - (id)init {


### PR DESCRIPTION
This is a little fix to avoid problems by testing for 64 bits architectures.
In 64 bits archs, the size of `int` is 4 bytes while the size of `NSInteger`are 8 bytes.

[Apple Documentation](https://developer.apple.com/library/iOS/documentation/General/Conceptual/CocoaTouch64BitGuide/Major64-BitChanges/Major64-BitChanges.html#//apple_ref/doc/uid/TP40013501-CH2-TPXREF103)
