### PR TITLE
Fix mistaken sharerDidCancel: message after Share Dialog completion

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/ProtocolVersions/FBSDKBridgeAPIProtocolWebV1.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/ProtocolVersions/FBSDKBridgeAPIProtocolWebV1.m
@@ -65,6 +65,9 @@
                                       cancelled:(BOOL *)cancelledRef
                                           error:(NSError *__autoreleasing *)errorRef
 {
+  if (cancelledRef != NULL) {
+    *cancelledRef = NO;
+  }
   if (errorRef != NULL) {
     *errorRef = nil;
   }


### PR DESCRIPTION
Bug: Share Dialog performs the sharing successfully, but `FBSDKSharingDelegate` receives `sharerDidCancel:` message instead of `sharer:didCompleteWithResults:`.

Conditions: iPhone 6, iOS 10.3.1, FB app not installed, FB authenticated in Safari.

Stack trace for receiving `sharerDidCancel:`:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 4.1
  * frame #0: 0x001832e6 ProjectName`-[SCRFacebook sharer:didCompleteWithResults:](self=0x7bfc2d60, _cmd="sharer:didCompleteWithResults:", sharer=0x7d60aec0, results=0x7be0e340) at SCRFacebook.m:574
    frame #1: 0x00321c76 ProjectName`-[FBSDKShareDialog _invokeDelegateDidCompleteWithResults:](self=0x7d60aec0, _cmd="_invokeDelegateDidCompleteWithResults:", results=0 key/value pairs) at FBSDKShareDialog.m:1026
    frame #2: 0x0031d1b0 ProjectName`-[FBSDKShareDialog _handleWebResponseParameters:error:cancelled:](self=0x7d60aec0, _cmd="_handleWebResponseParameters:error:cancelled:", webResponseParameters=1 key/value pair, error=0x00000000, isCancelled=NO) at FBSDKShareDialog.m:482
    frame #3: 0x0031e3b4 ProjectName`__37-[FBSDKShareDialog _showFeedBrowser:]_block_invoke(.block_descriptor=0x7d70a2f0, response=0x7e826400) at FBSDKShareDialog.m:563
    frame #4: 0x0025b75e ProjectName`-[FBSDKApplicationDelegate _handleBridgeAPIResponseURL:sourceApplication:](self=0x7d253790, _cmd="_handleBridgeAPIResponseURL:sourceApplication:", responseURL=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", sourceApplication=@"com.apple.SafariViewService") at FBSDKApplicationDelegate.m:541
    frame #5: 0x00257f34 ProjectName`-[FBSDKApplicationDelegate application:openURL:sourceApplication:annotation:](self=0x7d253790, _cmd="application:openURL:sourceApplication:annotation:", application=0x7d2169f0, url=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", sourceApplication=@"com.apple.SafariViewService", annotation=0x00000000) at FBSDKApplicationDelegate.m:187
    frame #6: 0x000705f1 ProjectName`-[AppDelegate application:openURL:options:](self=0x7d11cf90, _cmd="application:openURL:options:", app=0x7d2169f0, url=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", options=2 key/value pairs) at AppDelegate.m:94
    frame #7: 0x042e2ae5 UIKit`__45-[UIApplication _applicationOpenURL:payload:]_block_invoke + 863
    frame #8: 0x042e24b2 UIKit`-[UIApplication _applicationOpenURL:payload:] + 770
    frame #9: 0x06547eb7 SafariServices`-[SFSafariViewController remoteViewController:hostApplicationOpenURL:] + 141
    frame #10: 0x0653e9c9 SafariServices`-[SFBrowserRemoteViewController willOpenURLInHostApplication:] + 76
    frame #11: 0x07280f4d CoreFoundation`__invoking___ + 29
    frame #12: 0x07280e81 CoreFoundation`-[NSInvocation invoke] + 321
    frame #13: 0x04c6cc9a UIKit`__63-[_UIViewServiceInterface connection:handleInvocation:isReply:]_block_invoke + 32
    frame #14: 0x0911d635 FrontBoardServices`__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 23
    frame #15: 0x0911d499 FrontBoardServices`-[FBSSerialQueue _performNext] + 168
    frame #16: 0x0911d86e FrontBoardServices`-[FBSSerialQueue _performNextFromRunLoopSource] + 52
    frame #17: 0x0911ccb5 FrontBoardServices`FBSSerialQueueRunLoopSourceHandler + 29
    frame #18: 0x0729ea5f CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 15
    frame #19: 0x072841c4 CoreFoundation`__CFRunLoopDoSources0 + 500
    frame #20: 0x0728369c CoreFoundation`__CFRunLoopRun + 1084
    frame #21: 0x07282fd4 CoreFoundation`CFRunLoopRunSpecific + 372
    frame #22: 0x07282e4b CoreFoundation`CFRunLoopRunInMode + 123
    frame #23: 0x08a3ca7a GraphicsServices`GSEventRunModal + 71
    frame #24: 0x08a3c95f GraphicsServices`GSEventRun + 80
    frame #25: 0x042d6bc9 UIKit`UIApplicationMain + 148
    frame #26: 0x00100edc ProjectName`main(argc=1, argv=0xbfff95ec) at main.m:14
    frame #27: 0x07a25779 libdyld.dylib`start + 1
```

Stack trace for the actual error origin:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = step over
  * frame #0: 0x002647be ProjectName`-[FBSDKBridgeAPIProtocolWebV1 responseParametersForActionID:queryParameters:cancelled:error:](self=0x7ea15da0, _cmd="responseParametersForActionID:queryParameters:cancelled:error:", actionID=@"881CB085-0745-4CA0-9E70-7D36D7413308", queryParameters=1 key/value pair, cancelledRef=NO, errorRef=0xbfff81fc) at FBSDKBridgeAPIProtocolWebV1.m:112
    frame #1: 0x00266f5f ProjectName`+[FBSDKBridgeAPIResponse bridgeAPIResponseWithRequest:responseURL:sourceApplication:error:](self=FBSDKBridgeAPIResponse, _cmd="bridgeAPIResponseWithRequest:responseURL:sourceApplication:error:", request=0x7d6c4a80, responseURL=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", sourceApplication=@"com.apple.SafariViewService", errorRef=0xbfff82a8) at FBSDKBridgeAPIResponse.m:82
    frame #2: 0x0025b71d ProjectName`-[FBSDKApplicationDelegate _handleBridgeAPIResponseURL:sourceApplication:](self=0x7d253790, _cmd="_handleBridgeAPIResponseURL:sourceApplication:", responseURL=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", sourceApplication=@"com.apple.SafariViewService") at FBSDKApplicationDelegate.m:536
    frame #3: 0x00257f34 ProjectName`-[FBSDKApplicationDelegate application:openURL:sourceApplication:annotation:](self=0x7d253790, _cmd="application:openURL:sourceApplication:annotation:", application=0x7d2169f0, url=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", sourceApplication=@"com.apple.SafariViewService", annotation=0x00000000) at FBSDKApplicationDelegate.m:187
    frame #4: 0x000705f1 ProjectName`-[AppDelegate application:openURL:options:](self=0x7d11cf90, _cmd="application:openURL:options:", app=0x7d2169f0, url=@"fb587290567967248://bridge/feed?bridge_args=%7B%22action_id%22%3A%22881CB085-0745-4CA0-9E70-7D36D7413308%22%7D#_=_", options=2 key/value pairs) at AppDelegate.m:94
    frame #5: 0x042e2ae5 UIKit`__45-[UIApplication _applicationOpenURL:payload:]_block_invoke + 863
    frame #6: 0x042e24b2 UIKit`-[UIApplication _applicationOpenURL:payload:] + 770
    frame #7: 0x06547eb7 SafariServices`-[SFSafariViewController remoteViewController:hostApplicationOpenURL:] + 141
    frame #8: 0x0653e9c9 SafariServices`-[SFBrowserRemoteViewController willOpenURLInHostApplication:] + 76
    frame #9: 0x07280f4d CoreFoundation`__invoking___ + 29
    frame #10: 0x07280e81 CoreFoundation`-[NSInvocation invoke] + 321
    frame #11: 0x04c6cc9a UIKit`__63-[_UIViewServiceInterface connection:handleInvocation:isReply:]_block_invoke + 32
    frame #12: 0x0911d635 FrontBoardServices`__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__ + 23
    frame #13: 0x0911d499 FrontBoardServices`-[FBSSerialQueue _performNext] + 168
    frame #14: 0x0911d86e FrontBoardServices`-[FBSSerialQueue _performNextFromRunLoopSource] + 52
    frame #15: 0x0911ccb5 FrontBoardServices`FBSSerialQueueRunLoopSourceHandler + 29
    frame #16: 0x0729ea5f CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 15
    frame #17: 0x072841c4 CoreFoundation`__CFRunLoopDoSources0 + 500
    frame #18: 0x0728369c CoreFoundation`__CFRunLoopRun + 1084
    frame #19: 0x07282fd4 CoreFoundation`CFRunLoopRunSpecific + 372
    frame #20: 0x07282e4b CoreFoundation`CFRunLoopRunInMode + 123
    frame #21: 0x08a3ca7a GraphicsServices`GSEventRunModal + 71
    frame #22: 0x08a3c95f GraphicsServices`GSEventRun + 80
    frame #23: 0x042d6bc9 UIKit`UIApplicationMain + 148
    frame #24: 0x00100edc ProjectName`main(argc=1, argv=0xbfff95ec) at main.m:14
    frame #25: 0x07a25779 libdyld.dylib`start + 1
```

Bug reason: `[FBSDKBridgeAPIProtocolWebV1 responseParametersForActionID:queryParameters:cancelled:error:]` doesn't actuallly provide `cancelled` flag, leaving it in uninitialized and undefined state (usually not 0 which means `YES`).