### PR TITLE
Deprecating FBSDKShareApi

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  If you want to use FBSDKShareAPI in a background thread, you must manage the run loop
  yourself.
  */
+DEPRECATED_MSG_ATTRIBUTE("Sharing using the publish_actions permission is deprecated. Sharing should be performed through the Facebook App, native share sheet, or mobile site. This interface will be removed in v7.0")
 NS_SWIFT_NAME(ShareAPI)
 @interface FBSDKShareAPI : NSObject <FBSDKSharing>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareAPI.m
@@ -51,6 +51,8 @@
 static NSString *const FBSDKShareAPIDefaultGraphNode = @"me";
 static NSString *const FBSDKShareAPIPhotosEdge = @"photos";
 static NSString *const FBSDKShareAPIVideosEdge = @"videos";
+static NSString *const FBSDK_SHARE_RESULT_POST_ID_KEY = @"postId";
+
 static NSMutableArray *g_pendingFBSDKShareAPI;
 
 @interface FBSDKShareAPI () <FBSDKVideoUploaderDelegate>

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m
@@ -522,12 +522,7 @@ static inline void FBSDKShareDialogValidateShareExtensionSchemeRegisteredForCanO
       [self _invokeDelegateDidCancel];
     } else {
       // not all web dialogs report cancellation, so assume that the share has completed with no additional information
-      NSMutableDictionary *results = [[NSMutableDictionary alloc] init];
-      // the web response comes back with a different payload, so we need to translate it
-      [FBSDKBasicUtility dictionary:results
-                          setObject:webResponseParameters[FBSDK_SHARE_WEB_PARAM_POST_ID_KEY]
-                             forKey:FBSDK_SHARE_RESULT_POST_ID_KEY];
-      [self _invokeDelegateDidCompleteWithResults:results];
+      [self _invokeDelegateDidCompleteWithResults:@{}];
     }
   }
 }
@@ -686,11 +681,7 @@ static inline void FBSDKShareDialogValidateShareExtensionSchemeRegisteredForCanO
     } else if (response.error) {
       [self _invokeDelegateDidFailWithError:response.error];
     } else {
-      NSMutableDictionary *results = [[NSMutableDictionary alloc] init];
-      [FBSDKBasicUtility dictionary:results
-                          setObject:responseParameters[FBSDK_SHARE_RESULT_POST_ID_KEY]
-                             forKey:FBSDK_SHARE_RESULT_POST_ID_KEY];
-      [self _invokeDelegateDidCompleteWithResults:results];
+      [self _invokeDelegateDidCompleteWithResults:@{}];
     }
     [FBSDKInternalUtility unregisterTransientObject:self];
   };

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKShareDefines.h
@@ -27,7 +27,6 @@
 #define FBSDK_SHARE_RESULT_COMPLETION_GESTURE_VALUE_POST @"post"
 #define FBSDK_SHARE_RESULT_DID_COMPLETE_KEY @"didComplete"
 #define FBSDK_SHARE_RESULT_PHOTO_IDS_KEY @"photo_ids"
-#define FBSDK_SHARE_RESULT_POST_ID_KEY @"postId"
 #define FBSDK_SHARE_VIDEO_END_OFFSET @"end_offset"
 #define FBSDK_SHARE_VIDEO_FILE_CHUNK @"video_file_chunk"
 #define FBSDK_SHARE_VIDEO_ID @"video_id"


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Sharing using the publish_actions permission has been deprecated for some time. Thus having a helper class to use this permission is not helpful to the vast majority of developers. Deprecating it.

Additionally returning the postID was deprecated server-side some time ago but we still have code to check for it.  Removing that code as it will never succeed.

## Test Plan

Test Plan: Should still be able to access the symbol FBSDKShareApi but should see a deprecation warning.
