### PR TITLE
Fix for dangling session pointer in FBAppEvents

### DIFF
--- a/src/Insights/FBAppEvents.m
+++ b/src/Insights/FBAppEvents.m
@@ -456,9 +456,26 @@ const int MAX_IDENTIFIER_LENGTH                      = 40;
          selector:@selector(applicationDidBecomeActive)
          name:UIApplicationDidBecomeActiveNotification
          object:NULL];
+
+        // Subscribe to notifications for when the active session is unset
+        [[NSNotificationCenter defaultCenter]
+         addObserver:self
+         selector:@selector(handleActiveSessionUnset:)
+         name:FBSessionDidUnsetActiveSessionNotification
+         object:NULL];
     }
 
     return self;
+}
+
+- (void)handleActiveSessionUnset:(NSNotification *)notification
+{
+    // The active session is be being over released somewhere in the SDK which results in a
+    // dangling pointer. To solve the problem we can set _lastSessionLoggedTo = nil here.
+    FBSession *sessionUnset = [notification object];
+    if (_lastSessionLoggedTo == sessionUnset) {
+        _lastSessionLoggedTo = nil;
+    }
 }
 
 - (void)dealloc


### PR DESCRIPTION
It seems that somewhere in the SDK an `FBSession` is being over released causing `lastSessionLoggedTo` to point to an invalid object. I've been able to reproduce a crash when the `flushTimer` is fired and running the code with zombies enabled will show `[FBSession retain] message sent to deallocated instance`. This fix works but someone who is more familiar with the code could probably figure out where the session is being over released.