### PR TITLE
suppress unused function warnings in FBSDKCoreKitTests using xcode setting

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -4929,6 +4929,7 @@
 			baseConfigurationReference = 814AC8CB1D1B5CAC00D61E6C /* FBSDKCoreKitTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				GCC_WARN_UNUSED_FUNCTION = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -4940,6 +4941,7 @@
 			baseConfigurationReference = 814AC8CB1D1B5CAC00D61E6C /* FBSDKCoreKitTests.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				GCC_WARN_UNUSED_FUNCTION = NO;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SWIFT_VERSION = 5.0;
 			};

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKModelRuntime.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKModelRuntime.hpp
@@ -209,7 +209,7 @@ namespace mat1 {
         return a;
     }
 
-    static inline float* predictOnText(const char *texts, std::unordered_map<std::string, mat::MTensor>& weights, float *df) {
+    static float* predictOnText(const char *texts, std::unordered_map<std::string, mat::MTensor>& weights, float *df) {
         int *x;
         float *embed_x;
         float *dense1_x;

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKStandaloneModel.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKStandaloneModel.hpp
@@ -140,7 +140,7 @@ namespace mat {
         std::shared_ptr<void> storage_;
     };
 
-    static inline MTensor mempty(const std::vector<int64_t>& sizes) {
+    static MTensor mempty(const std::vector<int64_t>& sizes) {
         return MTensor(sizes);
     }
 } // namespace mat


### PR DESCRIPTION
Summary: suppress unused function warnings in FBSDKCoreKitTests using xcode setting and get rid ofinline to avoid confusion

Differential Revision: D18947289

