### PR TITLE
Login modal leaves black screen after dismissing

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -337,6 +337,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
     [components setQueryItems:[components.queryItems arrayByAddingObject:sfvcQueryItem]];
     url = components.URL;
     FBSDKContainerViewController *container = [[FBSDKContainerViewController alloc] init];
+    container.modalPresentationStyle = UIModalPresentationOverFullScreen;
     container.delegate = self;
     if (parent.transitionCoordinator != nil) {
       // Wait until the transition is finished before presenting SafariVC to avoid a blank screen.


### PR DESCRIPTION
To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

---

### OS / FB Version
iOS 10.x, FB SDK 4.20.1

### What I did
Using a custom login button, I asked for login w/ read permissions. This defaulted to using the Safari view controller since the Facebook app was not installed.

```swift
let manager = FBSDKLoginManager()
manager.logIn(withReadPermissions: nil, from: self) { (result, error) in
    if let error = error as? NSError {
        debugPrint(error)
        return
    }
    
    if result?.isCancelled == true { return }
    guard let token = result?.token else {
        // Show error
        debugPrint("No token given")
        return
    }
    
    // Login here to API
}
```

### What I expected to happen
The Safari controller should dismiss and show the original parent controller (i.e. my app) as it was before presenting

### What actually happened
When the Safari controller dismissed, the original parent controller was just a black screen. This happened because the container view that is actually presented by Facebook did not have a modal presentation style set on it before presenting it.

Adding this line of code corrected this behavior.

<img width="1086" alt="screen shot 2017-03-16 at 10 43 53 am" src="https://cloud.githubusercontent.com/assets/317671/24010556/7caeee22-0a35-11e7-9f21-978cbc7a35f8.png">


