### PR TITLE
[Podspec] Include only public headers from the target's header build phase

### DIFF
--- a/Facebook-iOS-SDK.podspec
+++ b/Facebook-iOS-SDK.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.source_files  =  "src/**/*.{h,m}"
   s.exclude_files = "src/**/*Tests.{h,m}", "src/tests/*.{h,m}", "src/*Test*/*.{h,m}"
 
-  s.public_header_files = "src/*.h"
+  s.public_header_files = `./scripts/find_public_headers.rb`.split("\n")
 
   s.header_dir = "FacebookSDK"
 

--- a/scripts/find_public_headers.rb
+++ b/scripts/find_public_headers.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'pathname'
+require 'xcodeproj'
+
+ROOT = Pathname.new(File.expand_path('../../', __FILE__))
+
+separator = ARGV.shift || "\n"
+
+project = Xcodeproj::Project.open(ROOT + 'src/facebook-ios-sdk.xcodeproj')
+target = project.targets.find { |t| t.symbol_type == :static_library && t.name == 'facebook-ios-sdk' }
+public_headers = target.headers_build_phase.files.select do |build_file|
+  settings = build_file.settings
+  settings && settings['ATTRIBUTES'].include?('Public')
+end
+
+puts public_headers.map { |build_file|
+  build_file.file_ref.real_path.relative_path_from ROOT
+}.to_a.join(separator)


### PR DESCRIPTION
In preparation to the upcoming Swift and Framework support in CocoaPods (see CocoaPods/CocoaPods#2835), I wanted to test a pod which uses the `header_dir` podspec attribute. This attribute was previously used to modify the header directory which the user specifies for imports. E.g. in this case it would be `#import <FacebookSDK/FacebookSDK.h>` instead of `#import <Facebook-iOS-SDK/FacebookSDK.h>`. We will now also start using this name as base to derive a clang module name.

When testing this with your podspec, I noticed that a framework build would fail. That's because the specification of the `public_header_files` in the podspec is wrong. It is including _all_ headers in the `src` directory's root, which includes private headers, such as the clearly labeled [FBTask+BPrivate.h](https://github.com/facebook/facebook-ios-sdk/blob/sdk-version-3.21.1/src/FBTask%2BPrivate.h) and, more importantly, [private headers](https://github.com/facebook/facebook-ios-sdk/blob/sdk-version-3.21.1/src/FBSessionLoginStrategy.h#L18) which in turn import [private headers](https://github.com/facebook/facebook-ios-sdk/blob/sdk-version-3.21.1/src/Login/FBSessionAuthLogger.h) that are not in the `src` directory and thus not included in the build product. This leads to build errors when those private headers are not available at the time the user builds their project.

Note that this PR depends on CocoaPods/CocoaPods#2893, as this change includes a dynamic script which needs to be evaluated in the context of the source directory. As a workaround, it's possible to replace the shell script invocation by a static list of headers.

The added ruby script itself depends on the gem Xcodeproj, which is a transitive dependency of CocoaPods, so it should be present in an environment where the podspec is used. It opens the project file, looks for the library target and inspects its header build phase to grep all headers, which are marked as public.

----

Another solution would be to move all public headers to a dedicated directory, which should also make it easier for any developer to contribute _and_ not mess up header visibility, but this could break existing user code depending on the FacebookSDK.