### PR TITLE
PlacesKit Attribution

### DIFF
--- a/FBSDKPlacesKit/FBSDKPlacesKit/FBSDKPlacesManager.m
+++ b/FBSDKPlacesKit/FBSDKPlacesKit/FBSDKPlacesManager.m
@@ -20,9 +20,11 @@
 
 #import <SystemConfiguration/CaptiveNetwork.h>
 
+#import "FBSDKCoreKit+Internal.h"
 #import "FBSDKPlacesBluetoothScanner.h"
 
 static NSString *const ParameterKeyFields = @"fields";
+static FBSDKAppEventName const FBSDKPlacesKitInitialized = @"FBSDKPlacesKitInitialized";
 
 typedef void (^FBSDKLocationRequestCompletion)(CLLocation *_Nullable location, NSError *_Nullable error);
 
@@ -46,6 +48,11 @@ typedef void (^FBSDKLocationRequestCompletion)(CLLocation *_Nullable location, N
     _locationCompletionBlocks = [NSMutableArray new];
     _bluetoothScanner = [FBSDKPlacesBluetoothScanner new];
   }
+
+  [FBSDKAppEvents logInternalEvent:FBSDKPlacesKitInitialized
+                        parameters:@{}
+                isImplicitlyLogged:true];
+
   return self;
 }
 


### PR DESCRIPTION
Summary: Attempting to attribute hits to the graphAPI to FBSDKPlacesKit. This will let us know the percentage of hits to various places related endpoints that are coming from PlacesKit vs CoreKit.

Reviewed By: KylinChang

Differential Revision: D19818473

