### PR TITLE
update .gitattributes to better solve merge conflicts of project.pbxproj

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.strings diff=localizablestrings
+*.pbxproj binary merge=union


### PR DESCRIPTION
Summary: Since we don't rely on buck to build project so project.pbxproj can be easily to have merge conflicts for distributed development, update .gitattributes to avoid merge conflicts of project.pbxproj so git/Mercurial can handle it for us.

Differential Revision: D18655686

