### PR TITLE
Updating Submodules Schemes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "vendor/OHHTTPStubs"]
 	path = vendor/OHHTTPStubs
-	url = git://github.com/AliSoftware/OHHTTPStubs.git
+	url = https://github.com/AliSoftware/OHHTTPStubs.git
 [submodule "vendor/OCMock"]
 	path = vendor/OCMock
-	url = git://github.com/erikdoe/ocmock
+	url = https://github.com/erikdoe/ocmock
 [submodule "vendor/appledoc"]
 	path = vendor/appledoc
-	url = git://github.com/tomaz/appledoc.git
+	url = https://github.com/tomaz/appledoc.git
 [submodule "Bolts-IOS"]
 	path = Bolts-IOS
-  	url = git://github.com/BoltsFramework/Bolts-iOS.git
+  	url = https://github.com/BoltsFramework/Bolts-iOS.git
 [submodule "vendor/ios-snapshot-test-case"]
 	path = vendor/ios-snapshot-test-case
-	url = git://github.com/facebook/ios-snapshot-test-case.git
+	url = https://github.com/facebook/ios-snapshot-test-case.git
 [submodule "vendor/xctool"]
 	path = vendor/xctool
-	url = git://github.com/facebook/xctool.git
+	url = https://github.com/facebook/xctool.git
 
 
 [submodule "FBNotifications"]


### PR DESCRIPTION
carthage update on any Facebook-SDK for iOS Development causes a timeout when checking out the dependancies for facebook-ios-sdk

Many companies restrict using the git:// scheme due to it using a specific port and not using proper authorization. Https is much more secure and more commonly unblocked.

Proposing this file be standardized to use https instead of both git and https schemes.

This fixes the carthage update timeout issue.

Alternatively users cloning this project will need to run a command similar to:

git config --global url."https://".insteadOf git://

or remove --global and do it on a project-to-project basis.