### PR TITLE
Remove NSLog statements when keychain store uses user defaults on sim

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/TokenCaching/FBSDKKeychainStore.m
@@ -90,7 +90,6 @@
     }
 
 #if TARGET_OS_SIMULATOR
-    NSLog(@"Falling back to storing access token in NSUserDefaults because of simulator bug");
     [[NSUserDefaults standardUserDefaults] setObject:value forKey:key];
 
     return [[NSUserDefaults standardUserDefaults] synchronize];
@@ -131,7 +130,6 @@
     }
 
 #if TARGET_OS_SIMULATOR
-    NSLog(@"Falling back to loading access token from NSUserDefaults because of simulator bug");
     return [[NSUserDefaults standardUserDefaults] dataForKey:key];
 #else
     NSMutableDictionary *query = [self queryForKey:key];


### PR DESCRIPTION
Wondering if these NSLog statements are still useful to SDK developers. Open to other potential solutions. Happy to wrap the log statements inside a configuration macro. 