### PR TITLE
Fixes CocoaPod static libraries for TVOSKit

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
@@ -22,7 +22,7 @@
 
 #import <UIKit/UIKit.h>
 
-#ifdef BUCK
+#if defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKTVOSKit.podspec
+++ b/FBSDKTVOSKit.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.source_files   = 'FBSDKTVOSKit/FBSDKTVOSKit/**/*.{h,m}'
   s.public_header_files = 'FBSDKTVOSKit/FBSDKTVOSKit/*.h'
   s.header_dir = 'FBSDKTVOSKit'
+  s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
 
   s.dependency 'FBSDKCoreKit', "~> 5.0"
   # We have a compile time depend on FBSDKShareKit


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Fix for using TVOSKit via CocoaPods as a static library

## Test Plan

Test Plan: Create a new tvOS project. Add this to the podfile:
`pod 'FBSDKTVOSKit', :path => 'your checkout path'`
Make sure `use_frameworks!` is commented out.

Should build successfully.

Also should successfully lint as a static lib with:
`bundle exec pod lib lint FBSDKTVOSKit.podspec --include-podspecs=FBSDKShareKit.podspec --allow-warnings  --use-libraries`
