### PR TITLE
Provide sourceView for AlertController in logout function

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
@@ -212,6 +212,11 @@
                                                      }];
       [alertController addAction:cancel];
       [alertController addAction:logout];
+      
+      UIPopoverPresentationController *presentationController = alertController.popoverPresentationController;
+      presentationController.sourceView = self;
+      presentationController.sourceRect = self.bounds;
+      
       UIViewController *topMostViewController = [FBSDKInternalUtility topMostViewController];
       [topMostViewController presentViewController:alertController
                                           animated:YES


### PR DESCRIPTION
App crash when tap on logout button (`FBSDKLoginButton`) due to iPad (iOS8 or later) need `sourceView`/`sourceRect` to present action sheet.

---

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)
