### PR TITLE
Flip return value of -application:didFinishLaunchingWithOptions:

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -167,13 +167,13 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
     if (loginManagerClass) {
       id annotation = launchOptions[UIApplicationLaunchOptionsAnnotationKey];
       id<FBSDKURLOpening> loginManager = [[loginManagerClass alloc] init];
-      return [loginManager application:application
-                               openURL:launchedURL
-                     sourceApplication:sourceApplication
-                            annotation:annotation];
+      return ![loginManager application:application
+                                openURL:launchedURL
+                      sourceApplication:sourceApplication
+                             annotation:annotation];
     }
   }
-  return NO;
+  return YES;
 }
 
 - (void)applicationDidEnterBackground:(NSNotification *)notification


### PR DESCRIPTION
(#792 targeted at dev branch)

The delegate should return YES if it wants to continue to receive delegate methods related to the launch. For example, if the app is being launched to handle a URL, the application could either:

1. Handle the URL contained in the options dictionary parameter and return NO from `-application:didFinishLaunchingWithOptions:`.

2. Launch as usual and return YES from `-application:didFinishLaunchingWithOptions:`, and then handle the URL in `-application:openURL:sourceApplication:annotation:` or `-application:openURL:options:`.

In the first case, returning NO stops the system calling an `openURL:` delegate method.

This is more important with the release of `UIApplicationShortcutItem` (a.k.a. "Home screen dynamic quick actions"), which adds another way the application can be launched (and a corresponding delegate method). The delegate should default to returning YES from `-application:didFinishLaunchingWithOptions:` so that `-application:performActionForShortcutItem:completion:` will be called when launched from a shortcut. (If the application can launch more efficiently with knowledge of the shortcut, it can use the information
passed in the launch options dictionary and return NO, the same as with a URL.)