### PR TITLE
Add missing fr localizable strings in FacebookSDKStrings bundle

### DIFF
--- a/FacebookSDKStrings.bundle/Resources/fr.lproj/FacebookSDK.strings
+++ b/FacebookSDKStrings.bundle/Resources/fr.lproj/FacebookSDK.strings
@@ -8,10 +8,10 @@
 "DeviceLogin.SmartLogInStep0" = "Confirmez votre code sur Facebook.";
 
 /* The string for smart login instructions */
-"DeviceLogin.SmartLogInStep1" = "\n1. Allez dans le Menu  ";
+"DeviceLogin.SmartLogInStep1" = "\n1. Allez dans le Menu";
 
 /* The string for smart login instructions */
-"DeviceLogin.SmartLogInStep2" = "\n2. Sélectionnez Demandes d'appareils  ";
+"DeviceLogin.SmartLogInStep2" = "\n2. Sélectionnez Demandes d'appareils";
 
 /* The string for smart login instructions */
 "DeviceLogin.SmartLogInStep3" = "\n3. Confirmez le code.";

--- a/FacebookSDKStrings.bundle/Resources/fr.lproj/FacebookSDK.strings
+++ b/FacebookSDKStrings.bundle/Resources/fr.lproj/FacebookSDK.strings
@@ -1,5 +1,5 @@
 /* The format string for device login instructions */
-"DeviceLogin.LogInPrompt" = "Rendez-vous sur %@ sur votre smartphone ou votre ordinateur et entrez ce code :";
+"DeviceLogin.LogInPrompt" = "Rendez-vous sur %@ sur votre smartphone ou votre ordinateur et entrez votre code.";
 
 /* The 'or' string for smart login instructions */
 "DeviceLogin.SmartLogInOrLabel" = "-- OU --";
@@ -8,10 +8,10 @@
 "DeviceLogin.SmartLogInStep0" = "Confirmez votre code sur Facebook.";
 
 /* The string for smart login instructions */
-"DeviceLogin.SmartLogInStep1" = "\n1. Allez dans le Menu";
+"DeviceLogin.SmartLogInStep1" = "\n1. Allez dans le Menu ";
 
 /* The string for smart login instructions */
-"DeviceLogin.SmartLogInStep2" = "\n2. Sélectionnez Demandes d'appareils";
+"DeviceLogin.SmartLogInStep2" = "\n2. Sélectionnez Demandes d'appareils ";
 
 /* The string for smart login instructions */
 "DeviceLogin.SmartLogInStep3" = "\n3. Confirmez le code.";

--- a/FacebookSDKStrings.bundle/Resources/fr.lproj/FacebookSDK.strings
+++ b/FacebookSDKStrings.bundle/Resources/fr.lproj/FacebookSDK.strings
@@ -1,6 +1,21 @@
 /* The format string for device login instructions */
 "DeviceLogin.LogInPrompt" = "Rendez-vous sur %@ sur votre smartphone ou votre ordinateur et entrez ce code :";
 
+/* The 'or' string for smart login instructions */
+"DeviceLogin.SmartLogInOrLabel" = "-- OU --";
+
+/* The string for smart login instructions */
+"DeviceLogin.SmartLogInStep0" = "Confirmez votre code sur Facebook.";
+
+/* The string for smart login instructions */
+"DeviceLogin.SmartLogInStep1" = "\n1. Allez dans le Menu  ";
+
+/* The string for smart login instructions */
+"DeviceLogin.SmartLogInStep2" = "\n2. Sélectionnez Demandes d'appareils  ";
+
+/* The string for smart login instructions */
+"DeviceLogin.SmartLogInStep3" = "\n3. Confirmez le code.";
+
 /* The title of the label to dismiss the alert when presenting user facing error messages */
 "ErrorRecovery.Alert.OK" = "OK";
 
@@ -72,3 +87,12 @@
 
 /* The label for FBSDKShareButton */
 "ShareButton.Share" = "Partager";
+
+/* The title for the alert when smart login requires confirmation */
+"SmartLogin.ConfirmationTitle" = "Confirmez la connexion";
+
+/* The format string to continue as <name> for the alert when smart login requires confirmation */
+"SmartLogin.Continue" = "Continuer en tant que %@";
+
+/* The cancel label for the alert when smart login requires confirmation */
+"SmartLogin.NotYou" = "Ce n’est pas vous ?";


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

Add missing french translations for some keys in FacebookSDKStrings fr.lproj's FacebookSDK.strings file.

Correct `DeviceLogin.LogInPrompt`'s value since the string is misplaced in the LoginView :
![image](https://cloud.githubusercontent.com/assets/3032313/22295919/e4ac8bcc-e318-11e6-996a-19e819668ced.png)
