### PR TITLE
Fix build error in iOS 9.3 before.

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.h
@@ -58,6 +58,7 @@
   sourceApplication:(NSString *)sourceApplication
          annotation:(id)annotation;
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_3
 /*!
  @abstract
  Call this method from the [UIApplicationDelegate application:openURL:options:] method
@@ -75,6 +76,7 @@
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options;
+#endif
 
 /*!
  @abstract

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -122,6 +122,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
 
 #pragma mark - UIApplicationDelegate
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_3
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
@@ -131,6 +132,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
          sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
                 annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
 }
+#endif
 
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

Fix build error 'No type or protocol named UIApplicationOpenURLOptionsKey' in iOS 9.3 before.