### PR TITLE
Update sentence spacing in warning message

### DIFF
--- a/FBSDKIntegrationTests/FBSDKIntegrationTests/FBSDKIntegrationTestCase.m
+++ b/FBSDKIntegrationTests/FBSDKIntegrationTests/FBSDKIntegrationTestCase.m
@@ -46,14 +46,14 @@ static id g_mockNSBundle;
     if (g_AppID.length == 0 || g_AppSecret.length == 0 || g_AppClientToken.length == 0) {
       [[NSException exceptionWithName:NSInternalInconsistencyException
                                reason:
-        @"Integration Tests Cannot Be Run."
-        @"Missing App ID or App Secret, or Client Token in Build Settings."
-        @" You can set this in an xcconfig file containing your unit-testing Facebook"
-        @" Application's ID and Secret in this format:\n"
+        @"Integration Tests cannot be run. "
+        @"Missing App ID or App Secret, or Client Token in Build Settings. "
+        @"You can set this in an xcconfig file containing your unit-testing Facebook "
+        @"Application's ID and Secret in this format:\n"
         @"\tIOS_SDK_TEST_APP_ID = // your app ID, e.g.: 1234567890\n"
         @"\tIOS_SDK_TEST_APP_SECRET = // your app secret, e.g.: 1234567890abcdef\n"
         @"\tIOS_SDK_TEST_CLIENT_TOKEN = // your app client token, e.g.: 1234567890abcdef\n"
-        @"Do NOT release your app secret in your app"
+        @"Do NOT release your app secret in your app. "
         @"To create a Facebook AppID, visit https://developers.facebook.com/apps"
                              userInfo:nil]
        raise];


### PR DESCRIPTION
It's a small change, but the spacing around sentences was missing and there was a missing period as well.

#### Before
<img width="637" alt="screenshot 2015-10-07 17 45 25" src="https://cloud.githubusercontent.com/assets/48065/10355012/57e781b6-6d1b-11e5-8a70-a7b536f86313.png">


#### After
<img width="640" alt="screenshot 2015-10-07 17 57 31" src="https://cloud.githubusercontent.com/assets/48065/10355125/f5bb78ec-6d1c-11e5-80f7-c899b07ee3ef.png">
