### PR TITLE
Fixed tvOS compile error on c++ projects

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
@@ -22,7 +22,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS
+#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Fixed compile error on tvOS c++ projects when using the _FBSDKShareKit.framework_.

## Test Plan

Simply compile a c++ project which uses the _FBSDKShareKit_ framework.
