### PR TITLE
Resolve static-analyser warnings

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAppEvents.m
@@ -657,6 +657,10 @@ static NSString *g_overrideAppID = nil;
   if (![FBSDKAppEventsUtility validateIdentifier:eventName]) {
     failed = YES;
   }
+  
+  if (parameters == nil) {
+    failed = YES;
+  }
 
   // Make sure parameter dictionary is well formed.  Log and exit if not.
   [parameters enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.h
@@ -20,7 +20,7 @@
 
 @interface FBSDKGameRequestFrictionlessRecipientCache : NSObject
 
-- (BOOL)recipientsAreFrictionless:(id)recipients;
+- (BOOL)recipientsAreFrictionless:(id _Nullable)recipients;
 - (void)updateWithResults:(NSDictionary *)results;
 
 @end

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.m
@@ -56,7 +56,10 @@
   NSArray *recipientIDArray = [FBSDKTypeUtility arrayValue:recipients];
   if (!recipientIDArray && [recipients isKindOfClass:[NSString class]]) {
     recipientIDArray = [recipients componentsSeparatedByString:@","];
+  } else {
+    recipientIDArray = @[];
   }
+
   NSSet *recipientIDs = [[NSSet alloc] initWithArray:recipientIDArray];
   return [recipientIDs isSubsetOfSet:_recipientIDs];
 }


### PR DESCRIPTION
This PR attempts to fix all static-analyser warnings across the Facebook iOS-SDK project. I noticed it during my dependency-monitoring and decided to fix it here as well. Step by step:

- `FBSDKAppEvents`: The `parameters` parameter can be nil, causing the dictionary-assignment to become `nil` as well.
- `FBSDKGameRequestFrictionlessRecipientCache`: The `recipients` requires to be non-null, otherwise the `recipientIDs` set will get initialized by nil.