### PR TITLE
Adding client_id to oauth/access_token:fb_extend_sso_token

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/Network/FBSDKGraphRequestPiggybackManager.m
@@ -52,6 +52,7 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
   __block NSString *tokenString = nil;
   __block NSNumber *expirationDateNumber = nil;
   __block NSNumber *dataAccessExpirationDateNumber = nil;
+  __block NSString *graphDomain = nil;
   __block int expectingCallbacksCount = 2;
   void (^expectingCallbackComplete)(void) = ^{
     if (--expectingCallbacksCount == 0) {
@@ -77,7 +78,7 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
                                                                         expirationDate:expirationDate
                                                                            refreshDate:[NSDate date]
                                                                            dataAccessExpirationDate:dataExpirationDate
-                                                                           graphDomain:currentToken.graphDomain];
+                                                                           graphDomain:graphDomain ?: currentToken.graphDomain];
       if (expectedToken == currentToken) {
         [FBSDKAccessToken setCurrentAccessToken:refreshedToken];
       }
@@ -85,7 +86,8 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
   };
   FBSDKGraphRequest *extendRequest = [[FBSDKGraphRequest alloc] initWithGraphPath:@"oauth/access_token"
                                                                  parameters:@{@"grant_type" : @"fb_extend_sso_token",
-                                                                              @"fields": @""
+                                                                              @"fields": @"",
+                                                                              @"client_id": expectedToken.appID
                                                                               }
                                                                       flags:FBSDKGraphRequestFlagDisableErrorRecovery];
 
@@ -93,6 +95,7 @@ static int const FBSDKTokenRefreshRetrySeconds = 60 * 60;           // hour
     tokenString = result[@"access_token"];
     expirationDateNumber = result[@"expires_at"];
     dataAccessExpirationDateNumber = result[@"data_access_expiration_time"];
+    graphDomain = result[@"graph_domain"];
     expectingCallbackComplete();
   }];
   FBSDKGraphRequest *permissionsRequest = [[FBSDKGraphRequest alloc] initWithGraphPath:@"me/permissions"


### PR DESCRIPTION
Summary: Adds the ability to update the graph_domain on a AccessToken during refresh

Differential Revision: D19633162

