### PR TITLE
Use NSRunLoopCommonModes for NSURLConnections

### DIFF
--- a/src/Network/FBURLConnection.m
+++ b/src/Network/FBURLConnection.m
@@ -88,7 +88,10 @@ static NSArray *_cdnHosts;
             _loggerSerialNumber = [FBLogger newSerialNumber];
             _connection = [[NSURLConnection alloc]
                            initWithRequest:request
-                           delegate:self];
+                           delegate:self startImmediately:NO];
+            [_connection scheduleInRunLoop: [NSRunLoop mainRunLoop]
+                                   forMode: NSRunLoopCommonModes];
+            [_connection start];
             _data = [[NSMutableData alloc] init];
 
             [self logMessage:[NSString stringWithFormat:@"FBURLConnection <#%lu>:\n  URL: '%@'\n\n",


### PR DESCRIPTION
If we schedule the connection in NSRunLoopCommonModes then the connection will not be paused when we change to NSEventTrackingRunLoopMode. 

https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/Multithreading/RunLoopManagement/RunLoopManagement.html#//apple_ref/doc/uid/10000057i-CH16-SW1