### PR TITLE
Fix headers for cpp usage in tvOS projects

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
@@ -30,7 +30,9 @@
 
 #else
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppGroupContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppGroupContent.h
@@ -27,7 +27,9 @@ NS_REFINED_FOR_SWIFT;
 
 #else
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.h
@@ -22,7 +22,9 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectArguments.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectArguments.h
@@ -22,7 +22,9 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectTextures.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectTextures.h
@@ -22,7 +22,9 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h
@@ -20,13 +20,15 @@
 
 #if TARGET_OS_TV
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
-#import <FBSDKShareKit/FBSDKSharingContent.h>
 #else
 @import FBSDKCoreKit;
-#import "FBSDKSharingContent.h"
 #endif
+
+#import "FBSDKSharingContent.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
@@ -22,7 +22,9 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestContent.h
@@ -22,7 +22,9 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h
@@ -18,7 +18,9 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
@@ -22,7 +22,9 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareButton.h
@@ -22,7 +22,9 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h
@@ -18,7 +18,9 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h
@@ -19,7 +19,9 @@
 #import <Photos/Photos.h>
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h
@@ -18,7 +18,9 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
+#if defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined BUCK || defined FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #else
 @import FBSDKCoreKit;


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

tvOS projects using SPM were failing to compile if they included cpp sources. This update changes imports to use the `<FBSDKCoreKit.h>` syntax which works in all cases (cocoapods, spm, xcode)

## Test Plan

Test Plan: Create a new projects in Xcode, adds the Swift package by pointing to `https://github.com/facebook/facebook-ios-sdk/` and specifying this branch. Then import the sdk from a cpp file and make sure the projects builds for iOS and tvOS.
