### PR TITLE
Stabilize flaky static podspec linting

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -87,7 +87,6 @@ main() {
     SDK_POD_SPECS[6]="AccountKit/${SDK_POD_SPECS[6]}"
 
     SDK_LINT_POD_SPECS=(
-      "FBSDKCoreKit.podspec"
       "FBSDKLoginKit.podspec"
       "FBSDKShareKit.podspec"
       "FBSDKPlacesKit.podspec"


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Pretty sure there is no reason to ever lint FBSDKCoreKit by itself since it is linted as a dependent podspec by all of the other podspecs.

That said, for the extra safety it seems we can still lint it if it does not include itself as a dependent spec.

## Test Plan

Test Plan: Travis
