### PR TITLE
Ensure fb.gg graph domain override only affect graph. domains

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -144,6 +144,7 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift)
   }
 
   NSString *host =
+  [hostPrefix isEqualToString:@"graph."] &&
   [[FBSDKAccessToken currentAccessToken].graphDomain isEqualToString:@"gaming"]
   ? @"fb.gg"
   : @"facebook.com";


### PR DESCRIPTION
Summary: When the graph domain is set to 'Gaming' and the SDK attempts to link to mSite, it fails as we are blanket overriding all URLs that are generated. This adds a check to ensure that the URL being generated starts with 'graph.'

Reviewed By: joesus

Differential Revision: D19817928

