### PR TITLE
Fixing issue with Cocoapods used in Unity

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Core', 'Basics'
   s.swift_version = '5.0'
+  s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
 
   s.subspec 'Basics' do |ss|
     ss.source_files = 'FBSDKCoreKit/FBSDKCoreKit/Basics/*.{h,m}',

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
@@ -18,7 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKDeviceLoginManagerResult+Internal.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKDeviceLoginManagerResult+Internal.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppGroupContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppGroupContent.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectArguments.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectArguments.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectTextures.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectTextures.h
@@ -18,7 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestContent.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
@@ -18,7 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
@@ -22,7 +22,7 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 #endif
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareButton.h
@@ -18,7 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerActionButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerActionButton.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareMessengerGenericTemplateElement.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphAction.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareOpenGraphObject.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h
@@ -18,7 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h
@@ -19,7 +19,7 @@
 #import <Photos/Photos.h>
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined __cplusplus
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKGameRequestFrictionlessRecipientCache.m
@@ -18,7 +18,7 @@
 
 #import "FBSDKGameRequestFrictionlessRecipientCache.h"
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKLikeActionController.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKLikeActionController.m
@@ -20,7 +20,7 @@
 
 #import <QuartzCore/QuartzCore.h>
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m
@@ -20,7 +20,7 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Fixing import errors when using Unity.

## Test Plan

Test Plan: 
Open a new unity project that includes the SDK. Open the generated Xcode workspace. It should compile without error about improper header import syntax.
