### PR TITLE
Adding ShareDialog stub for tvOS

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.h
@@ -18,7 +18,23 @@
 
 #import "TargetConditionals.h"
 
-#if !TARGET_OS_TV
+#if TARGET_OS_TV
+
+// This is an unfortunate hack for Swift Package Manager support.
+// SPM does not allow us to conditionally exclude Swift files for compilation by platform.
+//
+// So to support tvOS with SPM we need to use runtime availability checks in the Swift files.
+// This means that even though the Swift extension of ShareDialog will never be run for tvOS
+// targets, it still needs to be able to compile. Hence we need to declare it here.
+//
+// The way to fix this is to remove extensions of ObjC types in Swift.
+// This will be be done in the next major release (6.0)
+
+NS_SWIFT_NAME(ShareDialog)
+@interface FBSDKShareDialog : NSObject
+@end
+
+#else
 
 #import <UIKit/UIKit.h>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialogMode.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialogMode.h
@@ -57,7 +57,7 @@ typedef NS_ENUM(NSUInteger, FBSDKShareDialogMode)
    @Displays the feed dialog in a WKWebView within the app.
    */
   FBSDKShareDialogModeFeedWeb,
-};
+} NS_SWIFT_NAME(ShareDialog.Mode);
 
 /**
   Converts an FBSDKShareDialogMode to an NSString.

--- a/FBSDKShareKit/FBSDKShareKit/Swift/Enums+Extensions.swift
+++ b/FBSDKShareKit/FBSDKShareKit/Swift/Enums+Extensions.swift
@@ -20,11 +20,6 @@
  ShareDialog.Mode CustomStringConvertible
  */
 @available(tvOS, unavailable)
-public enum ShareDialog {
-    public typealias Mode = FBSDKShareDialogMode
-}
-
-@available(tvOS, unavailable)
 extension ShareDialog.Mode: CustomStringConvertible {
   /// The string description
   public var description: String {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This is sort of unfortunate. We are essentially stubbing classes so that we can compile Swift extensions that will never be run.

To support tvOS with SPM we need to use runtime availability checks in the Swift files. This means that even though the Swift extension of ShareDialog will never be run for tvOS targets, it still needs to be able to compile so we stub it out in the header. Eventually we will get away from this pattern entirely.

## Test Plan

Test Plan: The SPM integration test caught this issue so a passing build should be enough to verify a fix.
