### PR TITLE
Updating script to check for bad symlinks

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKLoginKit.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKLoginKit.h
@@ -1,1 +1,1 @@
-FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit.h
+../FBSDKLoginKit.h

--- a/FBSDKShareKit/FBSDKShareKit/include/FBSDKDeviceShareButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/include/FBSDKDeviceShareButton.h
@@ -1,1 +1,1 @@
-FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h
+../FBSDKDeviceShareButton.h

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -705,39 +705,38 @@ verify_spm_headers() {
       cd .. || exit
     done
 
-    echo ""
     echo "Success! All of your public headers are visible to users of SPM!"
   }
 
   # Verifies that existing symlinks are valid since it is easy to break them by moving the
   # original file
   verify_validity() {
-      for kit in "${SDK_BASE_KITS[@]}"; do
-        cd "$kit"
+    echo ""
+    echo "Verifying that the symlinks used for exposing public headers to SPM are pointing to valid source files."
 
-        echo ""
-        echo "Verifying that the symlinks used for exposing public headers to SPM for $kit"
-        echo "are pointing to valid source files."
+    for kit in "${SDK_BASE_KITS[@]}"; do
+      cd "$kit"
 
-        find . -type l ! -exec test -e {} \; -print >| BadSymlinks.txt
-
-        if [ -s BadSymlinks.txt ] ; then
-          echo ""
-          echo "Bad symlinks found: "
-          cat BadSymlinks.txt
-          echo "Please fix these by recreating the symlink(s) from the include directory with: "
-          echo "ln -s <path_to_source_file(s)> ."
-
-         rm BadSymlinks.txt
-
-          exit 1;
-        fi
-
-        rm BadSymlinks.txt
-
-      echo ""
+      find . -type l ! -exec test -e {} \; -print >| ../BadSymlinks.txt
       cd .. || exit
-      done
+    done
+
+    if [ -s BadSymlinks.txt ] ; then
+      echo ""
+      echo "Bad symlinks found: "
+      cat BadSymlinks.txt
+      echo "Please fix these by recreating the symlink(s) from the include directory with: "
+      echo "ln -s <path_to_source_file(s)> ."
+      echo "run ./scripts/run.sh verify-spm-headers to verify that these are fixed."
+
+      rm BadSymlinks.txt
+
+      exit 1;
+    fi
+
+    rm BadSymlinks.txt
+
+    echo "Success! All of the public header symlinks are valid!"
   }
 
   verify_inclusion


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This fixes the an issue I saw earlier where a bad symlink resulted in a header not being exposed to projects that consume the SDK using Swift Package Manager

## Test Plan

Test Plan: 
Break one of the symlinks in the include directory by having it point to a missing file. You can do this by running 
`cd FBSDKCoreKit/FBSDKCoreKit`
`ln -s FBSDKAccessToken.h include`

This will create a symlink in the include directory that points to itself.

from the project root run
`./scripts/run.sh verify-spm-headers`

It will log an error message and fail.