### PR TITLE
Specify blocks as taking no parameters, not unspecified parameters

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
@@ -59,7 +59,7 @@
 
         // Set up a block to do the typical recovery work so that we can chain it for ios auth special cases.
         // the block returns YES if recovery UI is started (meaning we wait for the alertviewdelegate to resume control flow).
-        BOOL (^standardRecoveryWork)() = ^BOOL(){
+        BOOL (^standardRecoveryWork)(void) = ^BOOL {
           NSArray *recoveryOptionsTitles = error.userInfo[NSLocalizedRecoveryOptionsErrorKey];
           if (recoveryOptionsTitles.count > 0 && _recoveryAttempter) {
             NSString *recoverySuggestion = error.userInfo[NSLocalizedRecoverySuggestionErrorKey];
@@ -87,7 +87,7 @@
           // (for example, this can repair expired tokens seamlessly)
           [[FBSDKSystemAccountStoreAdapter sharedInstance]
            renewSystemAuthorization:^(ACAccountCredentialRenewResult result, NSError *renewError) {
-             dispatch_async(dispatch_get_main_queue(), ^() {
+             dispatch_async(dispatch_get_main_queue(), ^{
                if (result == ACAccountCredentialRenewResultRenewed) {
                  [self.delegate processorDidAttemptRecovery:self didRecover:YES error:nil];
                  self.delegate = nil;

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
@@ -706,12 +706,12 @@ typedef NS_ENUM(NSUInteger, FBSDKGraphRequestConnectionState)
 
 - (void)processResultBody:(NSDictionary *)body error:(NSError *)error metadata:(FBSDKGraphRequestMetadata *)metadata canNotifyDelegate:(BOOL)canNotifyDelegate
 {
-  void (^clearToken)() = ^{
+  void (^clearToken)(void) = ^{
     if (!(metadata.request.flags & FBSDKGraphRequestFlagDoNotInvalidateTokenOnError)) {
       [FBSDKAccessToken setCurrentAccessToken:nil];
     }
   };
-  void (^finishAndInvokeCompletionHandler)() = ^{
+  void (^finishAndInvokeCompletionHandler)(void) = ^{
     NSDictionary *graphDebugDict = [body objectForKey:@"__debug__"];
     if ([graphDebugDict isKindOfClass:[NSDictionary class]]) {
       [self processResultDebugDictionary: graphDebugDict];

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
@@ -51,7 +51,7 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
   __block NSString *tokenString = nil;
   __block NSNumber *expirationDateNumber = nil;
   __block int expectingCallbacksCount = 2;
-  void (^expectingCallbackComplete)() = ^() {
+  void (^expectingCallbackComplete)(void) = ^{
     if (--expectingCallbacksCount == 0) {
       FBSDKAccessToken *currentToken = [FBSDKAccessToken currentAccessToken];
       NSDate *expirationDate = currentToken.expirationDate;

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKTooltipView.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKTooltipView.m
@@ -241,7 +241,7 @@ static CGMutablePathRef _fbsdkCreateDownPointingBubbleWithRect(CGRect rect, CGFl
 
   // Prepare animation steps
   // 1st Step.
-  void (^zoomIn)() = ^() {
+  void (^zoomIn)(void) = ^{
     self.alpha = 1.0;
 
     CGFloat newZoomOffsetX = (centerPos - _arrowMidpoint) * (kZoomInScale - 1.0f);
@@ -256,7 +256,7 @@ static CGMutablePathRef _fbsdkCreateDownPointingBubbleWithRect(CGRect rect, CGFl
   };
 
   // 2nd Step.
-  void (^bounceZoom)() = ^() {
+  void (^bounceZoom)(void) = ^{
     CGFloat centerPos2 = self.bounds.size.width / 2.0;
     CGFloat zoomOffsetX2 = (centerPos2 - _arrowMidpoint) * (kZoomBounceScale - 1.0f);
     CGFloat zoomOffsetY2 = -0.5f * self.bounds.size.height * (kZoomBounceScale - 1.0f);
@@ -268,7 +268,7 @@ static CGMutablePathRef _fbsdkCreateDownPointingBubbleWithRect(CGRect rect, CGFl
   };
 
   // 3rd Step.
-  void (^normalizeZoom)() = ^() {
+  void (^normalizeZoom)(void) = ^{
     self.layer.transform = fbsdkdfl_CATransform3DIdentity;
   };
 


### PR DESCRIPTION
A block or function with parameters `()` means "unspecified parameters", so the following code compiles and runs without complaint:

    void (^clearToken)() = ^{ ... };
    clearToken(@"hi", 13, NO);

Change to `(void)` meaning "no parameters". Also standardize on `^{` to open a block with no parameters (from a mix of `^{` and `^() {`).