### PR TITLE
Cleanup script for SPM Headers

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -712,6 +712,8 @@ verify_spm_headers() {
 
       echo "Verifying the following public headers are exposed to SPM for $kit:"
 
+      mkdir -p include
+
       headers=$(find . -name "*.h" -type f -not -path "./include/*" -not -path "**/Internal/*" -not -path "**/Basics/*")
       echo "$(basename ${headers} )" | sort >| headers.txt
 


### PR DESCRIPTION
Summary: Script will fail for new kits that do not have an 'include' directory.

Reviewed By: jingping2015

Differential Revision: D19755345

