### PR TITLE
Added an error and handler callback for the event where no bridge scheme is present. 

### DIFF
--- a/src/DeviceAPI/FBDialogs.m
+++ b/src/DeviceAPI/FBDialogs.m
@@ -500,6 +500,9 @@
                                           handler:handler];
 
     } else {
+        NSString *bridgeSchemeErrorMsg = @"Could not find an appropriate bridging scheme to open the dialog" ;
+        NSError *noBridgeSchemeError = [self createError:bridgeSchemeErrorMsg session:nil];
+        handler(nil, nil, noBridgeSchemeError);
         return nil;
     }
 }


### PR DESCRIPTION
When the FBApp is unable to open a dialog, the 

``` objc
+ (FBAppCall *)presentLikeDialogWithParams:(FBLikeDialogParams *)params
                               clientState:(NSDictionary *)clientState
                                   handler:(FBDialogAppCallCompletionHandler)handler;
```

call returns nil. It would be nice to know why it failed, or even have the callback handler return some information. Added an error to the handler to alert that the sdk can't open the dialog. 
