### PR TITLE
Updating FBSDKAutoAppLinkPresentationStyle's Swift name

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKAppLink.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKAppLink.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSUInteger, FBSDKAutoAppLinkPresentationStyle)
    * Push to current navigation controller or a new navigation controller
    */
   FBSDKAutoAppLinkPresentationStylePush,
-} NS_SWIFT_NAME(AutoAppLink.PresentationStyle);
+} NS_SWIFT_NAME(AutoAppLinkPresentationStyle);
 
 /**
  A Protocol that Auto App Link content view controller should implement


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

It is not possible to Swift-namespace an ObjC enum into an ObjC protocol. This renames so that the symbol can be made available to Swift.

## Test Plan

Test Plan:
Add a Swift package to a sample project and point to this branch `spm-patch-1`
In code, reference `AutoAppLinkPresentationStyle.auto`. 
Should not throw an error.
