### PR TITLE
silence compiler warnings regarding deprecation of UIAlertView and UIActionSheet

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
@@ -137,6 +137,7 @@
 
 #pragma mark - UIAlertViewDelegate
 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
@@ -144,6 +145,7 @@
   _alertView.delegate = nil;
   _alertView = nil;
 }
+#pragma clang diagnostic pop
 
 #pragma mark - FBSDKErrorRecoveryAttempting "delegate"
 

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphErrorRecoveryProcessor.m
@@ -137,6 +137,7 @@
 
 #pragma mark - UIAlertViewDelegate
 
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
   [_recoveryAttempter attemptRecoveryFromError:_error optionIndex:buttonIndex delegate:self didRecoverSelector:@selector(didPresentErrorWithRecovery:contextInfo:) contextInfo:nil];

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
@@ -105,6 +105,7 @@
 
 #pragma mark - UIActionSheetDelegate
 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
@@ -114,6 +115,7 @@
     [self.delegate loginButtonDidLogOut:self];
   }
 }
+#pragma clang diagnostic pop
 
 #pragma mark - FBSDKButtonImpressionTracking
 

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
@@ -105,6 +105,7 @@
 
 #pragma mark - UIActionSheetDelegate
 
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
   if (buttonIndex == 0) {


### PR DESCRIPTION
In answer to https://github.com/facebook/facebook-ios-sdk/pull/812

The warnings appear when using Xcode 7.2 (7C68), using the default settings from the template Swift _iOS Single View Application_.

Using Cocoapods v0.39.0, i.e. the [latest stable release](https://github.com/CocoaPods/CocoaPods-app/releases).