### PR TITLE
Fix #587: Allow spaces in directory names.

### DIFF
--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -18,7 +18,7 @@
 # This script builds the FacebookSDK.framework that is distributed at
 # https://github.com/facebook/facebook-ios-sdk/downloads/FacebookSDK.framework.tgz
 
-. ${FB_SDK_SCRIPT:-$(dirname $0)}/common.sh
+. "${FB_SDK_SCRIPT:-$(dirname $0)}"/common.sh
 
 # process options, valid arguments -c [Debug|Release] -n 
 BUILDCONFIGURATION=Debug
@@ -66,19 +66,19 @@ progress_message Building Framework.
 # -----------------------------------------------------------------------------
 # Compile binaries 
 #
-test -d $FB_SDK_BUILD \
-  || mkdir -p $FB_SDK_BUILD \
+test -d "$FB_SDK_BUILD" \
+  || mkdir -p "$FB_SDK_BUILD" \
   || die "Could not create directory $FB_SDK_BUILD"
 
-cd $FB_SDK_SRC
+cd "$FB_SDK_SRC"
 function xcode_build_target() {
   echo "Compiling for platform: ${1}."
-  $XCODEBUILD \
+  "$XCODEBUILD" \
     RUN_CLANG_STATIC_ANALYZER=NO \
     -target "facebook-ios-sdk" \
     -sdk $1 \
     -configuration "${2}" \
-    SYMROOT=$FB_SDK_BUILD \
+    SYMROOT="$FB_SDK_BUILD" \
     clean build \
     || die "XCode build failed for platform: ${1}."
 }
@@ -93,15 +93,15 @@ xcode_build_target "iphoneos" "${BUILDCONFIGURATION}64"
 #
 progress_message "Building $FB_SDK_BINARY_NAME library using lipo."
 
-mkdir -p $(dirname $FB_SDK_UNIVERSAL_BINARY)
+mkdir -p $(dirname "$FB_SDK_UNIVERSAL_BINARY")
 
-$LIPO \
+"$LIPO" \
   -create \
-    $FB_SDK_BUILD/${BUILDCONFIGURATION}-iphonesimulator/libfacebook_ios_sdk.a \
-    $FB_SDK_BUILD/${BUILDCONFIGURATION}-iphoneos/libfacebook_ios_sdk.a \
-    $FB_SDK_BUILD/${BUILDCONFIGURATION}64-iphonesimulator/libfacebook_ios_sdk.a \
-    $FB_SDK_BUILD/${BUILDCONFIGURATION}64-iphoneos/libfacebook_ios_sdk.a \
-  -output $FB_SDK_UNIVERSAL_BINARY \
+    "$FB_SDK_BUILD/${BUILDCONFIGURATION}"-iphonesimulator/libfacebook_ios_sdk.a \
+    "$FB_SDK_BUILD/${BUILDCONFIGURATION}"-iphoneos/libfacebook_ios_sdk.a \
+    "$FB_SDK_BUILD/${BUILDCONFIGURATION}"64-iphonesimulator/libfacebook_ios_sdk.a \
+    "$FB_SDK_BUILD/${BUILDCONFIGURATION}"64-iphoneos/libfacebook_ios_sdk.a \
+  -output "$FB_SDK_UNIVERSAL_BINARY" \
   || die "lipo failed - could not create universal static library"
 
 # -----------------------------------------------------------------------------
@@ -109,22 +109,22 @@ $LIPO \
 #
 progress_message "Building $FB_SDK_FRAMEWORK_NAME."
 
-\rm -rf $FB_SDK_FRAMEWORK
-mkdir $FB_SDK_FRAMEWORK \
+\rm -rf "$FB_SDK_FRAMEWORK"
+mkdir "$FB_SDK_FRAMEWORK" \
   || die "Could not create directory $FB_SDK_FRAMEWORK"
-mkdir $FB_SDK_FRAMEWORK/Versions
-mkdir $FB_SDK_FRAMEWORK/Versions/A
-mkdir $FB_SDK_FRAMEWORK/Versions/A/Headers
-mkdir $FB_SDK_FRAMEWORK/Versions/A/DeprecatedHeaders
-mkdir $FB_SDK_FRAMEWORK/Versions/A/Resources
+mkdir "$FB_SDK_FRAMEWORK"/Versions
+mkdir "$FB_SDK_FRAMEWORK"/Versions/A
+mkdir "$FB_SDK_FRAMEWORK"/Versions/A/Headers
+mkdir "$FB_SDK_FRAMEWORK"/Versions/A/DeprecatedHeaders
+mkdir "$FB_SDK_FRAMEWORK"/Versions/A/Resources
 
 \cp \
-  $FB_SDK_BUILD/${BUILDCONFIGURATION}-iphoneos/facebook-ios-sdk/*.h \
-  $FB_SDK_FRAMEWORK/Versions/A/Headers \
+  "$FB_SDK_BUILD/${BUILDCONFIGURATION}"-iphoneos/facebook-ios-sdk/*.h \
+  "$FB_SDK_FRAMEWORK"/Versions/A/Headers \
   || die "Error building framework while copying SDK headers"
 \cp \
-  $FB_SDK_BUILD/${BUILDCONFIGURATION}-iphoneos/facebook-ios-sdk/*.h \
-  $FB_SDK_FRAMEWORK/Versions/A/DeprecatedHeaders \
+  "$FB_SDK_BUILD/${BUILDCONFIGURATION}"-iphoneos/facebook-ios-sdk/*.h \
+  "$FB_SDK_FRAMEWORK"/Versions/A/DeprecatedHeaders \
   || die "Error building framework while copying SDK headers to deprecated folder"
 for HEADER in Legacy/FBConnect.h \
               Legacy/FBDialog.h \
@@ -135,50 +135,50 @@ for HEADER in Legacy/FBConnect.h \
               Legacy/FBSessionManualTokenCachingStrategy.h
 do 
   \cp \
-    $FB_SDK_SRC/$HEADER \
-    $FB_SDK_FRAMEWORK/Versions/A/DeprecatedHeaders \
+    "$FB_SDK_SRC/$HEADER" \
+    "$FB_SDK_FRAMEWORK"/Versions/A/DeprecatedHeaders \
     || die "Error building framework while copying deprecated SDK headers"
 done
 \cp \
-  $FB_SDK_SRC/Framework/Resources/* \
-  $FB_SDK_FRAMEWORK/Versions/A/Resources \
+  "$FB_SDK_SRC"/Framework/Resources/* \
+  "$FB_SDK_FRAMEWORK"/Versions/A/Resources \
   || die "Error building framework while copying Resources"
 \cp -r \
-  $FB_SDK_SRC/*.bundle \
-  $FB_SDK_FRAMEWORK/Versions/A/Resources \
+  "$FB_SDK_SRC"/*.bundle \
+  "$FB_SDK_FRAMEWORK"/Versions/A/Resources \
   || die "Error building framework while copying bundle to Resources"
 \cp -r \
-  $FB_SDK_SRC/*.bundle.README \
-  $FB_SDK_FRAMEWORK/Versions/A/Resources \
+  "$FB_SDK_SRC"/*.bundle.README \
+  "$FB_SDK_FRAMEWORK"/Versions/A/Resources \
   || die "Error building framework while copying README to Resources"
 \cp \
-  $FB_SDK_UNIVERSAL_BINARY \
-  $FB_SDK_FRAMEWORK/Versions/A/FacebookSDK \
+  "$FB_SDK_UNIVERSAL_BINARY" \
+  "$FB_SDK_FRAMEWORK"/Versions/A/FacebookSDK \
   || die "Error building framework while copying FacebookSDK"
 
 # Current directory matters to ln.
-cd $FB_SDK_FRAMEWORK
+cd "$FB_SDK_FRAMEWORK"
 ln -s ./Versions/A/Headers ./Headers
 ln -s ./Versions/A/Resources ./Resources
 ln -s ./Versions/A/FacebookSDK ./FacebookSDK
-cd $FB_SDK_FRAMEWORK/Versions
+cd "$FB_SDK_FRAMEWORK"/Versions
 ln -s ./A ./Current
 
 # -----------------------------------------------------------------------------
 # Run unit tests 
 #
 
-if [ ${NOEXTRAS:-0} -eq  1 ];then
+if [ ${NOEXTRAS:-0} -eq  1 ]; then
   progress_message "Skipping unit tests."
 else
   progress_message "Running unit tests."
-  cd $FB_SDK_SRC
-  $FB_SDK_SCRIPT/run_tests.sh -c $BUILDCONFIGURATION facebook-ios-sdk-tests
+  cd "$FB_SDK_SRC"
+  "$FB_SDK_SCRIPT"/run_tests.sh -c $BUILDCONFIGURATION facebook-ios-sdk-tests
 fi
 
 # -----------------------------------------------------------------------------
 # Done
 #
 
-progress_message "Framework version info:" `perl -ne 'print "$1 " if (m/FB_IOS_SDK_MIGRATION_BUNDLE @(.+)$/ || m/FB_IOS_SDK_VERSION_STRING @(.+)$/);' $FB_SDK_SRC/Core/FBSDKVersion.h $FB_SDK_SRC/FacebookSDK.h` 
+progress_message "Framework version info:" `perl -ne 'print "$1 " if (m/FB_IOS_SDK_MIGRATION_BUNDLE @(.+)$/ || m/FB_IOS_SDK_VERSION_STRING @(.+)$/);' "$FB_SDK_SRC"/Core/FBSDKVersion.h "$FB_SDK_SRC"/FacebookSDK.h`
 common_success

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -30,7 +30,7 @@ if [ -z "$FB_SDK_SCRIPT" ]; then
   popd >/dev/null
 
   # The root directory where the Facebook SDK for iOS is cloned
-  FB_SDK_ROOT=$(dirname $FB_SDK_SCRIPT)
+  FB_SDK_ROOT=$(dirname "$FB_SDK_SCRIPT")
 
   # Path to source files for Facebook SDK
   FB_SDK_SRC=$FB_SDK_ROOT/src
@@ -52,7 +52,7 @@ if [ -z "$FB_SDK_SCRIPT" ]; then
   FB_SDK_FRAMEWORK=$FB_SDK_BUILD/$FB_SDK_FRAMEWORK_NAME
 
   # Extract the SDK version from FacebookSDK.h
-  FB_SDK_VERSION_RAW=$(sed -n 's/.*FB_IOS_SDK_VERSION_STRING @\"\(.*\)\"/\1/p' ${FB_SDK_SRC}/FacebookSDK.h)
+  FB_SDK_VERSION_RAW=$(sed -n 's/.*FB_IOS_SDK_VERSION_STRING @\"\(.*\)\"/\1/p' "${FB_SDK_SRC}"/FacebookSDK.h)
   FB_SDK_VERSION_MAJOR=$(echo $FB_SDK_VERSION_RAW | awk -F'.' '{print $1}')
   FB_SDK_VERSION_MINOR=$(echo $FB_SDK_VERSION_RAW | awk -F'.' '{print $2}')
   FB_SDK_VERSION_REVISION=$(echo $FB_SDK_VERSION_RAW | awk -F'.' '{print $3}')
@@ -77,7 +77,7 @@ if [ -z $FB_SDK_ENV ]; then
   # Explains where the log is if this is the outermost build or if
   # we hit a fatal error.
   function show_summary() {
-    test -r $FB_SDK_BUILD_LOG && echo "Build log is at $FB_SDK_BUILD_LOG"
+    test -r "$FB_SDK_BUILD_LOG" && echo "Build log is at $FB_SDK_BUILD_LOG"
   }
 
   # Determines whether this is out the outermost build.
@@ -95,7 +95,7 @@ if [ -z $FB_SDK_ENV ]; then
   # Deletes any previous build log if this is the outermost build.
   # Do not call outside common.sh.
   function push_common() {
-    test 0 -eq $FB_SDK_BUILD_DEPTH && \rm -f $FB_SDK_BUILD_LOG
+    test 0 -eq $FB_SDK_BUILD_DEPTH && \rm -f "$FB_SDK_BUILD_LOG"
     FB_SDK_BUILD_DEPTH=$(($FB_SDK_BUILD_DEPTH + 1))
   }
 
@@ -130,7 +130,6 @@ if [ -z $FB_SDK_ENV ]; then
     # XCode from app store
     XCODEBUILD=/Applications/XCode.app/Contents/Developer/usr/bin/xcodebuild
   fi
-
 fi
 
 # Increment depth every time we . this file.  At the end of any script


### PR DESCRIPTION
This only fixes `scripts/build_framework.sh`. Other scripts probably won't work if the working directory has spaces in it's path.
