### PR TITLE
setCurrentAccessToken changed.

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
@@ -83,12 +83,15 @@ static FBSDKAccessToken *g_currentAccessToken;
 
 + (void)setCurrentAccessToken:(FBSDKAccessToken *)token
 {
+  if(token != nil && token.isExpired)
+    token = nil;
+  
   if (token != g_currentAccessToken) {
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
     [FBSDKInternalUtility dictionary:userInfo setObject:token forKey:FBSDKAccessTokenChangeNewKey];
     [FBSDKInternalUtility dictionary:userInfo setObject:g_currentAccessToken forKey:FBSDKAccessTokenChangeOldKey];
     // We set this flag also when the current Access Token was not valid, since there might be legacy code relying on it
-    if (![g_currentAccessToken.userID isEqualToString:token.userID] || ![self currentAccessTokenIsActive]) {
+    if (![g_currentAccessToken.userID isEqualToString:token.userID]) {
       userInfo[FBSDKAccessTokenDidChangeUserID] = @YES;
     }
 

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
@@ -83,7 +83,7 @@ static FBSDKAccessToken *g_currentAccessToken;
 
 + (void)setCurrentAccessToken:(FBSDKAccessToken *)token
 {
-  if(token != nil && token.isExpired) {
+  if (token != nil && token.isExpired) {
     token = nil;
   }
   

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
@@ -83,8 +83,9 @@ static FBSDKAccessToken *g_currentAccessToken;
 
 + (void)setCurrentAccessToken:(FBSDKAccessToken *)token
 {
-  if(token != nil && token.isExpired)
+  if(token != nil && token.isExpired) {
     token = nil;
+  }
   
   if (token != g_currentAccessToken) {
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];


### PR DESCRIPTION
changed to checking argument token from checking global variable token 'g_currentAccessToken' .

![self currentAccessTokenIsActive]
is checking g_currentAccessToken's exist and expired.

I think checking argument token(new token) is more make sense then checking old saved token.



Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] submit against our `dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)
