### PR TITLE
Fix SFAuthenticationSession background behaviour for iOS 11

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -338,6 +338,7 @@ static NSString *const FBSDKAppLinkInboundEvent = @"fb_al_inbound";
   if ([sender isAuthenticationURL:url]) {
     Class SFAuthenticationSessionClass = fbsdkdfl_SFAuthenticationSessionClass();
     if (SFAuthenticationSessionClass != nil) {
+      _expectingBackground = YES;
       _authenticationSession = [[SFAuthenticationSessionClass alloc] initWithURL:url callbackURLScheme:[FBSDKInternalUtility appURLScheme] completionHandler:^ (NSURL *aURL, NSError *error) {
         handler(error == nil, error);
         if (error == nil) {


### PR DESCRIPTION
This fix an unexpected call to FBSDKLoginManager applicationDidBecomeActive, which cancel the request and therefor call, wrongly, the FBSDKLoginManagerRequestTokenHandler that the user previously set.
SFAuthenticationSession bring momentary the app to background, so this should be treated as when leaving the app to do the login using Facebook.app

The problem appears when using FBSDKLoginBehaviorSystemAccount and fallback to FBSDKLoginBehaviorNative