### PR TITLE
Remove Default Safari View Controller

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
@@ -223,14 +223,9 @@ typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
   // the server to respond.
   static FBSDKServerConfiguration *_defaultServerConfiguration = nil;
   if (![_defaultServerConfiguration.appID isEqualToString:appID]) {
-    // Bypass the native dialog flow for iOS 9+, as it produces a series of additional confirmation dialogs that lead to
-    // extra friction that is not desirable.
-    NSOperatingSystemVersion iOS9Version = { .majorVersion = 9, .minorVersion = 0, .patchVersion = 0 };
-    BOOL useNativeFlow = ![FBSDKInternalUtility isOSRunTimeVersionAtLeast:iOS9Version];
-    // Also enable SFSafariViewController by default.
     NSDictionary *dialogFlows = @{
                                   FBSDKDialogConfigurationNameDefault: @{
-                                      FBSDKDialogConfigurationFeatureUseNativeFlow: @(useNativeFlow),
+                                      FBSDKDialogConfigurationFeatureUseNativeFlow: @YES,
                                       FBSDKDialogConfigurationFeatureUseSafariViewController: @YES,
                                       },
                                   FBSDKDialogConfigurationNameMessage: @{


### PR DESCRIPTION
Despite Facebook's internal team's internal testing showing that the Safari View Controller method is more user friendly, developers are seeing otherwise in a massive drop-off in sign-up rates. First, the additional alerts switching back and forth presents much less friction than having to retype your password on a safari modal. Facebook may see on a large scale more users are using Safari than native app (I'd be surprised), the users who are downloading most apps are more likely to be logged in via a native app. Many users use the Facebook so much that they haven't typed their passwords in ages. Facebook has also claimed that after the first time that users type in their password, the friction will decrease as the session is stored, but we are seeing that this session storage in unreliable. Even getting a user to sign in that very first time is enough to cause abandonment. Please see the negative feedback from developers here: 

`http://stackoverflow.com/questions/32566734/native-facebook-app-does-not-open-with-facebook-login-in-ios-9`

While the graph api is great, the most important feature is a frictionless sign up process. This is more important than the extra features of the graph-api, would can not even be used if a user abandons an app. Please reconsider Facebook !