### PR TITLE
Fixes login callbacks issue

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKConstants.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKConstants.h
@@ -323,6 +323,11 @@ typedef NS_ERROR_ENUM(FBSDKErrorDomain, FBSDKCoreError)
    Indicates an app switch to the browser (typically for a dialog) failed.
    */
   FBSDKErrorBrowserUnavailable,
+
+  /**
+   Indicates that a bridge api interaction was interrupted.
+   */
+  FBSDKErrorBridgeAPIInterruption,
 } NS_SWIFT_NAME(CoreError);
 
 /**

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m
@@ -103,6 +103,10 @@ typedef void (^FBSDKAuthenticationCompletionHandler)(NSURL *_Nullable callbackUR
          annotation:(id)annotation
 {
   id<FBSDKURLOpening> pendingURLOpen = _pendingURLOpen;
+  BOOL canOpenURL =   [pendingURLOpen canOpenURL:url
+                                  forApplication:application
+                               sourceApplication:sourceApplication
+                                      annotation:annotation];
 
   void (^completePendingOpenURLBlock)(void) = ^{
     self->_pendingURLOpen = nil;
@@ -123,15 +127,28 @@ typedef void (^FBSDKAuthenticationCompletionHandler)(NSURL *_Nullable callbackUR
       if (_authenticationSession != nil) {
         [_authenticationSession cancel];
         _authenticationSession = nil;
+
+        // This check is needed in case another sdk / message / ad etc... tries to open the app
+        // during the login flow.
+        // This dismisses the authentication browser without triggering any login callbacks.
+        // Hence we need to explicitly call the authentication session's completion handler.
+        if (!canOpenURL) {
+          NSString *errorMessage = [[NSString alloc]
+                                    initWithFormat:@"Login attempt cancelled by alternate call to openURL from: %@",
+                                    url];
+          NSError *loginError = [[NSError alloc]
+                                 initWithDomain:@"com.facebook.sdk.login"
+                                 code:0
+                                 userInfo:@{FBSDKErrorLocalizedDescriptionKey: errorMessage}];
+          _authenticationSessionCompletionHandler(url, loginError);
+          _authenticationSessionCompletionHandler = nil;
+        }
       }
     }
     completePendingOpenURLBlock();
   }
 
-  if ([pendingURLOpen canOpenURL:url
-                  forApplication:application
-               sourceApplication:sourceApplication
-                      annotation:annotation]) {
+  if (canOpenURL) {
     return YES;
   }
 

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m
@@ -137,8 +137,8 @@ typedef void (^FBSDKAuthenticationCompletionHandler)(NSURL *_Nullable callbackUR
                                     initWithFormat:@"Login attempt cancelled by alternate call to openURL from: %@",
                                     url];
           NSError *loginError = [[NSError alloc]
-                                 initWithDomain:@"com.facebook.sdk.login"
-                                 code:0
+                                 initWithDomain:FBSDKErrorDomain
+                                 code:FBSDKErrorBridgeAPIInterruption
                                  userInfo:@{FBSDKErrorLocalizedDescriptionKey: errorMessage}];
           _authenticationSessionCompletionHandler(url, loginError);
           _authenticationSessionCompletionHandler = nil;


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This fixes https://github.com/facebook/facebook-ios-sdk/issues/1121 by invoking the callback with an error when a non-recognized url (by the SDK) attempts to open a url during an ongoing login flow. 

## Test Plan

Test Plan: Follow the repro steps in https://github.com/facebook/facebook-ios-sdk/issues/1121
