### PR TITLE
Default behavior for iOS 9 and above devices - Facebook login

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.h
@@ -78,6 +78,7 @@ typedef NS_ENUM(NSUInteger, FBSDKLoginBehavior)
   FBSDKLoginBehaviorNative = 0,
   /*!
    @abstract Attempts log in through the Safari or SFSafariViewController, if available.
+   @note The SDK prefers this as the default behavior in iOS 9 and above.
    */
   FBSDKLoginBehaviorBrowser,
   /*!


### PR DESCRIPTION
It seems that there has been some confusion in the online community as to the default behavior of Facebook login for iOS 9 and above devices and some people seem to get confused by it.

When I was upgrading the SDK from V4.5 to V4.7 I met the same issue, looked into the SDK and figured Native was still the default and I must have done something wrong. Upon sourcing online I found out that the default was indeed changed to SFSafariViewController (if available) to prevent quick-app-switching, improve user experience.

Would adding a note like that help other fellow users who might look into the source code and not get confused or think that they did something wrong like I did?