### PR TITLE
Fix unused _printedUpdateMessage warning

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKServerConfigurationManager.m
@@ -60,7 +60,10 @@ static FBSDKServerConfiguration *_serverConfiguration;
 static NSError *_serverConfigurationError;
 static NSDate *_serverConfigurationErrorTimestamp;
 static const NSTimeInterval kTimeout = 4.0;
+
+#ifdef DEBUG
 static BOOL _printedUpdateMessage;
+#endif
 
 typedef NS_OPTIONS(NSUInteger, FBSDKServerConfigurationManagerAppEventsFeatures)
 {


### PR DESCRIPTION
If you compile without DEBUG this appeared unused
