### PR TITLE
Updating Swift runtime check to work with SceneDelegate

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -228,7 +228,8 @@ static UIApplicationState _applicationState;
     [FBSDKServerConfigurationManager loadServerConfigurationWithCompletionBlock:NULL];
 
     if (FBSDKSettings.isAutoLogAppEventsEnabled) {
-        [self _logSDKInitialize];
+      [self _logSDKInitialize];
+      [self _logSwiftRuntimeAvailability];
     }
 #if !TARGET_OS_TV
     FBSDKProfile *cachedProfile = [FBSDKProfile fetchCachedProfile];
@@ -364,32 +365,6 @@ static UIApplicationState _applicationState;
     bit++;
   }
 
-  // Tracking if the consuming Application is using Swift
-  id delegate = [UIApplication sharedApplication].delegate;
-  NSString const *className = NSStringFromClass([delegate class]);
-  if ([className componentsSeparatedByString:@"."].count > 1) {
-    params[@"is_using_swift"] = @YES;
-  }
-
-  void (^checkViewForSwift)(void) = ^void ()
-  {
-    // Additional check to see if the consuming application perhaps was
-    // originally an objc project but is now using Swift
-    UIViewController *topMostViewController = [FBSDKInternalUtility topMostViewController];
-    NSString const *vcClassName = NSStringFromClass([topMostViewController class]);
-    if ([vcClassName componentsSeparatedByString:@"."].count > 1) {
-      params[@"is_using_swift"] = @YES;
-    }
-  };
-
-  if ([NSThread isMainThread]) {
-    checkViewForSwift();
-  } else {
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      checkViewForSwift();
-    });
-  }
-
   NSInteger existingBitmask = [[NSUserDefaults standardUserDefaults] integerForKey:FBSDKKitsBitmaskKey];
   if (existingBitmask != bitmask) {
     [[NSUserDefaults standardUserDefaults] setInteger:bitmask forKey:FBSDKKitsBitmaskKey];
@@ -413,6 +388,37 @@ static UIApplicationState _applicationState;
     [FBSDKAppEvents logInternalEvent:@"fb_auto_applink" parameters:params isImplicitlyLogged:YES];
   }
 #endif
+}
+
+- (void)_logSwiftRuntimeAvailability
+{
+  NSString *swiftUsageKey = @"is_using_swift";
+  NSString *eventName = @"fb_sdk_swift_runtime_check";
+  NSMutableDictionary<NSString *, NSNumber *> *params = NSMutableDictionary.new;
+
+  // Tracking if the consuming Application is using Swift
+  id delegate = [UIApplication sharedApplication].delegate;
+  NSString const *className = NSStringFromClass([delegate class]);
+  if ([className componentsSeparatedByString:@"."].count > 1) {
+    params[swiftUsageKey] = @YES;
+  }
+
+  // Additional check to see if the consuming application perhaps was
+  // originally an objc project but is now using Swift
+  if (!params[swiftUsageKey]) {
+    double delayInSeconds = 1.0;
+    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
+    dispatch_after(delay, dispatch_get_main_queue(), ^{
+      UIViewController *topMostViewController = [FBSDKInternalUtility topMostViewController];
+      NSString const *vcClassName = NSStringFromClass([topMostViewController class]);
+      if ([vcClassName componentsSeparatedByString:@"."].count > 1) {
+        params[swiftUsageKey] = @YES;
+        [FBSDKAppEvents logInternalEvent:eventName
+                              parameters:params
+                      isImplicitlyLogged:NO];
+      }
+    });
+  };
 }
 
 + (BOOL)isSDKInitialized

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -229,7 +229,6 @@ static UIApplicationState _applicationState;
 
     if (FBSDKSettings.isAutoLogAppEventsEnabled) {
       [self _logSDKInitialize];
-      [self _logSwiftRuntimeAvailability];
     }
 #if !TARGET_OS_TV
     FBSDKProfile *cachedProfile = [FBSDKProfile fetchCachedProfile];
@@ -364,6 +363,8 @@ static UIApplicationState _applicationState;
     }
     bit++;
   }
+
+  [self _logSwiftRuntimeAvailability];
 
   NSInteger existingBitmask = [[NSUserDefaults standardUserDefaults] integerForKey:FBSDKKitsBitmaskKey];
   if (existingBitmask != bitmask) {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

For newer projects you may have seen: `FBSDKLog: Unable to find a valid UIWindow`. This is because there is code that checks for the existence of Swift. It does this check by seeing if the top view controller is namespaced (the module name-spacing implies Swift usage. This is not a perfect check but it is intended to give us a rough idea of how how many apps use Swift). Anyway, if a newer app is using SceneDelegate then the window is not available at the time we check this (AppDelegate's didFinishLaunching method). This delays the check by a second so that the window will be available.

**Why are we checking for the existence of Swift in apps that use the SDK?**
We would like to check for the existence of the Swift runtime to help make decisions around the direction of the SDK. For example, should we continue to support building with Xcode 10.2? What will the impact be of rewriting some classes / apis in Swift?

## Test Plan

Test Plan: Create a new app in objective c and add a root view controller that uses Swift. Make sure the code is invoked to send an app event with the name: "fb_sdk_swift_runtime_check" and that the "is_using_swift" value is true.
