### PR TITLE
Fix for sharing delegate on iOS 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     - stage: test
       name: Pod Lint Static - Xcode 10.3
       osx_image: xcode10.3
-      script: sh scripts/run.sh lint cocoapods --use-libraries
+      script: sh scripts/run.sh lint cocoapods --use-libraries --no-clean
     - stage: test
       name: Swift Lint
       osx_image: xcode10.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
     - stage: test
       name: Pod Lint Static - Xcode 10.3
       osx_image: xcode10.3
-      script: sh scripts/run.sh lint cocoapods --use-libraries --no-clean
+      script: sh scripts/run.sh lint cocoapods --use-libraries
     - stage: test
       name: Swift Lint
       osx_image: xcode10.3

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIResponse.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIResponse.m
@@ -56,10 +56,14 @@ NS_DESIGNATED_INITIALIZER;
   FBSDKBridgeAPIProtocolType protocolType = request.protocolType;
   switch (protocolType) {
     case FBSDKBridgeAPIProtocolTypeNative:{
-      if (![FBSDKInternalUtility isFacebookBundleIdentifier:sourceApplication]) {
-        return nil;
+      if (@available(iOS 13, *)) {
+        break;
+      } else {
+        if (![FBSDKInternalUtility isFacebookBundleIdentifier:sourceApplication]) {
+          return nil;
+        }
+        break;
       }
-      break;
     }
     case FBSDKBridgeAPIProtocolTypeWeb:{
       if (![FBSDKInternalUtility isSafariBundleIdentifier:sourceApplication]) {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Quick fix for callbacks on iOS 13. 

**Cause:**
Basically we were not accounting for the fact that source application is no longer shared on iOS 13 for applications that are from different application security groups.
See: https://forums.developer.apple.com/thread/119118

**Follow-up**
We need to add back the sanity checks that are being bypassed by this fix. It seemed more important to get the fix out quickly.

Also need to update the documentation to include instructions for adding code to invoke FBSDKApplicationDelegate from `SceneDelegate`'s openURL method.

This should fix: 
#1090 
#1144 

## Test Plan

Test Plan: With the native app installed, build and check that the delegates are invokes correctly for a simulator / device running 11 and 13. Both Should work. Make sure that the sample app includes the `SceneDelegate` code:
```
@available(iOS 13.0, *)
func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
    guard let urlContext = URLContexts.first else { return }

    ApplicationDelegate.shared.application(
        UIApplication.shared,
        open: urlContext.url,
        sourceApplication: urlContext.options.sourceApplication,
        annotation: urlContext.options.annotation
    )
}
```
