### PR TITLE
iOS FBSDK error during app start-up affecting all React Native projects

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.m
@@ -83,6 +83,7 @@
 {
   if (![FBSDKAccessToken currentAccessToken]) {
     _recipientIDs = nil;
+    return; // Don't attempt to retrieve the recipients without an access token
   }
   FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:@"me/apprequestformerrecipients"
                                                                  parameters:@{@"fields":@""}


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:
- [X] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [X] submit against our `:dev` branch, not `master`.
- [X] describe the change (for example, what happens before the change, and after the change)

# Before this change

I've described the behavior in greater detail in the bug tracker: https://developers.facebook.com/bugs/2026039627626444

Before the change, any react-native project with the latest [react-native-fbsdk](https://github.com/facebook/react-native-fbsdk) version and the latest iOS FBSDK integrated will result in the following 400 error for users who have not yet authenticated:
> {
>         error =         {
>             code = 2500;
>             "fbtrace_id" = HjJqFdOvWB0;
>             message = "An active access token must be used to query information about the current user.";
>             type = OAuthException;
>         };
>     };
>     code = 400;
> }

# After this change

React Native projects will not generate an error for every time their iOS app starts up.

# Commits
- Prevent React Native FBSDK unhelpful error report

    Further details iterated here:
    https://developers.facebook.com/bugs/2026039627626444