### PR TITLE
When I shared image without networ…

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m
@@ -447,6 +447,8 @@ FBSDK_STATIC_INLINE void FBSDKShareDialogValidateShareExtensionSchemeRegisteredF
     NSString *completionGesture = webResponseParameters[FBSDK_SHARE_RESULT_COMPLETION_GESTURE_KEY];
     if ([completionGesture isEqualToString:FBSDK_SHARE_RESULT_COMPLETION_GESTURE_VALUE_CANCEL]) {
       [self _invokeDelegateDidCancel];
+    } else if (completionGesture == nil){
+      [self _invokeDelegateDidCancel];
     } else {
       // not all web dialogs report cancellation, so assume that the share has completed with no additional information
       NSMutableDictionary *results = [[NSMutableDictionary alloc] init];
@@ -605,7 +607,9 @@ FBSDK_STATIC_INLINE void FBSDKShareDialogValidateShareExtensionSchemeRegisteredF
       [self _invokeDelegateDidCancel];
     } else if (response.error) {
       [self _invokeDelegateDidFailWithError:response.error];
-    } else {
+    } else if (completionGesture == nil){
+      [self _invokeDelegateDidCancel];
+    }else{
       NSMutableDictionary *results = [[NSMutableDictionary alloc] init];
       [FBSDKInternalUtility dictionary:results
                              setObject:responseParameters[FBSDK_SHARE_RESULT_POST_ID_KEY]


### PR DESCRIPTION
…k, it was always return completion delegate.It was also happended when I canceled share ，but it was also return completion delegate sometimes. I read the codes,I think "FBSDKShareDialog.m" string "completionGesture" should judge if(completionGesture == nil). it's just my personal suggestion.

Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)
