### PR TITLE
Fix for static libraries with CocoaPods

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -38,7 +38,8 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Core', 'Basics'
   s.swift_version = '5.0'
-  s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
+  s.pod_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
+  s.user_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
   s.library = 'c++', 'stdc++'
 
   s.subspec 'Basics' do |ss|

--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -33,12 +33,12 @@ Pod::Spec.new do |s|
                     'FBSDKCoreKit/FBSDKCoreKit/AppEvents/**/*',
                     'FBSDKCoreKit/FBSDKCoreKit/AppLink/**/*',
                     'FBSDKCoreKit/FBSDKCoreKit/Basics/**/*',
-                    'FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*',		
+                    'FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*',
                     'FBSDKCoreKit/FBSDKCoreKit/Internal/**/*']
 
   s.default_subspecs = 'Core', 'Basics'
   s.swift_version = '5.0'
-  s.pod_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
+  s.xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
   s.library = 'c++', 'stdc++'
 
   s.subspec 'Basics' do |ss|


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

What we have is similar to this issue here. https://github.com/CocoaPods/CocoaPods/issues/9101
Basically we need to expose FBSDKCOCOAPODS for static libs to work with other kits. There may be other convoluted workarounds but I'd argue it's worth taking the chance that few people are
using the SDK from CocoaPods as a static library AND are unable to avoid a macro collision with `FBSDKCOCOAPODS`

## Test Plan

Test Plan: 
`pod lib lint FBSDKLoginKit.podspec --allow-warnings --use-libraries --include-podspecs=FBSDKCoreKit.podspec`

