### PR TITLE
Correct an 'unrecognized selector' durring error handling.

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
@@ -824,7 +824,7 @@ NSURLSessionDataDelegate
   if ([result isKindOfClass:[NSDictionary class]]) {
     NSDictionary *errorDictionary = [FBSDKTypeUtility dictionaryValue:result[@"body"]][@"error"];
 
-    if (errorDictionary) {
+    if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
       NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
       [FBSDKInternalUtility dictionary:userInfo setObject:errorDictionary[@"code"] forKey:FBSDKGraphRequestErrorGraphErrorCode];
       [FBSDKInternalUtility dictionary:userInfo setObject:errorDictionary[@"error_subcode"] forKey:FBSDKGraphRequestErrorGraphErrorSubcode];

--- a/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKGraphRequestConnectionTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKGraphRequestConnectionTests.m
@@ -501,7 +501,6 @@ static id g_mockNSBundle;
   }];
   
   // adding fresh token to avoid piggybacking a token refresh
-  [FBSDKAccessToken setCurrentAccessToken:nil];
   FBSDKAccessToken *tokenNoRefresh = [[FBSDKAccessToken alloc]
                                       initWithTokenString:@"token"
                                       permissions:nil

--- a/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKGraphRequestConnectionTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKGraphRequestConnectionTests.m
@@ -483,6 +483,45 @@ static id g_mockNSBundle;
   }];
 }
 
+- (void)testNonDictionaryInError
+{
+  id mockPiggybackManager = [[self class] mockCachedServerConfiguration];
+  
+  XCTestExpectation *exp = [self expectationWithDescription:@"completed request"];
+  [FBSDKAccessToken setCurrentAccessToken:nil];
+  [FBSDKSettings setClientToken:@"clienttoken"];
+  [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
+    return YES;
+  } withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
+    NSData *data =  [@"{\"error\": \"a-non-dictionary\"}" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    return [OHHTTPStubsResponse responseWithData:data
+                                      statusCode:200
+                                         headers:nil];
+  }];
+  
+  // adding fresh token to avoid piggybacking a token refresh
+  [FBSDKAccessToken setCurrentAccessToken:nil];
+  FBSDKAccessToken *tokenNoRefresh = [[FBSDKAccessToken alloc]
+                                      initWithTokenString:@"token"
+                                      permissions:nil
+                                      declinedPermissions:nil
+                                      appID:@"appid"
+                                      userID:@"userid"
+                                      expirationDate:[NSDate distantPast]
+                                      refreshDate:[NSDate date]];
+  [FBSDKAccessToken setCurrentAccessToken:tokenNoRefresh];
+  
+  [[[FBSDKGraphRequest alloc] initWithGraphPath:@"me" parameters:@{@"fields":@""}] startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+    // should not crash when receiving something other than a dictionary within the response.
+    [exp fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
+    XCTAssertNil(error);
+  }];
+  [mockPiggybackManager stopMocking];
+}
+
 #pragma mark - Error recovery.
 
 // verify we do a single retry.


### PR DESCRIPTION
Correcting a crash on `FBSDKGraphRequestConnection` related to it assuming that errors are always dictionaries (i.e. `{ "error": { ... }}`.

I caught this while stubbing all requests to test an app with an API of ours that returns an "error" containing a string value (e.g. `{ "error": "Oops!" }`). Seems like the inner error handler checks the result itself is a dictionary, but fails to check whether the error contained within is a dictionary as well.

Testing the error is indeed an `NSDictionary` subtype fixes that.

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [√] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [√] submit against our `:dev` branch, not `master`.
- [√] describe the change (for example, what happens before the change, and after the change)
