### PR TITLE
refactor FBSDKAddressInferencer and FBSDKEventInferencer to have shared weights parse logic in FBSDKModelParser

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -870,6 +870,14 @@
 		C5D25D3921795B790037B13D /* FBSDKCodelessIndexer.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */; };
 		C5DFB84322CBC1EB0086E16C /* FBSDKTypeUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4B3E32276B88600CA3706 /* FBSDKTypeUtility.h */; };
 		C5F6EC861FA24FAF009EB258 /* FBSDKPaymentObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */; };
+		E4416C0123F61902009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C0223F61902009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E4416C1323F61911009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C1423F61913009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C1523F61914009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C1623F61917009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E4416C1723F61918009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E4416C1823F61919009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
 		E4C2B97A23867327002335A4 /* FBSDKModelRuntimeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */; };
 		F462DBF023B94C0F00FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
 		F462DBF123B94C1000FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
@@ -1848,6 +1856,8 @@
 		C5D25D3421795B790037B13D /* FBSDKCodelessIndexer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKCodelessIndexer.h; sourceTree = "<group>"; };
 		C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKCodelessIndexer.m; sourceTree = "<group>"; };
 		C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKPaymentObserverTests.m; sourceTree = "<group>"; };
+		E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKModelParser.h; sourceTree = "<group>"; };
+		E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelParser.mm; sourceTree = "<group>"; };
 		E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelRuntimeTests.mm; sourceTree = "<group>"; };
 		F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DBB9231EBCD2008416A9 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2081,6 +2091,8 @@
 				FD9E155B23777AF700A005EC /* FBSDKStandaloneModel.hpp */,
 				FDAF4A7D2395D1DE00711C4C /* FBSDKModelUtility.h */,
 				FDAF4A8C2395D21700711C4C /* FBSDKModelUtility.m */,
+				E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */,
+				E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */,
 			);
 			path = ML;
 			sourceTree = "<group>";
@@ -2614,6 +2626,7 @@
 				9D9947291A9531B5003375EC /* OCMockLibTests.xctest */,
 				52279E562150732600F31455 /* OCMock.framework */,
 				52279E582150732600F31455 /* OCMock.framework */,
+				E4416C0B23F61903009CCBFA /* OCMock.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2953,6 +2966,7 @@
 				81B71D611D19C87400933E93 /* FBSDKErrorRecoveryAttempter.h in Headers */,
 				81B71D621D19C87400933E93 /* FBSDKPaymentObserver.h in Headers */,
 				BFC02450237B6B7900A596EE /* FBSDKEventInferencer.h in Headers */,
+				E4416C1323F61911009CCBFA /* FBSDKModelParser.h in Headers */,
 				5DB7B07D230363190012E8CB /* FBSDKInstrumentManager.h in Headers */,
 				81B71D631D19C87400933E93 /* FBSDKProfile+Internal.h in Headers */,
 				5D41131F229F27DD002FF65A /* FBSDKRestrictiveDataFilterManager.h in Headers */,
@@ -3089,6 +3103,7 @@
 				89FB8C4A1A842A8A003CAE60 /* FBSDKWebDialogView.h in Headers */,
 				5DB7B07C230363190012E8CB /* FBSDKInstrumentManager.h in Headers */,
 				8917C4AD1B7A46C800B0B96B /* FBSDKServerConfiguration+Internal.h in Headers */,
+				E4416C0123F61902009CCBFA /* FBSDKModelParser.h in Headers */,
 				89D05A951AA0E89B00609300 /* FBSDKTriStateBOOL.h in Headers */,
 				5D41131E229F27DD002FF65A /* FBSDKRestrictiveDataFilterManager.h in Headers */,
 				89D652841A855A6000BB651C /* FBSDKCloseIcon.h in Headers */,
@@ -3448,6 +3463,7 @@
 				5D90CDEB2343D4D200AF326A /* FBSDKCrashShield.h in Headers */,
 				F483F40C233AC13000703DE3 /* FBSDKAccessTokenCache.h in Headers */,
 				F483F40D233AC13000703DE3 /* FBSDKCrashObserving.h in Headers */,
+				E4416C1523F61914009CCBFA /* FBSDKModelParser.h in Headers */,
 				F483F40E233AC13000703DE3 /* FBSDKAppLinkNavigation.h in Headers */,
 				F483F40F233AC13000703DE3 /* (null) in Headers */,
 			);
@@ -3585,6 +3601,7 @@
 				5D90CDEA2343D4D200AF326A /* FBSDKCrashShield.h in Headers */,
 				F487DBB2231EBCD2008416A9 /* FBSDKAccessTokenCache.h in Headers */,
 				5D9A703E23261D4E00BF9783 /* FBSDKCrashObserving.h in Headers */,
+				E4416C1423F61913009CCBFA /* FBSDKModelParser.h in Headers */,
 				F487DBB3231EBCD2008416A9 /* FBSDKAppLinkNavigation.h in Headers */,
 				F487DBB4231EBCD2008416A9 /* (null) in Headers */,
 			);
@@ -3962,6 +3979,13 @@
 			remoteRef = ADEA17811B7ECA1A0070EDC0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		E4416C0B23F61903009CCBFA /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = E4416C0A23F61903009CCBFA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -4273,6 +4297,7 @@
 				81B71D2F1D19C87400933E93 /* FBSDKColor.m in Sources */,
 				81B71D301D19C87400933E93 /* FBSDKAppLinkResolver.m in Sources */,
 				81B71D311D19C87400933E93 /* FBSDKIcon.m in Sources */,
+				E4416C1623F61917009CCBFA /* FBSDKModelParser.mm in Sources */,
 				5D90CDE02343D4BD00AF326A /* FBSDKCrashShield.m in Sources */,
 				81B71D321D19C87400933E93 /* FBSDKConstants.m in Sources */,
 				81B71D331D19C87400933E93 /* FBSDKAppEventsUtility.m in Sources */,
@@ -4383,6 +4408,7 @@
 				BFC02449237B6A9A00A596EE /* FBSDKEventInferencer.mm in Sources */,
 				C5C4B3F32276B88600CA3706 /* FBSDKTypeUtility.m in Sources */,
 				9DBA6A311A80265A00B4DE6A /* FBSDKColor.m in Sources */,
+				E4416C0223F61902009CCBFA /* FBSDKModelParser.mm in Sources */,
 				7E5557371A8D833100344F86 /* FBSDKAppLinkResolver.m in Sources */,
 				891687D31AB33CA200F55364 /* FBSDKIcon.m in Sources */,
 				5D90CDDF2343D4BD00AF326A /* FBSDKCrashShield.m in Sources */,
@@ -4604,6 +4630,7 @@
 				F483F33C233AC13000703DE3 /* FBSDKCloseIcon.m in Sources */,
 				F483F33E233AC13000703DE3 /* FBSDKWebViewAppLinkResolver.m in Sources */,
 				F483F33F233AC13000703DE3 /* FBSDKRestrictiveDataFilterManager.m in Sources */,
+				E4416C1823F61919009CCBFA /* FBSDKModelParser.mm in Sources */,
 				F483F340233AC13000703DE3 /* FBSDKBase64.m in Sources */,
 				F483F341233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV2.m in Sources */,
 				F483F342233AC13000703DE3 /* FBSDKGraphRequestBody.m in Sources */,
@@ -4718,6 +4745,7 @@
 				F487DAE8231EBCD2008416A9 /* FBSDKCloseIcon.m in Sources */,
 				F487DAE9231EBCD2008416A9 /* FBSDKWebViewAppLinkResolver.m in Sources */,
 				F487DAEA231EBCD2008416A9 /* FBSDKRestrictiveDataFilterManager.m in Sources */,
+				E4416C1723F61918009CCBFA /* FBSDKModelParser.mm in Sources */,
 				F487DAEB231EBCD2008416A9 /* FBSDKBase64.m in Sources */,
 				F487DAEC231EBCD2008416A9 /* FBSDKBridgeAPIProtocolWebV2.m in Sources */,
 				F487DAED231EBCD2008416A9 /* FBSDKGraphRequestBody.m in Sources */,

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.m
@@ -93,6 +93,7 @@ static NSMutableDictionary<NSString *, id> *_modelInfo;
           }];
         }
       }];
+
       [FBSDKFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:^(BOOL enabled) {
         if (enabled) {
           [self getModelAndRules:ADDRESS_FILTERING_KEY handler:^(BOOL success){

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TargetConditionals.h"
+
+#if !TARGET_OS_TV
+
+#import <Foundation/Foundation.h>
+
+#import "FBSDKStandaloneModel.hpp"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBSDKModelParser : NSObject
+
++ (std::unordered_map<std::string, mat::MTensor>)parseWeightsData:(NSData *)weightsData;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.mm
@@ -1,0 +1,107 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TargetConditionals.h"
+
+#if !TARGET_OS_TV
+
+#import "FBSDKModelParser.h"
+using mat::MTensor;
+using std::string;
+using std::unordered_map;
+
+static NSDictionary<NSString *, NSString *> *const KEYS_MAPPING = @{@"embedding.weight": @"embed.weight",
+                                                                    @"dense1.weight": @"fc1.weight",
+                                                                    @"dense2.weight": @"fc2.weight",
+                                                                    @"dense3.weight": @"fc3.weight",
+                                                                    @"dense1.bias": @"fc1.bias",
+                                                                    @"dense2.bias": @"fc2.bias",
+                                                                    @"dense3.bias": @"fc3.bias"};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation FBSDKModelParser
+
++ (unordered_map<string, MTensor>)parseWeightsData:(NSData *)weightsData {
+  unordered_map<string,  MTensor> weights;
+
+  const void *data = weightsData.bytes;
+  NSUInteger totalLength =  weightsData.length;
+
+  if (totalLength < 4) {
+    // Make sure data length is valid
+    return weights;
+  }
+  try {
+    int length;
+    memcpy(&length, data, 4);
+    if (length + 4 > totalLength) {
+      // Make sure data length is valid
+      return weights;
+    }
+
+    char *json = (char *)data + 4;
+    NSDictionary<NSString *, id> *info = [NSJSONSerialization JSONObjectWithData:[NSData dataWithBytes:json length:length]
+                                                                         options:0
+                                                                           error:nil];
+    NSArray<NSString *> *keys = [[info allKeys] sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
+      return [key1 compare:key2];
+    }];
+
+    int totalFloats = 0;
+    float *floats = (float *)(json + length);
+    for (NSString *key in keys) {
+      NSString *finalKey = key;
+      NSString *mapping = [KEYS_MAPPING objectForKey:key];
+      if (mapping) {
+        finalKey = mapping;
+      }
+      std::string s_name([finalKey UTF8String]);
+
+      std::vector<int64_t> v_shape;
+      NSArray<NSString *> *shape = [info objectForKey:key];
+      int count = 1;
+      for (NSNumber *_s in shape) {
+        int i = [_s intValue];
+        v_shape.push_back(i);
+        count *= i;
+      }
+
+      totalFloats += count;
+
+      if ((4 + length + totalFloats * 4) > totalLength) {
+        // Make sure data length is valid
+        break;
+      }
+      MTensor tensor = mat::mempty(v_shape);
+      float *tensor_data = tensor.data<float>();
+      memcpy(tensor_data, floats, sizeof(float) * count);
+      floats += count;
+
+      weights[s_name] = tensor;
+    }
+  } catch (const std::exception &e) {}
+
+  return weights;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelRuntime.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelRuntime.hpp
@@ -24,7 +24,6 @@
 #include <math.h>
 #include <stdint.h>
 #include <unordered_map>
-#include <unordered_set>
 
 #import <Accelerate/Accelerate.h>
 

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKStandaloneModel.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKStandaloneModel.hpp
@@ -144,7 +144,7 @@ namespace mat {
         std::shared_ptr<void> storage_;
     };
 
-    static MTensor mempty(const std::vector<int64_t>& sizes) {
+    static inline MTensor mempty(const std::vector<int64_t>& sizes) {
         return MTensor(sizes);
     }
 } // namespace mat

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
@@ -23,6 +23,7 @@
 #import "FBSDKAddressInferencer.h"
 
 #import "FBSDKModelManager.h"
+#import "FBSDKModelParser.h"
 #import "FBSDKModelRuntime.hpp"
 #import "FBSDKModelUtility.h"
 #import "FBSDKStandaloneModel.hpp"
@@ -45,14 +46,6 @@ static NSDictionary<NSString *, NSArray *> *const WEIGHTS_INFO = @{@"embed.weigh
                                                                     @"fc2.bias": @[@(64)],
                                                                     @"fc3.weight": @[@(2), @(64)],
                                                                     @"fc3.bias": @[@(2)]};
-
-static NSDictionary<NSString *, NSString *> *const WEIGHTS_KEYS = @{@"embedding.weight": @"embed.weight",
-                                                                    @"dense1.weight": @"fc1.weight",
-                                                                    @"dense2.weight": @"fc2.weight",
-                                                                    @"dense3.weight": @"fc3.weight",
-                                                                    @"dense1.bias": @"fc1.bias",
-                                                                    @"dense2.bias": @"fc2.bias",
-                                                                    @"dense3.bias": @"fc3.bias"};
 
 @implementation FBSDKAddressInferencer : NSObject
 
@@ -78,7 +71,7 @@ static std::vector<float> _denseFeature;
   if (!latestData) {
     return;
   }
-  std::unordered_map<std::string, mat::MTensor> weights = [self loadWeights:latestData];
+  std::unordered_map<std::string, mat::MTensor> weights = [FBSDKModelParser parseWeightsData:latestData];
   if ([self validateWeights:weights]) {
     _weights = weights;
   }
@@ -110,69 +103,6 @@ static std::vector<float> _denseFeature;
     return false;
   }
   return true;
-}
-
-+ (std::unordered_map<std::string, mat::MTensor>)loadWeights:(NSData *)weightsData{
-  std::unordered_map<std::string,  mat::MTensor> weights;
-
-  const void *data = weightsData.bytes;
-  NSUInteger totalLength =  weightsData.length;
-
-  int totalFloats = 0;
-  if (weightsData.length < 4) {
-    // Make sure data length is valid
-    return weights;
-  }
-  try {
-    int length;
-    memcpy(&length, data, 4);
-    if (length + 4 > totalLength) {
-      // Make sure data length is valid
-      return weights;
-    }
-
-    char *json = (char *)data + 4;
-    NSDictionary<NSString *, id> *info = [NSJSONSerialization JSONObjectWithData:[NSData dataWithBytes:json length:length]
-                                                                         options:0
-                                                                           error:nil];
-    NSArray<NSString *> *keys = [[info allKeys] sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
-      return [key1 compare:key2];
-    }];
-
-    float *floats = (float *)(json + length);
-    for (NSString *key in keys) {
-      NSString *finalKey = key;
-      NSString *mapping = [WEIGHTS_KEYS objectForKey:key];
-      if (mapping) {
-        finalKey = mapping;
-      }
-      std::string s_name([finalKey UTF8String]);
-
-      std::vector<int64_t> v_shape;
-      NSArray<NSString *> *shape = [info objectForKey:key];
-      int count = 1;
-      for (NSNumber *_s in shape) {
-        int i = [_s intValue];
-        v_shape.push_back(i);
-        count *= i;
-      }
-
-      totalFloats += count;
-
-      if ((4 + length + totalFloats * 4) > totalLength) {
-        // Make sure data length is valid
-        break;
-      }
-      mat::MTensor tensor = mat::mempty(v_shape);
-      float *tensor_data = tensor.data<float>();
-      memcpy(tensor_data, floats, sizeof(float) * count);
-      floats += count;
-
-      weights[s_name] = tensor;
-    }
-  } catch (const std::exception &e) {}
-
-  return weights;
 }
 
 + (BOOL)shouldFilterParam:(nullable NSString *)param


### PR DESCRIPTION
Summary: FBSDKAddressInferencer and FBSDKEventInferencer have very similar logic to parse weight file except key mapping, the duplicated code adds more potential bugs, maintainence and iteration effort, so consolidate the logic in FBSDKModelParser

Differential Revision: D19919417

