### PR TITLE
Removing source application check for iOS 13

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIResponse.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIResponse.m
@@ -54,22 +54,23 @@ NS_DESIGNATED_INITIALIZER;
                                        error:(NSError *__autoreleasing *)errorRef
 {
   FBSDKBridgeAPIProtocolType protocolType = request.protocolType;
-  switch (protocolType) {
-    case FBSDKBridgeAPIProtocolTypeNative:{
-      if (@available(iOS 13, *)) {
-        break;
-      } else {
+  if (@available(iOS 13.0, *)) {
+    // SourceApplication is not available in iOS 13.
+    // https://forums.developer.apple.com/thread/119118
+  } else {
+    switch (protocolType) {
+      case FBSDKBridgeAPIProtocolTypeNative:{
         if (![FBSDKInternalUtility isFacebookBundleIdentifier:sourceApplication]) {
           return nil;
         }
         break;
       }
-    }
-    case FBSDKBridgeAPIProtocolTypeWeb:{
-      if (![FBSDKInternalUtility isSafariBundleIdentifier:sourceApplication]) {
-        return nil;
+      case FBSDKBridgeAPIProtocolTypeWeb:{
+        if (![FBSDKInternalUtility isSafariBundleIdentifier:sourceApplication]) {
+          return nil;
+        }
+        break;
       }
-      break;
     }
   }
   NSDictionary<NSString *, NSString *> *const queryParameters = [FBSDKBasicUtility dictionaryWithQueryString:responseURL.query];


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Similar to #1185 
Ultimately need to deprecate most everything that relies on source application since it won't be available.
See: https://forums.developer.apple.com/thread/119118

This is the quick and dirty to get callbacks for sharing via safari working when using iOS 13.

## Test Plan

Test Plan: Set up a sample application that implements the Sharing delegate.
ex:
```
        let dialog = ShareDialog()
        dialog.delegate = self
        let content = ShareLinkContent()
        content.contentURL = URL(string: "https://facebook.com")!
        dialog.shareContent = content
        dialog.show()
```
 Share via browser and make sure the callbacks are invoked.

