### PR TITLE
Remove AdSupport from podspec [3.19]

### DIFF
--- a/Facebook-iOS-SDK.podspec
+++ b/Facebook-iOS-SDK.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
 
   s.resource  = "src/FBUserSettingsViewResources.bundle"
 
-  s.weak_frameworks = "Accounts", "CoreLocation", "Social", "Security", "QuartzCore", "CoreGraphics", "UIKit", "Foundation", "AudioToolbox", "AdSupport"
+  s.weak_frameworks = "Accounts", "CoreLocation", "Social", "Security", "QuartzCore", "CoreGraphics", "UIKit", "Foundation", "AudioToolbox"
 
   s.requires_arc = false
 


### PR DESCRIPTION
from #655 

I resubmit the pull request to `/dev` branch and already signed CLA.

Thank.
## 

Include AdSupport in podspec will make Xcode alway load AdSupport.framework into binary, even I remove it from project/workspace.

This might cause app get rejected from Apple due to IDFA.
