### PR TITLE
Only reporting errors in Travis release job

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -455,11 +455,12 @@ release_sdk() {
       mkdir -p Temp
 
       for kit in "${SDK_BASE_KITS[@]}"; do
+        # Redirecting to /dev/null because we only care about errors here and the full output drowns Travis
         xcodebuild build \
         -workspace FacebookSDK.xcworkspace \
         -scheme "$kit"Swift \
         -configuration Release \
-        -derivedDataPath Temp
+        -derivedDataPath Temp > /dev/null
 
         mv Temp/Build/Products/Release-iphoneos/"$kit".framework build/Release
 
@@ -483,10 +484,11 @@ release_sdk() {
     # Release frameworks in static
     release_static() {
       release_basics() {
+        # Redirecting to /dev/null because we only care about errors here and the full output drowns Travis
         xcodebuild build \
          -workspace FacebookSDK.xcworkspace \
          -scheme BuildCoreKitBasics \
-         -configuration Release
+         -configuration Release > /dev/null
 
         kit="FBSDKCoreKit_Basics"
         cd build || exit
@@ -502,15 +504,17 @@ release_sdk() {
         cd ..
       }
 
+      # Redirecting to /dev/null because we only care about errors here and the full output drowns Travis
       xcodebuild build \
        -workspace FacebookSDK.xcworkspace \
        -scheme BuildAllKits \
-       -configuration Release
+       -configuration Release > /dev/null
 
+      # Redirecting to /dev/null because we only care about errors here and the full output drowns Travis
       xcodebuild build \
        -workspace FacebookSDK.xcworkspace \
        -scheme BuildAllKits_TV \
-       -configuration Release
+       -configuration Release > /dev/null
 
       cd build || exit
       zip -r FacebookSDK_static.zip ./*.framework ./*/*.framework


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Previous release's xcodebuild command drowned Travis' logs and caused the build to fail. This should prevent this on the next release.

Note: There is a possibility that Travis will time out due to a LACK of output. If this happens we may need to add back xcpretty or find some other way to truncate output. Tried adding the '-quiet' flag to xcodebuild but this did not quiet output enough.

## Test Plan

Test Plan: run `sh scripts/run.sh release github` this will not  actually push anything to github. You should see that there is minimal output. Also you can change something to fail and make sure that there is output as expected.