### PR TITLE
Fix imports for CocoaPods' "generate_multiple_pod_projects" option

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKDeviceLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKDeviceLoginManager.m
@@ -19,13 +19,13 @@
 #import "FBSDKDeviceLoginManager.h"
 #import "FBSDKDeviceLoginManagerResult+Internal.h"
 
-#ifdef SWIFT_PACKAGE
-#import "FBSDKConstants.h"
-#else
+#ifdef FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <FBSDKCoreKit/FBSDKCoreKit+Internal.h>
+#else
+#import "FBSDKCoreKit+Internal.h"
 #endif
 
-#import "FBSDKCoreKit+Internal.h"
 #import "FBSDKDeviceLoginCodeInfo+Internal.h"
 #import "FBSDKLoginConstants.h"
 

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -26,7 +26,11 @@
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #endif
 
+#ifdef FBSDKCOCOAPODS
+#import <FBSDKCoreKit/FBSDKCoreKit+Internal.h>
+#else
 #import "FBSDKCoreKit+Internal.h"
+#endif
 
 #import "_FBSDKLoginRecoveryAttempter.h"
 #import "FBSDKLoginCompletion.h"

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManager+Internal.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginManager+Internal.h
@@ -18,7 +18,12 @@
 
 #import <UIKit/UIKit.h>
 
+#ifdef FBSDKCOCOAPODS
+#import <FBSDKCoreKit/FBSDKCoreKit+Internal.h>
+#else
 #import "FBSDKCoreKit+Internal.h"
+#endif
+
 #import "FBSDKLoginManager.h"
 
 @class FBSDKAccessToken;


### PR DESCRIPTION
Summary: There is a flag you can pass to a Podfile - generate_multiple_pod_projects - that requires headers to be fully qualified so they can be discovered across the multiple projects. This fixes errors in using that flag.

Differential Revision: D18616004

