### PR TITLE
Disable dismissing with edge pan gesture

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -339,12 +339,16 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
       [parent.transitionCoordinator animateAlongsideTransition:NULL completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
         // Note SFVC init must occur inside block to avoid blank screen.
         _safariViewController = [[SFSafariViewControllerClass alloc] initWithURL:url];
+        // Disable dismissing with edge pan gesture
+        _safariViewController.modalPresentationStyle = UIModalPresentationOverFullScreen;
         [_safariViewController performSelector:@selector(setDelegate:) withObject:self];
         [container displayChildController:_safariViewController];
         [parent presentViewController:container animated:YES completion:nil];
       }];
     } else {
       _safariViewController = [[SFSafariViewControllerClass alloc] initWithURL:url];
+      // Disable dismissing with edge pan gesture
+      _safariViewController.modalPresentationStyle = UIModalPresentationOverFullScreen;
       [_safariViewController performSelector:@selector(setDelegate:) withObject:self];
       [container displayChildController:_safariViewController];
       [parent presentViewController:container animated:YES completion:nil];


### PR DESCRIPTION
SFSafariViewController's container VC is dismissed unexpectedly when swiping the screen edge.

By dismissing with that way, SFSafariViewControllerDelegate's `-(void)safariViewControllerDidFinish:` is not invoked but FBSDKContainerViewControllerDelegate's `-(void)viewControllerDidDisappear:` is invoked, so the error log in `-(void)viewControllerDidDisappear:` appears.