### PR TITLE
Must exclude include directories

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -52,7 +52,8 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |ss|
     ss.dependency 'FBSDKCoreKit/Basics'
     ss.exclude_files = 'FBSDKCoreKit/FBSDKCoreKit/Basics/*',
-                       'FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}'
+                       'FBSDKCoreKit/FBSDKCoreKit/Basics/**/*.{h,m}',
+                       'FBSDKCoreKit/FBSDKCoreKit/include/**/*'
     ss.source_files = 'FBSDKCoreKit/FBSDKCoreKit/**/*.{h,m}'
     ss.public_header_files = 'FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h',
                              'FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h',

--- a/FBSDKLoginKit.podspec
+++ b/FBSDKLoginKit.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'Login' do |ss|
     ss.dependency 'FBSDKCoreKit', "~> 5.0"
+    ss.exclude_files = 'FBSDKLoginKit/FBSDKLoginKit/include/**/*'
     ss.ios.source_files   = 'FBSDKLoginKit/FBSDKLoginKit/**/*.{h,m}'
     ss.ios.public_header_files = 'FBSDKLoginKit/FBSDKLoginKit/*.{h}'
     ss.tvos.source_files = 'FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginConstants.{h,m}',

--- a/FBSDKShareKit.podspec
+++ b/FBSDKShareKit.podspec
@@ -38,6 +38,7 @@ Pod::Spec.new do |s|
   s.subspec 'Share' do |ss|
     ss.dependency 'FBSDKCoreKit', "~> 5.0"
 
+    ss.exclude_files = 'FBSDKShareKit/FBSDKShareKit/include/**/*'
     ss.public_header_files = 'FBSDKShareKit/FBSDKShareKit/*.{h}'
     ss.ios.source_files = 'FBSDKShareKit/FBSDKShareKit/**/*.{h,m}'
     ss.ios.exclude_files = 'FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.{h,m}',


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Cocoapods will pass allow directories full of symlinks during linting but not while pushing to trunk.

This is very strange. Cocoapods was able to lint these podspecs successfully but pushing them to trunk resulted in an error.

## Test Plan

Test Plan: 
Ran manually and pods are now available in trunk.
