### PR TITLE
Fix documentation spacing

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.h
@@ -50,7 +50,7 @@
  - Parameter annotation: The annotation as passed to [UIApplicationDelegate application:openURL:sourceApplication:annotation:].
 
  - Returns: YES if the url was intended for the Facebook SDK, NO if not.
-  */
+ */
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
   sourceApplication:(NSString *)sourceApplication


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

This removes the superfluous space before the end tag of the `application:openURL:sourceApplication`'s documentation.

It ensures that the same number of spaces is used for all the documentation end tags in this file.