### PR TITLE
FBUtility.h: rename function declaration to match implementation and usage

### DIFF
--- a/src/Core/FBUtility.h
+++ b/src/Core/FBUtility.h
@@ -83,7 +83,7 @@ typedef enum FBAdvertisingTrackingStatus {
 + (NSString *)attributionID;
 + (NSString *)advertiserID;
 + (FBAdvertisingTrackingStatus)advertisingTrackingStatus;
-+ (void)extendDictionaryWithEventUsageLimitsAndUrlSchemes:(NSMutableDictionary *)parameters
++ (void)updateParametersWithEventUsageLimitsAndBundleInfo:(NSMutableDictionary *)parameters
                           accessAdvertisingTrackingStatus:(BOOL)accessAdvertisingTrackingStatus;
 
 #pragma mark - JSON Encode / Decode


### PR DESCRIPTION
After 3.16.1 commit, build_framework.sh script always fails.
it looks like the FBUtility.h file with this rename somehow slipped out from the commit.
