### PR TITLE
-fixed condition that will otherwise never happen

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareUtility.m
@@ -141,7 +141,7 @@
     return value;
   } else if ([value isKindOfClass:[NSDictionary class]]) {
     NSDictionary *properties = (NSDictionary *)value;
-    if ([FBSDKTypeUtility stringValue:properties[@"type"]]) {
+    if ([FBSDKTypeUtility stringValue:properties[@"og:type"]]) {
       return [FBSDKShareOpenGraphObject objectWithProperties:properties];
     } else {
       NSURL *imageURL = [FBSDKTypeUtility URLValue:properties[@"url"]];


### PR DESCRIPTION
In FBSDKShareOpenGraphValueContainer(parseProperties:) there is call to [FBSDKShareUtility assertOpenGraphValues:properties requireKeyNamespace:[self requireKeyNamespace]]; that will never allow properties without namespace. So if I use og:type then [FBSDKShareUtility convertOpenGraphValues:properties] will never create FBSDKShareOpenGraphObject for dictionaries inside main dictionary.
```objectivec
NSDictionary *dictionary = @{@"og:type" : @"testairextension:taste",
                                 @"apple"   : @{
                                                @"og:title" : @"Apple",
                                                @"og:type"  : @"testairextension:apple"
                                                }
                                 };
FBSDKShareOpenGraphAction *action = [[FBSDKShareOpenGraphAction alloc] init];
[action parseProperties:dictionary];
...
```
This code will result to create only FBSDKShareOpenGraphAction object and not the apple (of type FBSDKShareOpenGraphObject) inside.