### PR TITLE
Fix headers for cpp usage in tvOS projects (#1231)

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit.xcodeproj/project.pbxproj
+++ b/FBSDKLoginKit/FBSDKLoginKit.xcodeproj/project.pbxproj
@@ -199,6 +199,12 @@
 		F487DBFE231EC34B008416A9 /* FBSDKDeviceLoginManagerResult+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B9DBEF7207C04FF00662776 /* FBSDKDeviceLoginManagerResult+Internal.h */; };
 		F487DC15231EC3EF008416A9 /* FBLoginButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DC13231EC3EF008416A9 /* FBLoginButton.swift */; };
 		F487DC16231EC3EF008416A9 /* LoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F487DC14231EC3EF008416A9 /* LoginManager.swift */; };
+		F4ECC67923EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC67A23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC67B23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC67C23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC67D23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC67E23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -438,6 +444,7 @@
 		F487DC03231EC34B008416A9 /* FBSDKLoginKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKLoginKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DC13231EC3EF008416A9 /* FBLoginButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FBLoginButton.swift; sourceTree = "<group>"; };
 		F487DC14231EC3EF008416A9 /* LoginManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginManager.swift; sourceTree = "<group>"; };
+		F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKCoreKitImport.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -660,6 +667,7 @@
 		9D9DB8DB1A114E500086167B /* FBSDKLoginKit */ = {
 			isa = PBXGroup;
 			children = (
+				F4ECC66F23EE2094005DBF05 /* FBSDKCoreKitImport.h */,
 				0B9DBF08207C051800662776 /* FBSDKDeviceLoginCodeInfo.h */,
 				0B9DBF02207C051700662776 /* FBSDKDeviceLoginCodeInfo.m */,
 				0B9DBF04207C051800662776 /* FBSDKDeviceLoginManager.h */,
@@ -733,6 +741,7 @@
 				0B9DBF38207C061D00662776 /* FBSDKDeviceLoginCodeInfo.h in Headers */,
 				0B9DBF3A207C061D00662776 /* FBSDKDeviceLoginManager.h in Headers */,
 				0B9DBF3B207C061D00662776 /* FBSDKDeviceLoginManagerResult.h in Headers */,
+				F4ECC67B23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				0B9DBF7C207C211900662776 /* FBSDKCoreKit+Internal.h in Headers */,
 				0B9DBF3C207C061D00662776 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
 				F462DC0E23B958E000FFCECA /* FBSDKLoginKit.h in Headers */,
@@ -749,6 +758,7 @@
 				0B9DBF48207C07C600662776 /* FBSDKDeviceLoginCodeInfo.h in Headers */,
 				0B9DBF4A207C07C600662776 /* FBSDKDeviceLoginManager.h in Headers */,
 				0B9DBF4B207C07C600662776 /* FBSDKDeviceLoginManagerResult.h in Headers */,
+				F4ECC67C23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				0B9DBF7D207C212500662776 /* FBSDKCoreKit+Internal.h in Headers */,
 				0B9DBF4C207C07C600662776 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
 				F462DC0F23B958E100FFCECA /* FBSDKLoginKit.h in Headers */,
@@ -769,6 +779,7 @@
 				818EB4341D1A283100252851 /* FBSDKLoginConstants.h in Headers */,
 				818EB4351D1A283100252851 /* FBSDKLoginKit.h in Headers */,
 				818EB4361D1A283100252851 /* FBSDKLoginManagerLoginResult.h in Headers */,
+				F4ECC67A23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				818EB4371D1A283100252851 /* FBSDKTooltipView.h in Headers */,
 				0B9DBF01207C04FF00662776 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
 				818EB4381D1A283100252851 /* FBSDKLoginButton.h in Headers */,
@@ -792,6 +803,7 @@
 				9D03E8341A72DF5800207493 /* FBSDKLoginConstants.h in Headers */,
 				9D9DB8DF1A114E500086167B /* FBSDKLoginKit.h in Headers */,
 				9D03E8251A72D89100207493 /* FBSDKLoginManagerLoginResult.h in Headers */,
+				F4ECC67923EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				9DDFBB721A829503006C9208 /* FBSDKTooltipView.h in Headers */,
 				0B9DBF00207C04FF00662776 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
 				9D65ACA81A803FF200E375C2 /* FBSDKLoginButton.h in Headers */,
@@ -815,6 +827,7 @@
 				F483F43E233AC85F00703DE3 /* FBSDKLoginConstants.h in Headers */,
 				F483F43F233AC85F00703DE3 /* FBSDKLoginKit.h in Headers */,
 				F483F440233AC85F00703DE3 /* FBSDKLoginManagerLoginResult.h in Headers */,
+				F4ECC67E23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				F483F441233AC85F00703DE3 /* FBSDKTooltipView.h in Headers */,
 				F483F442233AC85F00703DE3 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
 				F483F443233AC85F00703DE3 /* FBSDKLoginButton.h in Headers */,
@@ -838,6 +851,7 @@
 				F487DBF4231EC34B008416A9 /* FBSDKLoginConstants.h in Headers */,
 				F487DBF5231EC34B008416A9 /* FBSDKLoginKit.h in Headers */,
 				F487DBF6231EC34B008416A9 /* FBSDKLoginManagerLoginResult.h in Headers */,
+				F4ECC67D23EE2094005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				F487DBF7231EC34B008416A9 /* FBSDKTooltipView.h in Headers */,
 				F487DBF8231EC34B008416A9 /* FBSDKDeviceLoginCodeInfo+Internal.h in Headers */,
 				F487DBF9231EC34B008416A9 /* FBSDKLoginButton.h in Headers */,

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKCoreKitImport.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKCoreKitImport.h
@@ -16,29 +16,15 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "TargetConditionals.h"
+// Importing FBSDKCoreKit is tricky due to build variants so putting it here allows us
+// to share that logic in one place.
 
-#if !TARGET_OS_TV
-
-#import <UIKit/UIKit.h>
-
-#import "FBSDKCoreKitImport.h"
-
-#import "FBSDKSharingButton.h"
-
-NS_ASSUME_NONNULL_BEGIN
-
-/**
-  A button to share content.
-
- Tapping the receiver will invoke the FBSDKShareDialog with the attached shareContent.  If the dialog cannot
- be shown, the button will be disabled.
- */
-NS_SWIFT_NAME(FBShareButton)
-@interface FBSDKShareButton : FBSDKButton <FBSDKSharingButton>
-
-@end
-
-NS_ASSUME_NONNULL_END
-
+#if defined BUCK
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+#elif defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined FBSDKCOCOAPODS
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+#else
+@import FBSDKCoreKit;
 #endif

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
@@ -30,11 +30,7 @@
 
 #else
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKLoginManager.h"
 #import "FBSDKTooltipView.h"

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginKit.h
@@ -18,6 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
+#import "FBSDKCoreKitImport.h"
 #import "FBSDKDeviceLoginCodeInfo.h"
 #import "FBSDKDeviceLoginManager.h"
 #import "FBSDKDeviceLoginManagerResult.h"

--- a/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKCoreKitImport.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/include/FBSDKCoreKitImport.h
@@ -1,0 +1,1 @@
+../FBSDKCoreKitImport.h

--- a/FBSDKShareKit/FBSDKShareKit.xcodeproj/project.pbxproj
+++ b/FBSDKShareKit/FBSDKShareKit.xcodeproj/project.pbxproj
@@ -427,6 +427,12 @@
 		F4E751B623EA57940061BBFC /* FBSDKSendButton.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E7517623EA19010061BBFC /* FBSDKSendButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F4E751B723EA579B0061BBFC /* FBSDKMessageDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E7517323EA19000061BBFC /* FBSDKMessageDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F4E751B823EA579C0061BBFC /* FBSDKMessageDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = F4E7517323EA19000061BBFC /* FBSDKMessageDialog.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC66923EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC66A23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC66B23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC66C23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC66D23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4ECC66E23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -726,6 +732,7 @@
 		F4E7517623EA19010061BBFC /* FBSDKSendButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKSendButton.h; sourceTree = "<group>"; };
 		F4E7518F23EA1A130061BBFC /* FBSDKMessengerIcon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKMessengerIcon.h; sourceTree = "<group>"; };
 		F4E7519023EA1A130061BBFC /* FBSDKMessengerIcon.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKMessengerIcon.m; sourceTree = "<group>"; };
+		F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKCoreKitImport.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1035,6 +1042,7 @@
 		9D46C5F21A11E5D800A0DDB6 /* FBSDKShareKit */ = {
 			isa = PBXGroup;
 			children = (
+				F4ECC65F23EE2065005DBF05 /* FBSDKCoreKitImport.h */,
 				F4E7517323EA19000061BBFC /* FBSDKMessageDialog.h */,
 				F4E7517523EA19010061BBFC /* FBSDKMessageDialog.m */,
 				F4E7517623EA19010061BBFC /* FBSDKSendButton.h */,
@@ -1119,6 +1127,7 @@
 				8144D9091D261D2900C8E4AC /* FBSDKDeviceShareButton.h in Headers */,
 				B3D17FF4212CD046000D28D6 /* FBSDKSharingValidation.h in Headers */,
 				8144D90B1D261D2900C8E4AC /* FBSDKSharingContent.h in Headers */,
+				F4ECC66C23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				8144D90C1D261D2900C8E4AC /* FBSDKSharing.h in Headers */,
 				883644BD1F969CA800124BCB /* FBSDKShareMediaContent.h in Headers */,
 				8144D90D1D261D2900C8E4AC /* FBSDKShareKit.h in Headers */,
@@ -1143,6 +1152,7 @@
 				81A07F161D1A2E6A0041A29C /* FBSDKLiking.h in Headers */,
 				81A07F171D1A2E6A0041A29C /* FBSDKShareDefines.h in Headers */,
 				81A07F181D1A2E6A0041A29C /* FBSDKGameRequestDialog.h in Headers */,
+				F4ECC66A23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				81A07F191D1A2E6A0041A29C /* FBSDKLikeObjectType.h in Headers */,
 				81A07F1A1D1A2E6A0041A29C /* FBSDKShareConstants.h in Headers */,
 				81A07F1B1D1A2E6A0041A29C /* FBSDKSharingContent.h in Headers */,
@@ -1194,6 +1204,7 @@
 				9D9E16B41CB46E8F00C8B68F /* FBSDKDeviceShareButton.h in Headers */,
 				B3D17FF3212CD046000D28D6 /* FBSDKSharingValidation.h in Headers */,
 				9D2D99B41BC4543300929E76 /* FBSDKSharingContent.h in Headers */,
+				F4ECC66B23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				9D2D99BD1BC4563A00929E76 /* FBSDKSharing.h in Headers */,
 				883644BC1F969CA700124BCB /* FBSDKShareMediaContent.h in Headers */,
 				9D2D999F1BC4538300929E76 /* FBSDKShareKit.h in Headers */,
@@ -1218,6 +1229,7 @@
 				89688B561AA63A2900A98519 /* FBSDKLiking.h in Headers */,
 				8904148B1A648DFA00617215 /* FBSDKShareDefines.h in Headers */,
 				89F203841AA9255B0053499E /* FBSDKGameRequestDialog.h in Headers */,
+				F4ECC66923EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				89D05A701A9FE02400609300 /* FBSDKLikeObjectType.h in Headers */,
 				893774891A3B5B9A00BE2807 /* FBSDKShareConstants.h in Headers */,
 				8973B37D1A40A93D0001EDC5 /* FBSDKSharingContent.h in Headers */,
@@ -1268,6 +1280,7 @@
 				F483F495233AC91700703DE3 /* FBSDKLiking.h in Headers */,
 				F483F496233AC91700703DE3 /* FBSDKShareDefines.h in Headers */,
 				F483F497233AC91700703DE3 /* FBSDKGameRequestDialog.h in Headers */,
+				F4ECC66E23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				F483F498233AC91700703DE3 /* FBSDKLikeObjectType.h in Headers */,
 				F483F499233AC91700703DE3 /* FBSDKShareConstants.h in Headers */,
 				F483F49A233AC91700703DE3 /* FBSDKSharingContent.h in Headers */,
@@ -1318,6 +1331,7 @@
 				F487DC51231EC4CC008416A9 /* FBSDKLiking.h in Headers */,
 				F487DC52231EC4CC008416A9 /* FBSDKShareDefines.h in Headers */,
 				F487DC53231EC4CC008416A9 /* FBSDKGameRequestDialog.h in Headers */,
+				F4ECC66D23EE2065005DBF05 /* FBSDKCoreKitImport.h in Headers */,
 				F487DC54231EC4CC008416A9 /* FBSDKLikeObjectType.h in Headers */,
 				F487DC55231EC4CC008416A9 /* FBSDKShareConstants.h in Headers */,
 				F487DC56231EC4CC008416A9 /* FBSDKSharingContent.h in Headers */,

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppGroupContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppGroupContent.h
@@ -27,11 +27,7 @@ NS_REFINED_FOR_SWIFT;
 
 #else
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKAppInviteContent.h
@@ -22,11 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKSharingValidation.h"
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectArguments.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectArguments.h
@@ -22,11 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectTextures.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCameraEffectTextures.h
@@ -22,11 +22,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCoreKitImport.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCoreKitImport.h
@@ -16,29 +16,15 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#import "TargetConditionals.h"
+// Importing FBSDKCoreKit is tricky due to build variants so putting it here allows us
+// to share that logic in one place.
 
-#if !TARGET_OS_TV
-
-#import <UIKit/UIKit.h>
-
-#import "FBSDKCoreKitImport.h"
-
-#import "FBSDKSharingButton.h"
-
-NS_ASSUME_NONNULL_BEGIN
-
-/**
-  A button to share content.
-
- Tapping the receiver will invoke the FBSDKShareDialog with the attached shareContent.  If the dialog cannot
- be shown, the button will be disabled.
- */
-NS_SWIFT_NAME(FBShareButton)
-@interface FBSDKShareButton : FBSDKButton <FBSDKSharingButton>
-
-@end
-
-NS_ASSUME_NONNULL_END
-
+#if defined BUCK
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+#elif defined __cplusplus
+#import <FBSDKCoreKit.h>
+#elif defined FBSDKCOCOAPODS
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+#else
+@import FBSDKCoreKit;
 #endif

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareButton.h
@@ -20,13 +20,9 @@
 
 #if TARGET_OS_TV
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#import <FBSDKShareKit/FBSDKSharingContent.h>
-#else
-@import FBSDKCoreKit;
+#import "FBSDKCoreKitImport.h"
+
 #import "FBSDKSharingContent.h"
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKDeviceShareViewController.h
@@ -22,11 +22,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKSharingContent.h"
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestContent.h
@@ -22,11 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKSharingValidation.h"
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKHashtag.h
@@ -18,11 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
@@ -22,11 +22,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKShareConstants.h"
 #import "FBSDKSharingButton.h"

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharePhoto.h
@@ -18,11 +18,7 @@
 
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKShareMediaContent.h"
 #import "FBSDKSharingValidation.h"

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareVideo.h
@@ -19,11 +19,7 @@
 #import <Photos/Photos.h>
 #import <UIKit/UIKit.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKShareMediaContent.h"
 #import "FBSDKSharingValidation.h"

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharingContent.h
@@ -18,11 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS || defined __cplusplus
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
+#import "FBSDKCoreKitImport.h"
 
 #import "FBSDKSharingValidation.h"
 

--- a/FBSDKShareKit/FBSDKShareKit/include/FBSDKCoreKitImport.h
+++ b/FBSDKShareKit/FBSDKShareKit/include/FBSDKCoreKitImport.h
@@ -1,0 +1,1 @@
+../FBSDKCoreKitImport.h


### PR DESCRIPTION
Summary:
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

tvOS projects using SPM were failing to compile if they included cpp sources. This update changes imports to use the `<FBSDKCoreKit.h>` syntax which works in all cases (cocoapods, spm, xcode)
Pull Request resolved: https://github.com/facebook/facebook-ios-sdk/pull/1231

Test Plan: Create a new projects in Xcode, adds the Swift package by pointing to `https://github.com/facebook/facebook-ios-sdk/` and specifying this branch. Then import the sdk from a cpp file and make sure the projects builds for iOS and tvOS.