### PR TITLE
add back #import "FBSDKCoreKit+Internal.h" to solve swift package build error

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKGraphRequestConnection.m
@@ -20,6 +20,7 @@
 
 #import "FBSDKAppEvents+Internal.h"
 #import "FBSDKConstants.h"
+#import "FBSDKCoreKit+Internal.h"
 #import "FBSDKError.h"
 #import "FBSDKErrorConfiguration.h"
 #import "FBSDKGraphRequest+Internal.h"


### PR DESCRIPTION
Summary: Even though FBSDKGraphRequestPiggybackManager.h has contains `#import "FBSDKCoreKit+Internal.h"` in the file of `FBSDKGraphRequestConnection.m` and the project can build for coffeeShop and FBSDKCoreKitSwift. But if opening project with package.swift, we get some wired errors. So adding back the import and will investigate later why we get this issue

Differential Revision: D19276391

