### PR TITLE
Support for iOS6

### DIFF
--- a/Facebook-iOS-SDK.podspec
+++ b/Facebook-iOS-SDK.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.author             = 'Facebook'
 
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "6.0"
 
   s.source       = { :git => "https://github.com/facebook/facebook-ios-sdk.git",
                      :tag => "sdk-version-3.24.0"


### PR DESCRIPTION
Why did we drop iOS6 support?

I've looked at the changes, seems like there isn't anything that breaks on iOS6?

Please advise.