### PR TITLE
[ShareKit] Provide override for usage of global [FBSDKAccessToken currentAccessToken]

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h
@@ -18,12 +18,13 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FBSDKCoreKit/FBSDKAccessToken.h>
 #import <FBSDKShareKit/FBSDKShareOpenGraphObject.h>
 #import <FBSDKShareKit/FBSDKSharing.h>
 
 /*!
- @abstract A utility class for sharing through the graph API.  Using this class requires an access token in
- [FBSDKAccessToken currentAccessToken] that has been granted the "publish_actions" permission.
+ @abstract A utility class for sharing through the graph API.  Using this class requires an access token that
+ has been granted the "publish_actions" permission.
  @discussion FBSDKShareAPI network requests are scheduled on the current run loop in the default run loop mode
  (like NSURLConnection). If you want to use FBSDKShareAPI in a background thread, you must manage the run loop
  yourself.
@@ -46,6 +47,14 @@
  @abstract The graph node to which content should be shared.
  */
 @property (nonatomic, copy) NSString *graphNode;
+
+/*!
+ @abstract The access token to use instead of the global [FBSDKAccessToken currentAccessToken].  The access token must
+ have the "publish_actions" permission granted.
+ @discussion Set this value when sharing to a destination (ex. Page) that requires a separate access token from that
+ of the currently logged-in user.
+ */
+@property (nonatomic, strong) FBSDKAccessToken *accessTokenOverride;
 
 /*!
  @abstract A Boolean value that indicates whether the receiver can send the share.

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h
@@ -49,12 +49,12 @@
 @property (nonatomic, copy) NSString *graphNode;
 
 /*!
- @abstract The access token to use instead of the global [FBSDKAccessToken currentAccessToken].  The access token must
- have the "publish_actions" permission granted.
- @discussion Set this value when sharing to a destination (ex. Page) that requires a separate access token from that
- of the currently logged-in user.
+ @abstract The access token used when performing a share. The access token must have the "publish_actions"
+ permission granted.
+ @discussion Defaults to [FBSDKAccessToken currentAccessToken]. Setting this to nil will revert the access token to
+ [FBSDKAccessToken currentAccessToken].
  */
-@property (nonatomic, strong) FBSDKAccessToken *accessTokenOverride;
+@property (nonatomic, strong) FBSDKAccessToken *accessToken;
 
 /*!
  @abstract A Boolean value that indicates whether the receiver can send the share.

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
@@ -71,6 +71,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 @synthesize delegate = _delegate;
 @synthesize shareContent = _shareContent;
 @synthesize shouldFailOnDataError = _shouldFailOnDataError;
+@synthesize accessToken = _accessToken;
 
 #pragma mark - Object Lifecycle
 
@@ -201,12 +202,12 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
   return [FBSDKShareUtility validateShareContent:shareContent error:errorRef];
 }
 
-#pragma mark - Helper Methods
-
-- (FBSDKAccessToken *)_accessToken
+- (FBSDKAccessToken *)accessToken
 {
-  return self.accessTokenOverride ?: [FBSDKAccessToken currentAccessToken];
+  return _accessToken ?: [FBSDKAccessToken currentAccessToken];
 }
+
+#pragma mark - Helper Methods
 
 - (NSString *)_graphPathWithSuffix:(NSString *)suffix, ... NS_REQUIRES_NIL_TERMINATION
 {
@@ -242,7 +243,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 
 - (BOOL)_hasPublishActions
 {
-  return [self._accessToken.permissions containsObject:@"publish_actions"];
+  return [self.accessToken.permissions containsObject:@"publish_actions"];
 }
 
 - (BOOL)_shareLinkContent:(FBSDKShareLinkContent *)linkContent
@@ -273,7 +274,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
 
   [[[FBSDKGraphRequest alloc] initWithGraphPath:[self _graphPathWithSuffix:@"feed", nil]
                                      parameters:parameters
-                                    tokenString:self._accessToken.tokenString
+                                    tokenString:self.accessToken.tokenString
                                         version:nil
                                      HTTPMethod:@"POST"] startWithCompletionHandler:completionHandler];
   return YES;
@@ -315,7 +316,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     NSString *graphPath = [self _graphPathWithSuffix:[FBSDKUtility URLEncode:action.actionType], nil];
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:graphPath
                                                                    parameters:parameters
-                                                                  tokenString:self._accessToken.tokenString
+                                                                  tokenString:self.accessToken.tokenString
                                                                       version:nil
                                                                    HTTPMethod:@"POST"];
     [self _connection:connection addRequest:request completionHandler:requestHandler];
@@ -345,7 +346,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
       parameters[@"picture"] = image;
       [requests addObject:[[FBSDKGraphRequest alloc] initWithGraphPath:graphPath
                                                             parameters:parameters
-                                                           tokenString:self._accessToken.tokenString
+                                                           tokenString:self.accessToken.tokenString
                                                                version:nil
                                                             HTTPMethod:@"POST"]];
     }
@@ -388,7 +389,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
   NSMutableDictionary *parameters = [[NSMutableDictionary alloc] init];
   [self _addCommonParameters:parameters content:videoContent];
   [FBSDKInternalUtility dictionary:parameters setObject:self.message forKey:@"description"];
-  if ([self._accessToken.permissions containsObject:@"ads_management"]) {
+  if ([self.accessToken.permissions containsObject:@"ads_management"]) {
     FBSDKSharePhoto *photo = videoContent.previewPhoto;
     UIImage *image = photo.image;
     if (!image && [photo.imageURL isFileURL]) {
@@ -558,7 +559,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     NSDictionary *parameters = @{ @"object": objectString };
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:graphPath
                                                                    parameters:parameters
-                                                                  tokenString:self._accessToken.tokenString
+                                                                  tokenString:self.accessToken.tokenString
                                                                       version:nil
                                                                    HTTPMethod:@"POST"];
     FBSDKGraphRequestHandler requestCompletionHandler = ^(FBSDKGraphRequestConnection *requestConnection,
@@ -669,7 +670,7 @@ static NSMutableArray *g_pendingFBSDKShareAPI;
     NSDictionary *parameters = @{ @"file": photo.image };
     FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:graphPath
                                                                    parameters:parameters
-                                                                  tokenString:self._accessToken.tokenString
+                                                                  tokenString:self.accessToken.tokenString
                                                                       version:nil
                                                                    HTTPMethod:@"POST"];
     FBSDKGraphRequestHandler completionHandler = ^(FBSDKGraphRequestConnection *requestConnection,


### PR DESCRIPTION
This is needed when sharing to a destination (ex. Page) that requires a separate access token from that of the currently logged-in user.

Prior to this change, you'd need to set the global access token and then revert it back. Doing so would post numerous notifications about the currently logged-in user changing.