### PR TITLE
Log fb_auto_applink in sdkInitialize

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -127,6 +127,7 @@ static UIApplicationState _applicationState;
 #if !TARGET_OS_TV
   // Register Listener for App Link measurement events
   [FBSDKMeasurementEventListener defaultListener];
+  [delegate _logIfAutoAppLinkEnabled];
 #endif
   // Set the SourceApplication for time spent data. This is not going to update the value if the app has already launched.
   [FBSDKTimeSpentData setSourceApplication:launchOptions[UIApplicationLaunchOptionsSourceApplicationKey]
@@ -396,6 +397,22 @@ static UIApplicationState _applicationState;
                           parameters:params
                   isImplicitlyLogged:NO];
   }
+}
+
+- (void)_logIfAutoAppLinkEnabled
+{
+#if !TARGET_OS_TV
+  NSNumber *enabled = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FBSDKAutoAppLinkEnabled"];
+  if (enabled.boolValue) {
+    NSMutableDictionary<NSString *, NSString *> *params = [[NSMutableDictionary alloc] init];
+    if (![FBSDKAppLinkUtility isMatchURLScheme:[NSString stringWithFormat:@"fb%@", [FBSDKSettings appID]]]) {
+      NSString *warning = @"You haven't set the Auto App Link URL scheme: fb<YOUR APP ID>";
+      params[@"SchemeWarning"] = warning;
+      NSLog(@"%@", warning);
+    }
+    [FBSDKAppEvents logInternalEvent:@"fb_auto_applink" parameters:params isImplicitlyLogged:YES];
+  }
+#endif
 }
 
 + (BOOL)isSDKInitialized

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m
@@ -95,7 +95,6 @@ static NSString *const advertiserIDCollectionEnabledFalseWarning =
 
     [FBSDKSettings _logWarnings];
     [FBSDKSettings _logIfSDKSettingsChanged];
-    [FBSDKSettings _logIfAutoAppLinkEnabled];
   }
 }
 
@@ -358,22 +357,6 @@ FBSDKSETTINGS_PLIST_CONFIGURATION_SETTING_IMPL(NSNumber, FacebookCodelessDebugLo
                                        @"current": @(bitmask)}
                   isImplicitlyLogged:YES];
   }
-}
-
-+ (void)_logIfAutoAppLinkEnabled
-{
-#if !TARGET_OS_TV
-  NSNumber *enabled = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FBSDKAutoAppLinkEnabled"];
-  if (enabled.boolValue) {
-    NSMutableDictionary<NSString *, NSString *> *params = [[NSMutableDictionary alloc] init];
-    if (![FBSDKAppLinkUtility isMatchURLScheme:[NSString stringWithFormat:@"fb%@", [FBSDKSettings appID]]]) {
-      NSString *warning = @"You haven't set the Auto App Link URL scheme: fb<YOUR APP ID>";
-      params[@"SchemeWarning"] = warning;
-      NSLog(@"%@", warning);
-    }
-    [FBSDKAppEvents logInternalEvent:@"fb_auto_applink" parameters:params isImplicitlyLogged:YES];
-  }
-#endif
 }
 
 #pragma mark - Internal - Graph API Debug


### PR DESCRIPTION
Summary:
fb_auto_applink event is logged when com.facebook.sdk.AutoAppLinkEnabled is set to be true and it respects AutoLog flag.
We also need to log this event when developers manually initialize FB SDK and thus we move the logging to sdkInitialize.

Differential Revision: D19505471

