### PR TITLE
Use `FBSDKLogger` instead of NSLog in `FBSDKKeychainStore`

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
@@ -25,7 +25,9 @@
 #import "FBSDKKeychainStore.h"
 
 #import "FBSDKDynamicFrameworkLoader.h"
+#import "FBSDKLogger.h"
 #import "FBSDKMacros.h"
+#import "FBSDKSettings.h"
 
 @implementation FBSDKKeychainStore
 
@@ -90,7 +92,7 @@
     }
 
 #if TARGET_OS_SIMULATOR
-    NSLog(@"Falling back to storing access token in NSUserDefaults because of simulator bug");
+    [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorInformational formatString:@"Falling back to storing access token in NSUserDefaults because of simulator bug"];
     [[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
 
     return [[NSUserDefaults standardUserDefaults] synchronize];
@@ -131,7 +133,7 @@
     }
 
 #if TARGET_OS_SIMULATOR
-    NSLog(@"Falling back to loading access token from NSUserDefaults because of simulator bug");
+    [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorInformational formatString:@"Falling back to loading access token from NSUserDefaults because of simulator bug"];
     return [[NSUserDefaults standardUserDefaults] dataForKey:key];
 #else
     NSMutableDictionary *query = [self queryForKey:key];


### PR DESCRIPTION
**Motivation:** Don't spew information about FBSDKKeychainStore to the console when loading access token.

**Before the change:** Many instances of "Falling back to loading access token from NSUserDefaults because of simulator bug" reach the console in innocuous circumstances.

**After the change:** They do not.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)
