### PR TITLE
Fixed a crash when assuming that sessionID is stored in the FBSDKTime…

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKTimeSpentData.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKTimeSpentData.m
@@ -189,7 +189,11 @@ static const long INACTIVE_SECONDS_QUANTA[] =
                        formatString:@"FBSDKTimeSpentData Restore: %@", content];
 
     long now = [FBSDKAppEventsUtility unixTimeNow];
-    if (!content) {
+
+    //If no content of no stored sessionID, consider it's a first launch
+    //Note that stored sessionID could be nil since it was not persisted in previous versions of the SDK
+    NSDictionary *results = [FBSDKInternalUtility objectForJSONString:content error:NULL];
+    if (!content || !results[FBSDKTimeSpentPersistKeySessionID]) {
 
       // Nothing persisted, so this is the first launch.
       _sessionID = [[NSUUID UUID] UUIDString];
@@ -202,8 +206,6 @@ static const long INACTIVE_SECONDS_QUANTA[] =
       _shouldLogDeactivateEvent = NO;
 
     } else {
-
-      NSDictionary *results = [FBSDKInternalUtility objectForJSONString:content error:NULL];
 
       _lastSuspendTime = [[results objectForKey:FBSDKTimeSpentPersistKeyLastSuspendTime] longValue];
 


### PR DESCRIPTION
Fixed a crash when assuming that sessionID is stored in the FBSDKTimeSpentFilename although it could be missing if file was created with a previous version of the SDK.
It crashes when trying to store the nil sessionID into a dictionary to save it in the FBSDKTimeSpentFilename file.