### PR TITLE
ShareKit - Like action : added engagement message localization by default based on device setting

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKLikeButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKLikeButton.h
@@ -33,6 +33,13 @@
 @interface FBSDKLikeButton : FBSDKButton <FBSDKLiking>
 
 /*!
+ @abstract Sets the locale for social engagement sentences.
+ 
+ @default Current locale identifier
+ */
++ (void)setLocaleIdentifier:(NSString *)localeIdentifier;
+
+/*!
  @abstract If YES, a sound is played when the receiver is toggled.
 
  @default YES

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKLikeButton.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKLikeButton.m
@@ -46,6 +46,11 @@
   }
 }
 
++ (void)setLocaleIdentifier:(NSString *)localeIdentifier
+{
+    [FBSDKLikeActionController setLocaleIdentifier:localeIdentifier];
+}
+
 #pragma mark - Object Lifecycle
 
 - (void)dealloc

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKLikeControl.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKLikeControl.h
@@ -136,4 +136,11 @@ FBSDK_EXTERN NSString *NSStringFromFBSDKLikeControlStyle(FBSDKLikeControlStyle s
  */
 @property (nonatomic, assign, getter = isSoundEnabled) BOOL soundEnabled;
 
+/*!
+ @abstract Sets the locale for social engagement sentences.
+ 
+ @default Current locale identifier
+ */
++ (void)setLocaleIdentifier:(NSString *)localeIdentifier;
+
 @end

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKLikeControl.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKLikeControl.m
@@ -95,6 +95,11 @@ typedef CGSize (^fbsdk_like_control_sizing_block_t)(UIView *subview, CGSize cons
   }
 }
 
++ (void)setLocaleIdentifier:(NSString *)localeIdentifier
+{
+    [FBSDKLikeActionController setLocaleIdentifier:localeIdentifier];
+}
+
 #pragma mark - Object Lifecycle
 
 - (instancetype)initWithFrame:(CGRect)frame

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKLikeActionController.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKLikeActionController.h
@@ -31,6 +31,7 @@ FBSDK_EXTERN NSString *const FBSDKLikeActionControllerAnimatedKey;
 @interface FBSDKLikeActionController : NSObject <NSDiscardableContent, NSSecureCoding>
 
 + (BOOL)isDisabled;
++ (void)setLocaleIdentifier:(NSString *)localeIdentifier;
 
 // this method will call beginContentAccess before returning the instance
 + (instancetype)likeActionControllerForObjectID:(NSString *)objectID objectType:(FBSDKLikeObjectType)objectType;


### PR DESCRIPTION
**Current behaviour** :
The engagement sentences are not localized, the graph API calls do not specify any locale and therefore the sentences are always in english.

**Proposed change** :
By default, the locale should be the same as the device one.
Give the possibility to the App layer to enforce a specific locale (for apps that don't necessary support the current locale of the device).

It would have been better to avoid having static methods like this but it's the simplest implementation I though of based on the current codebase.