### PR TITLE
Update FBSDKSettings+Internal.h

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSettings+Internal.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKSettings+Internal.h
@@ -23,7 +23,7 @@
 
 + (FBSDKAccessTokenCache *)accessTokenCache;
 
-- (void)setAccessTokenCache;
+- (void)setAccessTokenCache:(FBSDKAccessTokenCache *)cache;
 
 + (NSString *)graphAPIDebugParamValue;
 


### PR DESCRIPTION
The setter method takes an instance of `FBSDKAccessTokenCache` as it parameter.