### PR TITLE
Updates CI to lint CocoaPod static libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
     - stage: test
       name: Pod Lint - Xcode 10.3
       osx_image: xcode10.3
-      script: sh scripts/run.sh lint cocoapods --allow-warnings
+      script: sh scripts/run.sh lint cocoapods
     - stage: test
       name: Swift Lint
       osx_image: xcode10.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ jobs:
       osx_image: xcode10.3
       script: sh scripts/run.sh lint cocoapods
     - stage: test
+      name: Pod Lint Static - Xcode 10.3
+      osx_image: xcode10.3
+      script: sh scripts/run.sh lint cocoapods --use-libraries
+    - stage: test
       name: Swift Lint
       osx_image: xcode10.3
       script: sh scripts/run.sh lint swift

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -374,6 +374,11 @@ lint_sdk() {
       if [ "$spec" != FBSDKCoreKit.podspec ]; then
         dependent_spec="--include-podspecs=FBSDKCoreKit.podspec"
       fi
+
+      echo ""
+      echo "Running lib lint command:"
+      echo "pod lib lint" "$spec" $dependent_spec "$@"
+
       if ! pod lib lint "$spec" $dependent_spec "$@"; then
         pod_lint_failures+=("$spec")
       fi
@@ -381,10 +386,8 @@ lint_sdk() {
     done
 
     if [ ${#pod_lint_failures[@]} -ne 0 ]; then
-      echo "Failed lint for: ${pod_lint_failures[*]}"
+      echo "Failed lint for: ${pod_lint_failures[*]} with arguments: $*"
       exit 1
-    else
-      exit 0
     fi
   }
 
@@ -400,7 +403,9 @@ lint_sdk() {
   if [ -n "$lint_type" ]; then shift; fi
 
   case "$lint_type" in
-  "cocoapods") lint_cocoapods "$@" ;;
+  "cocoapods")
+    lint_cocoapods --allow-warnings "$@" && \
+    lint_cocoapods --allow-warnings --use-libraries "$@" ;;
   "swift") lint_swift "$@" ;;
   *) echo "Unsupported Lint: $lint_type" ;;
   esac

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -375,6 +375,13 @@ lint_sdk() {
         dependent_spec="--include-podspecs=FBSDKCoreKit.podspec"
       fi
 
+      # This is temporary to be able to lint before a fix in the ShareKit podspec
+      # is pushed to trunk
+      # https://github.com/facebook/facebook-ios-sdk/pull/1179
+      if [ "$spec" == FBSDKTVOSKit.podspec ]; then
+        dependent_spec="--include-podspecs=FBSDKShareKit.podspec"
+      fi
+
       echo ""
       echo "Running lib lint command:"
       echo "pod lib lint" "$spec" $dependent_spec "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -375,13 +375,6 @@ lint_sdk() {
         dependent_spec="--include-podspecs=FBSDKCoreKit.podspec"
       fi
 
-      # This is temporary to be able to lint before a fix in the ShareKit podspec
-      # is pushed to trunk
-      # https://github.com/facebook/facebook-ios-sdk/pull/1179
-      if [ "$spec" == FBSDKTVOSKit.podspec ]; then
-        dependent_spec="--include-podspecs=FBSDKShareKit.podspec"
-      fi
-
       echo ""
       echo "Running lib lint command:"
       echo "pod lib lint" "$spec" $dependent_spec "$@"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -366,14 +366,9 @@ lint_sdk() {
         continue
       fi
 
-      local dependent_spec
+      local dependent_spec="--include-podspecs=FBSDKCoreKit.podspec"
 
       set +e
-      # Needs to include dependent specs for some pods so that we can
-      # test linting without relying on specs being pushed to the trunk
-      if [ "$spec" != FBSDKCoreKit.podspec ]; then
-        dependent_spec="--include-podspecs=FBSDKCoreKit.podspec"
-      fi
 
       echo ""
       echo "Running lib lint command:"
@@ -403,9 +398,7 @@ lint_sdk() {
   if [ -n "$lint_type" ]; then shift; fi
 
   case "$lint_type" in
-  "cocoapods")
-    lint_cocoapods --allow-warnings "$@" && \
-    lint_cocoapods --allow-warnings --use-libraries "$@" ;;
+  "cocoapods") lint_cocoapods --allow-warnings "$@";;
   "swift") lint_swift "$@" ;;
   *) echo "Unsupported Lint: $lint_type" ;;
   esac


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Follow-up to [#1173](https://github.com/facebook/facebook-ios-sdk/pull/1173). 
Lints CocoaPod static libraries to make sure pods work when `use_frameworks!` is excluded from the Podfile.

## Test Plan

Test Plan: Travis job passes.
