### PR TITLE
FIX duplicate ShareKit tvOS podspec source include

### DIFF
--- a/FBSDKShareKit.podspec
+++ b/FBSDKShareKit.podspec
@@ -40,7 +40,6 @@ Pod::Spec.new do |s|
                         'FBSDKShareKit/FBSDKShareKit/FBSDKShareKit.h',
                         'FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.{h,m}',
                         'FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.{h,m}',
-                        'FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.{h,m}',
                         'FBSDKShareKit/FBSDKShareKit/FBSDKShareLinkContent.{h,m}',
                         'FBSDKShareKit/FBSDKShareKit/FBSDKShareMediaContent.{h,m}',
                         'FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.{h,m}',


### PR DESCRIPTION
FBSDKShareKit podspec included duplicated sources for tvOS (which also requires the request #890 to compile) 

To help us review the request, please complete the following:
- [x] sign contributor license agreement: https://developers.facebook.com/opensource/cla
- [x] submit against our `:dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)