### PR TITLE
Ensure event dictionaries are stored as mutable

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsState.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/AppEvents/FBSDKAppEventsState.m
@@ -118,7 +118,7 @@
     _numSkipped++;
   } else {
     [_mutableEvents addObject:@{
-                                @"event" : eventDictionary,
+                                @"event" : [eventDictionary mutableCopy],
                                 FBSDK_APPEVENTSTATE_ISIMPLICIT_KEY : @(isImplicit)
                                 }];
   }


### PR DESCRIPTION
Thanks for proposing a pull request.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] submit against our `dev` branch, not `master`.
- [x] describe the change (for example, what happens before the change, and after the change)

This change fixes the currently-broken `FBSDKAppEventsStateTests.testAppEventsStateAddSimple` test

AppEventsState assumes the event dictionaries are mutable in ExtractReceiptData and JSONStringForEvents. It looks like everything currently passes in a mutable dictionary, except for the 
`FBSDKAppEventsStateTests.testAppEventsStateAddSimple` test.


