### PR TITLE
Fix a crash caused by applink's `target_url` being `null`

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -420,6 +420,11 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
     return;
   }
 
+  NSString * targetURLString = applinkData[@"target_url"];
+  if (targetURLString == nil || ![targetURLString isKindOfClass: [NSString class]]) {
+    return;
+  }
+
   NSURL *targetURL = [NSURL URLWithString:applinkData[@"target_url"]];
   NSMutableDictionary *logData = [[NSMutableDictionary alloc] init];
   [FBSDKInternalUtility dictionary:logData setObject:[targetURL absoluteString] forKey:@"targetURL"];

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -420,12 +420,14 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
     return;
   }
 
+  NSURL *targetURL;
   NSString * targetURLString = applinkData[@"target_url"];
   if (targetURLString == nil || ![targetURLString isKindOfClass: [NSString class]]) {
-    return;
+    targetURL = nil;
+  } else {
+    targetURL = [NSURL URLWithString: targetURLString];
   }
 
-  NSURL *targetURL = [NSURL URLWithString:applinkData[@"target_url"]];
   NSMutableDictionary *logData = [[NSMutableDictionary alloc] init];
   [FBSDKInternalUtility dictionary:logData setObject:[targetURL absoluteString] forKey:@"targetURL"];
   [FBSDKInternalUtility dictionary:logData setObject:[targetURL host] forKey:@"targetURLHost"];


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

### Demo project

https://github.com/NicholasTD07/demos/tree/master/facebook-app-link-crash-demo

The `README.md` file describes how to reproduce the crash and also the following.

### The change

Add a check before creating `targetURL` from `applinkData[@"target_url"]`, to make sure

1. `applinkData[@"target_url"]` is not nil
2. `applinkData[@"target_url"]` is of type `NSString`

If there's a valid `target_url` string in the `applinkData` dict, then create a `targetURL` of type `NSURL`. Otherwise, set the `targetURL` (of type `NSURL`) to `nil`.

### What causes the crash?

If someone try to use `FBSDKApplicationDelegate.application(_:open:sourceApplication:annotation:)` to open an URL that contains a JSON string like this:

```json
{"target_url": null, "extras": {"fb_app_id": 12345}}
```

FBSDK will crash.

### Where is the crash?

In `FBSDKApplicationDelegate.m`, and in the method `_logIfAppLinkEvent`

### The crash

In the app link, the value of `target_url` in the JSON string can be
`null`.  After decoding the JSON string, `target_url` will be decoded
into an `NSNull`.

Without this check, FBSDKCoreKit will crash when trying to create an
`NSURL` from `NSNull` and thus crash the app.

