### PR TITLE
Fix syntax error in Croatian strings file

### DIFF
--- a/FacebookSDKStrings.bundle/Resources/hr.lproj/FacebookSDK.strings
+++ b/FacebookSDKStrings.bundle/Resources/hr.lproj/FacebookSDK.strings
@@ -26,7 +26,7 @@
 "LikeButton.Like" = "Sviđa mi se";
 
 /* The label for the FBSDKLikeButton when the object is currently liked. */
-"LikeButton.Liked" = "Označeno sa "sviđa mi se"";
+"LikeButton.Liked" = "Označeno sa "sviđa mi se";
 
 /* The label for the FBSDKLoginButton action sheet to cancel logging out */
 "LoginButton.CancelLogout" = "Odustani";

--- a/FacebookSDKStrings.bundle/Resources/hr.lproj/FacebookSDK.strings
+++ b/FacebookSDKStrings.bundle/Resources/hr.lproj/FacebookSDK.strings
@@ -26,7 +26,7 @@
 "LikeButton.Like" = "Sviđa mi se";
 
 /* The label for the FBSDKLikeButton when the object is currently liked. */
-"LikeButton.Liked" = "Označeno sa "sviđa mi se";
+"LikeButton.Liked" = "Označeno sa \"sviđa mi se\"";
 
 /* The label for the FBSDKLoginButton action sheet to cancel logging out */
 "LoginButton.CancelLogout" = "Odustani";


### PR DESCRIPTION
I accidentally found this syntax error in `hr.lproj/FacebookSDK.strings`.  I ran `find . -name "*.strings" | xargs plutil -lint` on my project, and it scanned the strings files in the FacebookSDK (which we depend on) as well.

With the fix in place, the linting succeeds. I have to admit that I didn't try it in an app. We don't have Croatian in our app.

----

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)