### PR TITLE
Modifies the key to prevent collisions between keychain and nsuserdefaults in simulator

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
@@ -91,6 +91,10 @@
 
 #if TARGET_OS_SIMULATOR
     NSLog(@"Falling back to storing access token in NSUserDefaults because of simulator bug");
+  
+    key = [key stringByAppendingString:@".TARGET_SIMULATOR"];
+    NSLog(@"To prevent key collisions between keychain store and nsuserdefaults in simulator, key changed to : %@",key);
+  
     [[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
 
     return [[NSUserDefaults standardUserDefaults] synchronize];
@@ -132,6 +136,10 @@
 
 #if TARGET_OS_SIMULATOR
     NSLog(@"Falling back to loading access token from NSUserDefaults because of simulator bug");
+  
+    key = [key stringByAppendingString:@".TARGET_SIMULATOR"];
+    NSLog(@"To prevent key collisions between keychain store and nsuserdefaults in simulator, key changed to : %@",key);
+  
     return [[NSUserDefaults standardUserDefaults] dataForKey:key];
 #else
     NSMutableDictionary *query = [self queryForKey:key];


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

---

`FBSDKKeychainStore` is responsible to store and fetch NSData object from iOS Keychain. On the other hand, in simulator `FBSDKKeychainStore` falls back to `NSUserDefaults` while there is no keychain function in simulator.

There was a crash happening on `-[FBSDKAccessTokenCacheV4 fetchAccessToken]`, which is described [here](https://developers.facebook.com/bugs/955908041210806/) . Reason of the crash was `FBSDKAccessTokenCacheV4` first writes the `UDID` to the user defaults with the key `kFBSDKAccessTokenUserDefaultsKey`. Then It tries to store some other dictionary into the keychain store with the same key. It is all ok in device, **but in simulator**, `FBSDKKeychainStore` falls back to nsuserdefaults, which cause an override on the same key `kFBSDKAccessTokenUserDefaultsKey`.

This change will add suffix `.TARGET_SIMULATOR` to every key at the time of that fallback therefore prevents the collisions between **nsuserdefaults** and **keychainstore**.
