### PR TITLE
Fix loggingOverrideAppID for FBSDKAppEvents 'updateUserProperties' method

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.h
@@ -512,4 +512,14 @@ FBSDK_EXTERN NSString *const FBSDKAppEventParameterValueNo;
  */
 + (void)updateUserProperties:(NSDictionary *)properties handler:(FBSDKGraphRequestHandler)handler;
 
+/*
+ Sends a request to update the properties for the current user, set by `setUserID:`
+
+ You must call `FBSDKAppEvents setUserID:` before making this call.
+ - Parameter properties: the custom user properties
+ - Parameter handler: the optional completion handler
+ - Parameter accessToken:  The optional access token to log the event as.
+ */
++ (void)updateUserProperties:(NSDictionary *)properties accessToken:(FBSDKAccessToken *)accessToken handler:(FBSDKGraphRequestHandler)handler;
+
 @end

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.h
@@ -512,14 +512,4 @@ FBSDK_EXTERN NSString *const FBSDKAppEventParameterValueNo;
  */
 + (void)updateUserProperties:(NSDictionary *)properties handler:(FBSDKGraphRequestHandler)handler;
 
-/*
- Sends a request to update the properties for the current user, set by `setUserID:`
-
- You must call `FBSDKAppEvents setUserID:` before making this call.
- - Parameter properties: the custom user properties
- - Parameter handler: the optional completion handler
- - Parameter accessToken:  The optional access token to log the event as.
- */
-+ (void)updateUserProperties:(NSDictionary *)properties accessToken:(FBSDKAccessToken *)accessToken handler:(FBSDKGraphRequestHandler)handler;
-
 @end

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
@@ -489,17 +489,7 @@ static NSString *g_overrideAppID = nil;
   return [[self class] singleton]->_userID;
 }
 
-+ (void)updateUserProperties:(NSDictionary *)properties
-                     handler:(FBSDKGraphRequestHandler)handler
-{
-  [FBSDKAppEvents updateUserProperties:properties
-                           accessToken:nil
-                               handler:handler];
-}
-
-+ (void)updateUserProperties:(NSDictionary *)properties
-                 accessToken:(FBSDKAccessToken *)accessToken
-                     handler:(FBSDKGraphRequestHandler)handler
++ (void)updateUserProperties:(NSDictionary *)properties handler:(FBSDKGraphRequestHandler)handler
 {
   NSString *userID = [[self class] userID];
 
@@ -534,12 +524,11 @@ static NSString *g_overrideAppID = nil;
     return;
   }
 
-  NSString *tokenString = [FBSDKAppEventsUtility tokenStringToUseFor:accessToken];
   NSString *appID = [FBSDKAppEvents loggingOverrideAppID] ?: [FBSDKSettings appID];
   NSDictionary *params = @{ @"data" : dataJSONString };
   FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:@"%@/user_properties", appID]
                                                                  parameters:params
-                                                                tokenString:tokenString
+                                                                tokenString:[FBSDKAccessToken currentAccessToken].tokenString
                                                                  HTTPMethod:@"POST"
                                                                       flags:FBSDKGraphRequestFlagDisableErrorRecovery |
                                                                             FBSDKGraphRequestFlagDoNotInvalidateTokenOnError |

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
@@ -489,7 +489,17 @@ static NSString *g_overrideAppID = nil;
   return [[self class] singleton]->_userID;
 }
 
-+ (void)updateUserProperties:(NSDictionary *)properties handler:(FBSDKGraphRequestHandler)handler
++ (void)updateUserProperties:(NSDictionary *)properties
+                     handler:(FBSDKGraphRequestHandler)handler
+{
+  [FBSDKAppEvents updateUserProperties:properties
+                           accessToken:nil
+                               handler:handler];
+}
+
++ (void)updateUserProperties:(NSDictionary *)properties
+                 accessToken:(FBSDKAccessToken *)accessToken
+                     handler:(FBSDKGraphRequestHandler)handler
 {
   NSString *userID = [[self class] userID];
 
@@ -523,10 +533,13 @@ static NSString *g_overrideAppID = nil;
     }
     return;
   }
+
+  NSString *tokenString = [FBSDKAppEventsUtility tokenStringToUseFor:accessToken];
+  NSString *appID = [FBSDKAppEvents loggingOverrideAppID] ?: [FBSDKSettings appID];
   NSDictionary *params = @{ @"data" : dataJSONString };
-  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:@"%@/user_properties", [FBSDKSettings appID]]
+  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:@"%@/user_properties", appID]
                                                                  parameters:params
-                                                                tokenString:[FBSDKAccessToken currentAccessToken].tokenString
+                                                                tokenString:tokenString
                                                                  HTTPMethod:@"POST"
                                                                       flags:FBSDKGraphRequestFlagDisableErrorRecovery |
                                                                             FBSDKGraphRequestFlagDoNotInvalidateTokenOnError |

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
@@ -524,9 +524,8 @@ static NSString *g_overrideAppID = nil;
     return;
   }
 
-  NSString *appID = [FBSDKAppEvents loggingOverrideAppID] ?: [FBSDKSettings appID];
   NSDictionary *params = @{ @"data" : dataJSONString };
-  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:@"%@/user_properties", appID]
+  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:@"%@/user_properties", [[self singleton] appID]]
                                                                  parameters:params
                                                                 tokenString:[FBSDKAccessToken currentAccessToken].tokenString
                                                                  HTTPMethod:@"POST"


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

**OS / FB Version**

iOS 10.x, FB SDK 4.22.0

**What I did**

I was looking to set custom user properties on Facebook Analytics (Using a separate app to gather the data, thanks to the `loggingOverrideAppID` property of FBSDKAppEvents), after looking to the relative code in the SDK, I saw that the method `updateUserProperties` did not use `loggingOverrideAppID` or could not take a custom app token like the other ones, I made the changes to get the expected behavior

**Before the change**

- `updateUserProperties` uses the main Facebook token and the main appID of the Facebook SDK

**After the change**

- `updateUserProperties` behaves like the similar analytics methods, taking into account `loggingOverrideAppID` or accepting a custom Facebook token
