### PR TITLE
Fix memory leaks in FBLoginView

### DIFF
--- a/src/UI/FBLoginView.m
+++ b/src/UI/FBLoginView.m
@@ -136,6 +136,8 @@ static CGSize g_buttonSize;
     [_session release];
     [_user release];
     [_permissions release];
+    [_readPermissions release];
+    [_publishPermissions release];
 
     [super dealloc];
 }


### PR DESCRIPTION
FBLoginView is leaking its readPermissions and publishPermissions properties because it fails to release them in its dealloc method.

Originally submitted against master here: https://github.com/facebook/facebook-ios-sdk/pull/600
