### PR TITLE
Fixed misspelling in FBError.h

### DIFF
--- a/src/FBError.h
+++ b/src/FBError.h
@@ -125,7 +125,7 @@ typedef NS_ENUM(NSInteger, FBErrorCode) {
     /*!
      Reserved for future use.
     */
-    FBErrorOperationDisallowedForRestrictedTreament,
+    FBErrorOperationDisallowedForRestrictedTreatment,
 };
 
 /*!


### PR DESCRIPTION
FBErrorOperationDisallowedForRestrictedTreament has a wrong spelling.
