### PR TITLE
Adding graph_domain support to FBSDKAccessToken.

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.h
@@ -163,6 +163,11 @@ NS_REFINED_FOR_SWIFT;
 @property (nonatomic, copy, readonly) NSString *userID;
 
 /**
+  The graph domain where this access token is valid.
+ */
+@property (nonatomic, copy, readonly) NSString *graphDomain;
+
+/**
  Returns whether the access token is expired by checking its expirationDate property
  */
 @property (readonly, assign, nonatomic, getter=isExpired) BOOL expired;
@@ -205,6 +210,38 @@ NS_REFINED_FOR_SWIFT;
                         refreshDate:(nullable NSDate *)refreshDate
            dataAccessExpirationDate:(nullable NSDate *)dataAccessExpirationDate
 NS_DESIGNATED_INITIALIZER;
+
+/**
+ Convenience initializer.
+ @param tokenString the opaque token string.
+ @param permissions the granted permissions. Note this is converted to NSSet and is only
+ an NSArray for the convenience of literal syntax.
+ @param declinedPermissions the declined permissions. Note this is converted to NSSet and is only
+ an NSArray for the convenience of literal syntax.
+ @param expiredPermissions the expired permissions. Note this is converted to NSSet and is only
+ an NSArray for the convenience of literal syntax.
+ @param appID the app ID.
+ @param userID the user ID.
+ @param expirationDate the optional expiration date (defaults to distantFuture).
+ @param refreshDate the optional date the token was last refreshed (defaults to today).
+ @param dataAccessExpirationDate the date which data access will expire for the given user
+ (defaults to distantFuture).
+ @param graphDomain the domain this access token can be used in.
+
+ This initializer should only be used for advanced apps that
+ manage tokens explicitly. Typical login flows only need to use `FBSDKLoginManager`
+ along with `+currentAccessToken`.
+ */
+- (instancetype)initWithTokenString:(NSString *)tokenString
+                        permissions:(NSArray<NSString *> *)permissions
+                declinedPermissions:(NSArray<NSString *> *)declinedPermissions
+                 expiredPermissions:(NSArray<NSString *> *)expiredPermissions
+                              appID:(NSString *)appID
+                             userID:(NSString *)userID
+                     expirationDate:(nullable NSDate *)expirationDate
+                        refreshDate:(nullable NSDate *)refreshDate
+           dataAccessExpirationDate:(nullable NSDate *)dataAccessExpirationDate
+                        graphDomain:(nullable NSString *)graphDomain;
 
 /**
   Convenience getter to determine if a permission has been granted

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKAccessToken.m
@@ -49,7 +49,7 @@ static FBSDKAccessToken *g_currentAccessToken;
 #define FBSDK_ACCESSTOKEN_REFRESHDATE_KEY @"refreshDate"
 #define FBSDK_ACCESSTOKEN_EXPIRATIONDATE_KEY @"expirationDate"
 #define FBSDK_ACCESSTOKEN_DATA_EXPIRATIONDATE_KEY @"dataAccessExpirationDate"
-
+#define FBSDK_ACCESSTOKEN_GRAPH_DOMAIN_KEY @"graphDomain"
 
 @implementation FBSDKAccessToken
 
@@ -75,6 +75,36 @@ static FBSDKAccessToken *g_currentAccessToken;
         _dataAccessExpirationDate = [dataAccessExpirationDate copy] ?: [NSDate distantFuture];
     }
     return self;
+}
+
+- (instancetype)initWithTokenString:(NSString *)tokenString
+                        permissions:(NSArray<NSString *> *)permissions
+                declinedPermissions:(NSArray<NSString *> *)declinedPermissions
+                 expiredPermissions:(NSArray<NSString *> *)expiredPermissions
+                              appID:(NSString *)appID
+                             userID:(NSString *)userID
+                     expirationDate:(NSDate *)expirationDate
+                        refreshDate:(NSDate *)refreshDate
+           dataAccessExpirationDate:(NSDate *)dataAccessExpirationDate
+                        graphDomain:(NSString *)graphDomain
+{
+  FBSDKAccessToken *accessToken =
+  [self
+   initWithTokenString:tokenString
+   permissions:permissions
+   declinedPermissions:declinedPermissions
+   expiredPermissions:expiredPermissions
+   appID:appID
+   userID:userID
+   expirationDate:expirationDate
+   refreshDate:refreshDate
+   dataAccessExpirationDate:dataAccessExpirationDate];
+
+  if (accessToken != nil) {
+    accessToken->_graphDomain = [graphDomain copy];
+  }
+
+  return accessToken;
 }
 
 - (BOOL)hasGranted:(NSString *)permission
@@ -156,7 +186,8 @@ static FBSDKAccessToken *g_currentAccessToken;
     self.userID.hash,
     self.refreshDate.hash,
     self.expirationDate.hash,
-    self.dataAccessExpirationDate.hash
+    self.dataAccessExpirationDate.hash,
+    self.graphDomain.hash
   };
   return [FBSDKMath hashWithIntegerArray:subhashes count:sizeof(subhashes) / sizeof(subhashes[0])];
 }
@@ -183,7 +214,8 @@ static FBSDKAccessToken *g_currentAccessToken;
           [FBSDKInternalUtility object:self.userID isEqualToObject:token.userID] &&
           [FBSDKInternalUtility object:self.refreshDate isEqualToObject:token.refreshDate] &&
           [FBSDKInternalUtility object:self.expirationDate isEqualToObject:token.expirationDate] &&
-          [FBSDKInternalUtility object:self.dataAccessExpirationDate isEqualToObject:token.dataAccessExpirationDate] );
+          [FBSDKInternalUtility object:self.dataAccessExpirationDate isEqualToObject:token.dataAccessExpirationDate] &&
+          [FBSDKInternalUtility object:self.graphDomain isEqualToObject:token.graphDomain]);
 }
 
 #pragma mark - NSCopying
@@ -212,16 +244,20 @@ static FBSDKAccessToken *g_currentAccessToken;
   NSDate *refreshDate = [decoder decodeObjectOfClass:[NSDate class] forKey:FBSDK_ACCESSTOKEN_REFRESHDATE_KEY];
   NSDate *expirationDate = [decoder decodeObjectOfClass:[NSDate class] forKey:FBSDK_ACCESSTOKEN_EXPIRATIONDATE_KEY];
   NSDate *dataAccessExpirationDate = [decoder decodeObjectOfClass:[NSDate class] forKey:FBSDK_ACCESSTOKEN_DATA_EXPIRATIONDATE_KEY];
+  NSString *graphDomain = [decoder decodeObjectOfClass:[NSString class] forKey:FBSDK_ACCESSTOKEN_GRAPH_DOMAIN_KEY];
 
-  return [self initWithTokenString:tokenString
-                       permissions:permissions.allObjects
-               declinedPermissions:declinedPermissions.allObjects
-                expiredPermissions:expiredPermissions.allObjects
-                             appID:appID
-                            userID:userID
-                    expirationDate:expirationDate
-                       refreshDate:refreshDate
-          dataAccessExpirationDate:dataAccessExpirationDate];
+  return
+  [self
+   initWithTokenString:tokenString
+   permissions:permissions.allObjects
+   declinedPermissions:declinedPermissions.allObjects
+   expiredPermissions:expiredPermissions.allObjects
+   appID:appID
+   userID:userID
+   expirationDate:expirationDate
+   refreshDate:refreshDate
+   dataAccessExpirationDate:dataAccessExpirationDate
+   graphDomain:graphDomain];
 }
 
 - (void)encodeWithCoder:(NSCoder *)encoder
@@ -235,6 +271,7 @@ static FBSDKAccessToken *g_currentAccessToken;
   [encoder encodeObject:self.expirationDate forKey:FBSDK_ACCESSTOKEN_EXPIRATIONDATE_KEY];
   [encoder encodeObject:self.refreshDate forKey:FBSDK_ACCESSTOKEN_REFRESHDATE_KEY];
   [encoder encodeObject:self.dataAccessExpirationDate forKey:FBSDK_ACCESSTOKEN_DATA_EXPIRATIONDATE_KEY];
+  [encoder encodeObject:self.graphDomain forKey:FBSDK_ACCESSTOKEN_GRAPH_DOMAIN_KEY];
 }
 
 @end

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKTestUsersManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKTestUsersManager.m
@@ -216,7 +216,8 @@ static NSMutableDictionary<NSString *, FBSDKTestUsersManager *> *gInstancesDicti
                                                 userID:userId
                                         expirationDate:nil
                                            refreshDate:nil
-                                           dataAccessExpirationDate:nil];
+                                           dataAccessExpirationDate:nil
+                                           graphDomain:nil];
 }
 
 - (NSArray *)userIdAndTokenOfExistingAccountWithPermissions:(NSSet *)permissions skip:(NSSet *)setToSkip {

--- a/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphRequestConnection.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphRequestConnection.m
@@ -78,7 +78,8 @@ static FBSDKAccessToken *_CreateExpiredAccessToken(FBSDKAccessToken *accessToken
                                                 userID:accessToken.userID
                                         expirationDate:expirationDate
                                            refreshDate:expirationDate
-                                           dataAccessExpirationDate:expirationDate];
+                                           dataAccessExpirationDate:expirationDate
+                                           graphDomain:accessToken.graphDomain];
 }
 #endif
 

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -143,7 +143,11 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift)
     hostPrefix = [hostPrefix stringByAppendingString:@"."];
   }
 
-  NSString *host = @"facebook.com";
+  NSString *host =
+  [[FBSDKAccessToken currentAccessToken].graphDomain isEqualToString:@"gaming"]
+  ? @"fb.gg"
+  : @"facebook.com";
+
   NSString *domainPart = [FBSDKSettings facebookDomainPart];
   if (domainPart.length) {
     host = [[NSString alloc] initWithFormat:@"%@.%@", domainPart, host];

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
@@ -76,7 +76,8 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
                                                                                 userID:currentToken.userID
                                                                         expirationDate:expirationDate
                                                                            refreshDate:[NSDate date]
-                                                                           dataAccessExpirationDate:dataExpirationDate];
+                                                                           dataAccessExpirationDate:dataExpirationDate
+                                                                           graphDomain:currentToken.graphDomain];
       if (expectedToken == currentToken) {
         [FBSDKAccessToken setCurrentAccessToken:refreshedToken];
       }

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKDeviceLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKDeviceLoginManager.m
@@ -162,7 +162,8 @@ static NSMutableArray<FBSDKDeviceLoginManager *> *g_loginManagerInstances;
                                                                                userID:userID
                                                                        expirationDate:nil
                                                                           refreshDate:nil
-                                                             dataAccessExpirationDate:nil];
+                                                             dataAccessExpirationDate:nil
+                                                                          graphDomain:nil];
         FBSDKDeviceLoginManagerResult *result = [[FBSDKDeviceLoginManagerResult alloc] initWithToken:accessToken
                                                                                          isCancelled:NO];
         completeWithResult(result);

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -230,7 +230,8 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
                                                                          userID:parameters.userID
                                                                  expirationDate:parameters.expirationDate
                                                                     refreshDate:[NSDate date]
-                                                                    dataAccessExpirationDate:parameters.dataAccessExpirationDate];
+                                                                    dataAccessExpirationDate:parameters.dataAccessExpirationDate
+                                                                    graphDomain:parameters.graphDomain];
         result = [[FBSDKLoginManagerLoginResult alloc] initWithToken:token
                                                          isCancelled:NO
                                                   grantedPermissions:recentlyGrantedPermissions
@@ -326,7 +327,7 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
 
   NSMutableDictionary *loginParams = [NSMutableDictionary dictionary];
   loginParams[@"client_id"] = [FBSDKSettings appID];
-  loginParams[@"response_type"] = @"token_or_nonce,signed_request";
+  loginParams[@"response_type"] = @"token_or_nonce,signed_request,graph_domain";
   loginParams[@"redirect_uri"] = @"fbconnect://success";
   loginParams[@"display"] = @"touch";
   loginParams[@"sdk"] = @"ios";

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion+Internal.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion+Internal.h
@@ -41,6 +41,8 @@
 
 @property (nonatomic, copy) NSString *challenge;
 
+@property (nonatomic, copy) NSString *graphDomain;
+
 @end
 
 #endif

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.h
@@ -58,6 +58,8 @@ NS_SWIFT_NAME(LoginCompletionParameters)
 @property (nonatomic, copy, readonly) NSDate *dataAccessExpirationDate;
 
 @property (nonatomic, copy, readonly) NSString *challenge;
+
+@property (nonatomic, copy, readonly) NSString *graphDomain;
 @end
 
 NS_SWIFT_NAME(LoginCompleting)

--- a/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/Internal/FBSDKLoginCompletion.m
@@ -198,6 +198,9 @@ static void FBSDKLoginRequestMeAndPermissions(FBSDKLoginCompletionParameters *pa
   NSError *error = nil;
   NSDictionary<id, id> *state = [FBSDKBasicUtility objectForJSONString:parameters[@"state"] error:&error];
   _parameters.challenge = [FBSDKUtility URLDecode:state[@"challenge"]];
+
+  NSString *domain = parameters[@"graph_domain"];
+  _parameters.graphDomain = [domain copy];
 }
 
 - (void)setErrorWithDictionary:(NSDictionary *)parameters

--- a/FBSDKLoginKit/FBSDKLoginKitTests/FBSDKLoginManagerTests.m
+++ b/FBSDKLoginKit/FBSDKLoginKitTests/FBSDKLoginManagerTests.m
@@ -334,7 +334,7 @@ static NSString *const kFakeChallenge = @"a =bcdef";
     long long currentMilliseconds = round(1000 * [NSDate date].timeIntervalSince1970);
     XCTAssertEqualWithAccuracy(cbt, currentMilliseconds, 500);
     XCTAssertEqualObjects(params[@"client_id"], @"7391628439");
-    XCTAssertEqualObjects(params[@"response_type"], @"token_or_nonce,signed_request");
+    XCTAssertEqualObjects(params[@"response_type"], @"token_or_nonce,signed_request,graph_domain");
     XCTAssertEqualObjects(params[@"redirect_uri"], @"fbconnect://success");
     XCTAssertEqualObjects(params[@"display"], @"touch");
     XCTAssertEqualObjects(params[@"sdk"], @"ios");


### PR DESCRIPTION
Summary:
Access tokens can now be granted for specific domains.

This updates the SDK to automatically start using 'fb.gg' when the graph_domain field returns 'gaming'.

This graph_domain is stored with the FBSDKAccessToken and is reset during normal token clearing (Logout, Expiration etc).

A convenience initializer was added so that this is not a breaking change.

Differential Revision: D19449489

