### PR TITLE
add requires_arc configure for GraphAPI folder

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -32,7 +32,8 @@ Pod::Spec.new do |s|
   s.requires_arc = ['FBSDKCoreKit/FBSDKCoreKit/*',
                     'FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*',
                     'FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*',
-		    'FBSDKCoreKit/FBSDKCoreKit/Basics/**/*',
+                    'FBSDKCoreKit/FBSDKCoreKit/Basics/**/*',
+                    'FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*',		
                     'FBSDKCoreKit/FBSDKCoreKit/Internal/**/*']
 
   s.default_subspecs = 'Core', 'Basics'


### PR DESCRIPTION
Summary: D19247723 moved relative files to a new folder named GraphAPI but haven't updated the requires_arc setting for this folder, so add back requires_arc setting back to avoid crash on sdk launch.

Differential Revision: D19357327

