### PR TITLE
Remove AccountKit compile-step from build-script, use GCD & loader in Places sample

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
@@ -110,7 +110,7 @@ typedef NS_ENUM(NSUInteger, FBSDKLoginButtonTooltipBehavior)
  - Parameter result: The results of the login
  - Parameter error: The error (if any) from the login
  */
-- (void)  loginButton:(FBSDKLoginButton *)loginButton
+- (void)loginButton:(FBSDKLoginButton *)loginButton
 didCompleteWithResult:(FBSDKLoginManagerLoginResult *)result
                 error:(NSError *)error;
 

--- a/samples/FBSDKPlacesSample/FBSDKPlacesSample.xcodeproj/project.pbxproj
+++ b/samples/FBSDKPlacesSample/FBSDKPlacesSample.xcodeproj/project.pbxproj
@@ -110,13 +110,11 @@
 		4117F43E1E492496005F8991 /* FBSDKPlacesSample */ = {
 			isa = PBXGroup;
 			children = (
-				4120F5F41E737535006D9380 /* LaunchScreen.storyboard */,
-				4120F5F11E73752F006D9380 /* Main.storyboard */,
 				41E4F27D1E7373410093F831 /* AppDelegate.h */,
 				41E4F27E1E7373410093F831 /* AppDelegate.m */,
 				41FA9A791E71FAF400C8EBB2 /* Models */,
 				41FA9A781E71FAE600C8EBB2 /* View Controllers */,
-				41E4F2801E73734B0093F831 /* Assets.xcassets */,
+				DB9228511EAD152A00DAFCE5 /* Resources */,
 				4117F43F1E492496005F8991 /* Supporting Files */,
 				41E4F2601E7373020093F831 /* main.m */,
 			);
@@ -168,6 +166,16 @@
 				4160884A1E831C0B00BF8B15 /* Hours.m */,
 			);
 			name = Models;
+			sourceTree = "<group>";
+		};
+		DB9228511EAD152A00DAFCE5 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				4120F5F41E737535006D9380 /* LaunchScreen.storyboard */,
+				4120F5F11E73752F006D9380 /* Main.storyboard */,
+				41E4F2801E73734B0093F831 /* Assets.xcassets */,
+			);
+			name = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/samples/FBSDKPlacesSample/FBSDKPlacesSample/PlaceDetailViewController.m
+++ b/samples/FBSDKPlacesSample/FBSDKPlacesSample/PlaceDetailViewController.m
@@ -43,7 +43,7 @@
 @implementation PlaceDetailViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
+  [super viewDidLoad];
 
   self.title = self.place.title;
 
@@ -61,9 +61,9 @@
   [request startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
     if (result) {
       self.place = [[Place alloc] initWithDictionary:result];
-      [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+      dispatch_async(dispatch_get_main_queue(), ^{
         [self refreshUI];
-      }];
+      });
     }
   }];
 }

--- a/samples/FBSDKPlacesSample/FBSDKPlacesSample/UIImageView+Web.m
+++ b/samples/FBSDKPlacesSample/FBSDKPlacesSample/UIImageView+Web.m
@@ -24,9 +24,9 @@
 {
   NSURLSessionDataTask *imageDataTask = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
     UIImage *image = [[UIImage alloc] initWithData:data];
-    [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+    dispatch_async(dispatch_get_main_queue(), ^{
       self.image = image;
-    }];
+    });
   }];
   [imageDataTask resume];
 }

--- a/scripts/build_distribution.sh
+++ b/scripts/build_distribution.sh
@@ -117,18 +117,6 @@ for fname in $(find "$FB_SDK_BUILD_PACKAGE_SAMPLES" -name "project.pbxproj" -pri
 done
 
 # -----------------------------------------------------------------------------
-# Build AKFAccountKit framework
-#
-if [ -z $SKIPBUILD ]; then
-  (xcodebuild -project "${FB_SDK_ROOT}"/AccountKit/AccountKit.xcodeproj -scheme "AccountKit-Universal" -configuration Release clean build) || die "Failed to build account kit"
-fi
-check_binary_has_architectures "$FB_SDK_BUILD"/AccountKit.framework/AccountKit "$COMMON_ARCHS";
-\cp -R "$FB_SDK_BUILD"/AccountKit.framework "$FB_SDK_BUILD_PACKAGE" \
-  || die "Could not copy AccountKit.framework"
-\cp -R "$FB_SDK_BUILD"/AccountKitStrings.bundle "$FB_SDK_BUILD_PACKAGE" \
-  || die "Could not copy AccountKitStrings.bundle"
-
-# -----------------------------------------------------------------------------
 # Build FBNotifications framework
 #
 


### PR DESCRIPTION
Hey @dzhuowen, I just saw your `FBSDKPlacesKit` changes for SDK 4.22.0. Pretty nice changes, so I'd love to adopt it asap, but noticed that when building the SDK, the build fails during the AccountKit compile-phase. I'm not sure when or why you removed it, but it's not on master or dev, so I assume it moved to an own repo and should not be built using the shell commands?