### PR TITLE
Symlink verification for public headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,9 @@ jobs:
     #   osx_image: xcode10.2
     #   script: sh scripts/run.sh tag-current-version --push
     - stage: test
+      name: Verify Swift Package Headers
+      script: sh scripts/run.sh verify-spm-headers
+    - stage: test
       name: Build Swift Packages
       osx_image: xcode11.2
       script: sh scripts/run.sh build spm

--- a/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKLoginKit.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKLoginKit.h
@@ -1,0 +1,1 @@
+FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit.h

--- a/FBSDKShareKit/FBSDKShareKit/include/FBSDKDeviceShareButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/include/FBSDKDeviceShareButton.h
@@ -1,0 +1,1 @@
+FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h


### PR DESCRIPTION
Summary:
SPM requires that C headers exist in an 'include' directory in order to be visible to consuming libraries.

This is similar to how CocoaPods' podspecs use the "public_header_files" argument.

In CocoaPods we can use a list of directories that have public headers. SPM is much more prescriptive in that it wants all of the public headers in one directory. We are using directory of symlinks to meet this requirement.

This Travis job should prevent us from mistakenly shipping new features that have not been exposed through this symlinking mechanism.

Differential Revision: D18513231

