### PR TITLE
move dispatch_once outside of ModelManager and add more tests

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -870,6 +870,14 @@
 		C5D25D3921795B790037B13D /* FBSDKCodelessIndexer.m in Sources */ = {isa = PBXBuildFile; fileRef = C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */; };
 		C5DFB84322CBC1EB0086E16C /* FBSDKTypeUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = C5C4B3E32276B88600CA3706 /* FBSDKTypeUtility.h */; };
 		C5F6EC861FA24FAF009EB258 /* FBSDKPaymentObserverTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */; };
+		E4416C0123F61902009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C0223F61902009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E4416C1323F61911009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C1423F61913009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C1523F61914009CCBFA /* FBSDKModelParser.h in Headers */ = {isa = PBXBuildFile; fileRef = E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */; };
+		E4416C1623F61917009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E4416C1723F61918009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E4416C1823F61919009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
 		E4C2B97A23867327002335A4 /* FBSDKModelRuntimeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */; };
 		F462DBF023B94C0F00FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
 		F462DBF123B94C1000FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
@@ -1528,6 +1536,13 @@
 			remoteGlobalIDString = C5C4B3BE2276B67200CA3706;
 			remoteInfo = FBSDKCoreKit_Basics_TV;
 		};
+		E4416C0A23F61903009CCBFA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9D99470F1A9531B5003375EC /* OCMock.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 8DE97CA022B43EE60098C63F;
+			remoteInfo = "OCMock watchOS";
+		};
 		F410D0332370CBC2005B9318 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9D26973E1A5DF40700143BFC /* Project object */;
@@ -1848,6 +1863,8 @@
 		C5D25D3421795B790037B13D /* FBSDKCodelessIndexer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKCodelessIndexer.h; sourceTree = "<group>"; };
 		C5D25D3521795B790037B13D /* FBSDKCodelessIndexer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKCodelessIndexer.m; sourceTree = "<group>"; };
 		C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKPaymentObserverTests.m; sourceTree = "<group>"; };
+		E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKModelParser.h; sourceTree = "<group>"; };
+		E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelParser.mm; sourceTree = "<group>"; };
 		E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelRuntimeTests.mm; sourceTree = "<group>"; };
 		F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DBB9231EBCD2008416A9 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2081,6 +2098,8 @@
 				FD9E155B23777AF700A005EC /* FBSDKStandaloneModel.hpp */,
 				FDAF4A7D2395D1DE00711C4C /* FBSDKModelUtility.h */,
 				FDAF4A8C2395D21700711C4C /* FBSDKModelUtility.m */,
+				E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */,
+				E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */,
 			);
 			path = ML;
 			sourceTree = "<group>";
@@ -2614,6 +2633,7 @@
 				9D9947291A9531B5003375EC /* OCMockLibTests.xctest */,
 				52279E562150732600F31455 /* OCMock.framework */,
 				52279E582150732600F31455 /* OCMock.framework */,
+				E4416C0B23F61903009CCBFA /* OCMock.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2953,6 +2973,7 @@
 				81B71D611D19C87400933E93 /* FBSDKErrorRecoveryAttempter.h in Headers */,
 				81B71D621D19C87400933E93 /* FBSDKPaymentObserver.h in Headers */,
 				BFC02450237B6B7900A596EE /* FBSDKEventInferencer.h in Headers */,
+				E4416C1323F61911009CCBFA /* FBSDKModelParser.h in Headers */,
 				5DB7B07D230363190012E8CB /* FBSDKInstrumentManager.h in Headers */,
 				81B71D631D19C87400933E93 /* FBSDKProfile+Internal.h in Headers */,
 				5D41131F229F27DD002FF65A /* FBSDKRestrictiveDataFilterManager.h in Headers */,
@@ -3089,6 +3110,7 @@
 				89FB8C4A1A842A8A003CAE60 /* FBSDKWebDialogView.h in Headers */,
 				5DB7B07C230363190012E8CB /* FBSDKInstrumentManager.h in Headers */,
 				8917C4AD1B7A46C800B0B96B /* FBSDKServerConfiguration+Internal.h in Headers */,
+				E4416C0123F61902009CCBFA /* FBSDKModelParser.h in Headers */,
 				89D05A951AA0E89B00609300 /* FBSDKTriStateBOOL.h in Headers */,
 				5D41131E229F27DD002FF65A /* FBSDKRestrictiveDataFilterManager.h in Headers */,
 				89D652841A855A6000BB651C /* FBSDKCloseIcon.h in Headers */,
@@ -3448,6 +3470,7 @@
 				5D90CDEB2343D4D200AF326A /* FBSDKCrashShield.h in Headers */,
 				F483F40C233AC13000703DE3 /* FBSDKAccessTokenCache.h in Headers */,
 				F483F40D233AC13000703DE3 /* FBSDKCrashObserving.h in Headers */,
+				E4416C1523F61914009CCBFA /* FBSDKModelParser.h in Headers */,
 				F483F40E233AC13000703DE3 /* FBSDKAppLinkNavigation.h in Headers */,
 				F483F40F233AC13000703DE3 /* (null) in Headers */,
 			);
@@ -3585,6 +3608,7 @@
 				5D90CDEA2343D4D200AF326A /* FBSDKCrashShield.h in Headers */,
 				F487DBB2231EBCD2008416A9 /* FBSDKAccessTokenCache.h in Headers */,
 				5D9A703E23261D4E00BF9783 /* FBSDKCrashObserving.h in Headers */,
+				E4416C1423F61913009CCBFA /* FBSDKModelParser.h in Headers */,
 				F487DBB3231EBCD2008416A9 /* FBSDKAppLinkNavigation.h in Headers */,
 				F487DBB4231EBCD2008416A9 /* (null) in Headers */,
 			);
@@ -3962,6 +3986,13 @@
 			remoteRef = ADEA17811B7ECA1A0070EDC0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		E4416C0B23F61903009CCBFA /* OCMock.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = OCMock.framework;
+			remoteRef = E4416C0A23F61903009CCBFA /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -4273,6 +4304,7 @@
 				81B71D2F1D19C87400933E93 /* FBSDKColor.m in Sources */,
 				81B71D301D19C87400933E93 /* FBSDKAppLinkResolver.m in Sources */,
 				81B71D311D19C87400933E93 /* FBSDKIcon.m in Sources */,
+				E4416C1623F61917009CCBFA /* FBSDKModelParser.mm in Sources */,
 				5D90CDE02343D4BD00AF326A /* FBSDKCrashShield.m in Sources */,
 				81B71D321D19C87400933E93 /* FBSDKConstants.m in Sources */,
 				81B71D331D19C87400933E93 /* FBSDKAppEventsUtility.m in Sources */,
@@ -4383,6 +4415,7 @@
 				BFC02449237B6A9A00A596EE /* FBSDKEventInferencer.mm in Sources */,
 				C5C4B3F32276B88600CA3706 /* FBSDKTypeUtility.m in Sources */,
 				9DBA6A311A80265A00B4DE6A /* FBSDKColor.m in Sources */,
+				E4416C0223F61902009CCBFA /* FBSDKModelParser.mm in Sources */,
 				7E5557371A8D833100344F86 /* FBSDKAppLinkResolver.m in Sources */,
 				891687D31AB33CA200F55364 /* FBSDKIcon.m in Sources */,
 				5D90CDDF2343D4BD00AF326A /* FBSDKCrashShield.m in Sources */,
@@ -4604,6 +4637,7 @@
 				F483F33C233AC13000703DE3 /* FBSDKCloseIcon.m in Sources */,
 				F483F33E233AC13000703DE3 /* FBSDKWebViewAppLinkResolver.m in Sources */,
 				F483F33F233AC13000703DE3 /* FBSDKRestrictiveDataFilterManager.m in Sources */,
+				E4416C1823F61919009CCBFA /* FBSDKModelParser.mm in Sources */,
 				F483F340233AC13000703DE3 /* FBSDKBase64.m in Sources */,
 				F483F341233AC13000703DE3 /* FBSDKBridgeAPIProtocolWebV2.m in Sources */,
 				F483F342233AC13000703DE3 /* FBSDKGraphRequestBody.m in Sources */,
@@ -4718,6 +4752,7 @@
 				F487DAE8231EBCD2008416A9 /* FBSDKCloseIcon.m in Sources */,
 				F487DAE9231EBCD2008416A9 /* FBSDKWebViewAppLinkResolver.m in Sources */,
 				F487DAEA231EBCD2008416A9 /* FBSDKRestrictiveDataFilterManager.m in Sources */,
+				E4416C1723F61918009CCBFA /* FBSDKModelParser.mm in Sources */,
 				F487DAEB231EBCD2008416A9 /* FBSDKBase64.m in Sources */,
 				F487DAEC231EBCD2008416A9 /* FBSDKBridgeAPIProtocolWebV2.m in Sources */,
 				F487DAED231EBCD2008416A9 /* FBSDKGraphRequestBody.m in Sources */,

--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -883,6 +883,7 @@
 		E493253023F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
 		E493253123F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
 		E493253223F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
+		E493254223FD06640000B63A /* FBSDKModelManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E493254123FD06640000B63A /* FBSDKModelManagerTests.m */; };
 		E4C2B97A23867327002335A4 /* FBSDKModelRuntimeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */; };
 		F462DBF023B94C0F00FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
 		F462DBF123B94C1000FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
@@ -1872,6 +1873,7 @@
 		E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelParser.mm; sourceTree = "<group>"; };
 		E493252C23F7C60E0000B63A /* FBSDKModelParserTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelParserTests.mm; sourceTree = "<group>"; };
 		E493252E23F9235C0000B63A /* FBSDKModelConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKModelConstants.h; sourceTree = "<group>"; };
+		E493254123FD06640000B63A /* FBSDKModelManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKModelManagerTests.m; sourceTree = "<group>"; };
 		E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelRuntimeTests.mm; sourceTree = "<group>"; };
 		F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DBB9231EBCD2008416A9 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2806,6 +2808,7 @@
 			isa = PBXGroup;
 			children = (
 				E493252C23F7C60E0000B63A /* FBSDKModelParserTests.mm */,
+				E493254123FD06640000B63A /* FBSDKModelManagerTests.m */,
 			);
 			path = ML;
 			sourceTree = "<group>";
@@ -4486,6 +4489,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E493254223FD06640000B63A /* FBSDKModelManagerTests.m in Sources */,
 				9DF18BCB1A9F2517000F6748 /* FBSDKErrorConfigurationTests.m in Sources */,
 				9D18A8E91A95495D00A41042 /* FBSDKAppEventsUtilityTests.m in Sources */,
 				7E55573C1A8D834B00344F86 /* FBSDKAppLinkResolverTests.m in Sources */,

--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -878,6 +878,11 @@
 		E4416C1623F61917009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
 		E4416C1723F61918009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
 		E4416C1823F61919009CCBFA /* FBSDKModelParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */; };
+		E493252D23F7C60E0000B63A /* FBSDKModelParserTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E493252C23F7C60E0000B63A /* FBSDKModelParserTests.mm */; };
+		E493252F23F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
+		E493253023F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
+		E493253123F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
+		E493253223F9235C0000B63A /* FBSDKModelConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = E493252E23F9235C0000B63A /* FBSDKModelConstants.h */; };
 		E4C2B97A23867327002335A4 /* FBSDKModelRuntimeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */; };
 		F462DBF023B94C0F00FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
 		F462DBF123B94C1000FFCECA /* FBSDKCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = 894C0B071A702194009137EF /* FBSDKCrypto.h */; };
@@ -1865,6 +1870,8 @@
 		C5F6EC851FA24FAF009EB258 /* FBSDKPaymentObserverTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKPaymentObserverTests.m; sourceTree = "<group>"; };
 		E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKModelParser.h; sourceTree = "<group>"; };
 		E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelParser.mm; sourceTree = "<group>"; };
+		E493252C23F7C60E0000B63A /* FBSDKModelParserTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelParserTests.mm; sourceTree = "<group>"; };
+		E493252E23F9235C0000B63A /* FBSDKModelConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKModelConstants.h; sourceTree = "<group>"; };
 		E4C2B97923867327002335A4 /* FBSDKModelRuntimeTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FBSDKModelRuntimeTests.mm; sourceTree = "<group>"; };
 		F483F414233AC13000703DE3 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DBB9231EBCD2008416A9 /* FBSDKCoreKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKCoreKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2100,6 +2107,7 @@
 				FDAF4A8C2395D21700711C4C /* FBSDKModelUtility.m */,
 				E4416BFF23F61902009CCBFA /* FBSDKModelParser.h */,
 				E4416C0023F61902009CCBFA /* FBSDKModelParser.mm */,
+				E493252E23F9235C0000B63A /* FBSDKModelConstants.h */,
 			);
 			path = ML;
 			sourceTree = "<group>";
@@ -2448,6 +2456,7 @@
 		9D18A8D91A95403F00A41042 /* AppEvents */ = {
 			isa = PBXGroup;
 			children = (
+				E493252B23F7C51D0000B63A /* ML */,
 				5DAB023A23A1B9FC005495FB /* EventDeactivation */,
 				F952EA4D2339412C00B20652 /* AAM */,
 				C51121C720A27EF50041DC94 /* Codeless */,
@@ -2793,6 +2802,14 @@
 			path = GraphAPI;
 			sourceTree = "<group>";
 		};
+		E493252B23F7C51D0000B63A /* ML */ = {
+			isa = PBXGroup;
+			children = (
+				E493252C23F7C60E0000B63A /* FBSDKModelParserTests.mm */,
+			);
+			path = ML;
+			sourceTree = "<group>";
+		};
 		F487DBCA231EBD8B008416A9 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
@@ -3025,6 +3042,7 @@
 				81B71D831D19C87400933E93 /* FBSDKDynamicFrameworkLoader.h in Headers */,
 				81B71D841D19C87400933E93 /* FBSDKKeychainStoreViaBundleID.h in Headers */,
 				81B71D851D19C87400933E93 /* FBSDKApplicationDelegate+Internal.h in Headers */,
+				E493253023F9235C0000B63A /* FBSDKModelConstants.h in Headers */,
 				81B71D861D19C87400933E93 /* FBSDKBridgeAPIRequest+Private.h in Headers */,
 				81B71D871D19C87400933E93 /* FBSDKGraphRequestConnection+Internal.h in Headers */,
 				81B71D881D19C87400933E93 /* FBSDKButton+Subclass.h in Headers */,
@@ -3162,6 +3180,7 @@
 				894C0ACE1A6F0D3F009137EF /* FBSDKApplicationDelegate+Internal.h in Headers */,
 				89D4AE861A7FFEFC00DB8C72 /* FBSDKBridgeAPIRequest+Private.h in Headers */,
 				9D69FC4F1AA66BBF0068EC76 /* FBSDKGraphRequestConnection+Internal.h in Headers */,
+				E493252F23F9235C0000B63A /* FBSDKModelConstants.h in Headers */,
 				52963A8C215992F400C7B252 /* FBSDKAppLink.h in Headers */,
 				891687FE1AB38D2300F55364 /* FBSDKButton+Subclass.h in Headers */,
 				9D30290A1A65C4420086B9ED /* FBSDKAccessToken.h in Headers */,
@@ -3377,6 +3396,7 @@
 				F483F3B7233AC13000703DE3 /* FBSDKMaleSilhouetteIcon.h in Headers */,
 				F483F3B8233AC13000703DE3 /* FBSDKCrashHandler.h in Headers */,
 				F483F3B9233AC13000703DE3 /* FBSDKCrashObserver.h in Headers */,
+				E493253223F9235C0000B63A /* FBSDKModelConstants.h in Headers */,
 				F483F3BA233AC13000703DE3 /* FBSDKMutableCopying.h in Headers */,
 				F483F3BB233AC13000703DE3 /* FBSDKTypeUtility.h in Headers */,
 				F483F3BC233AC13000703DE3 /* FBSDKSwizzler.h in Headers */,
@@ -3515,6 +3535,7 @@
 				F487DB5E231EBCD2008416A9 /* FBSDKMaleSilhouetteIcon.h in Headers */,
 				5D9A705423261D6900BF9783 /* FBSDKCrashHandler.h in Headers */,
 				5D9A709C2326EB5C00BF9783 /* FBSDKCrashObserver.h in Headers */,
+				E493253123F9235C0000B63A /* FBSDKModelConstants.h in Headers */,
 				F487DB5F231EBCD2008416A9 /* FBSDKMutableCopying.h in Headers */,
 				F487DB60231EBCD2008416A9 /* FBSDKTypeUtility.h in Headers */,
 				F487DB61231EBCD2008416A9 /* FBSDKSwizzler.h in Headers */,
@@ -4489,6 +4510,7 @@
 				5DBB0447227FEF700009E0A6 /* FBSDKBasicUtilityTests.m in Sources */,
 				F952EA4F2339432100B20652 /* FBSDKMetadataIndexerTests.m in Sources */,
 				5DB612A823593AB600150851 /* FBSDKCrashShieldTests.m in Sources */,
+				E493252D23F7C60E0000B63A /* FBSDKModelParserTests.mm in Sources */,
 				5D68D7D822BAEEF60063A3E2 /* FBSDKTimeSpentDataTests.m in Sources */,
 				9D3AF4661A9ED47900EEF724 /* FBSDKGraphRequestConnectionTests.m in Sources */,
 				C51122A020A4BCEB0041DC94 /* FBSDKApplicationDelegateTests.m in Sources */,

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
@@ -1096,7 +1096,10 @@ static dispatch_once_t *onceTokenPointer;
 #if !defined BUCK && !TARGET_OS_TV
     [FBSDKFeatureManager checkFeature:FBSDKFeaturePrivacyProtection completionBlock:^(BOOL enabled) {
       if (enabled) {
-        [FBSDKModelManager enable];
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+          [FBSDKModelManager enable];
+        });
       }
     }];
 #endif

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelConstants.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelConstants.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+static NSDictionary<NSString *, NSString *> *const KEYS_MAPPING = @{@"embedding.weight": @"embed.weight",
+                                                                    @"dense1.weight": @"fc1.weight",
+                                                                    @"dense2.weight": @"fc2.weight",
+                                                                    @"dense3.weight": @"fc3.weight",
+                                                                    @"dense1.bias": @"fc1.bias",
+                                                                    @"dense2.bias": @"fc2.bias",
+                                                                    @"dense3.bias": @"fc3.bias"};
+
+static NSDictionary<NSString *, NSArray *> *const SharedWeightsInfo =
+  @{@"embed.weight" : @[@(256), @(64)],
+    @"convs.0.weight" : @[@(32), @(64), @(2)],
+    @"convs.0.bias" : @[@(32)],
+    @"convs.1.weight" : @[@(32), @(64), @(3)],
+    @"convs.1.bias" : @[@(32)],
+    @"convs.2.weight" : @[@(32), @(64), @(5)],
+    @"convs.2.bias" : @[@(32)],
+    @"fc1.weight": @[@(128), @(126)],
+    @"fc1.bias": @[@(128)],
+    @"fc2.weight": @[@(64), @(128)],
+    @"fc2.bias": @[@(64)]};
+
+static NSDictionary<NSString *, NSArray *> *const AddressDetectSpec =
+   @{@"fc3.weight": @[@(2), @(64)],
+     @"fc3.bias": @[@(2)]};
+
+static NSDictionary<NSString *, NSArray *> *const AppEventPredSpec =
+  @{@"fc3.weight": @[@(4), @(64)],
+    @"fc3.bias": @[@(4)]};
+
+static NSDictionary<NSString *, NSArray *> *const MTMLSpec =
+  @{@"address_detect.weight": @[@(2), @(64)],
+    @"address_detect.bias": @[@(2)],
+    @"app_event_pred.weight": @[@(4), @(64)],
+    @"app_event_pred.bias": @[@(4)]};
+
+NS_ASSUME_NONNULL_END

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.h
@@ -22,14 +22,18 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef void (^FBSDKDownloadCompletionBlock)(BOOL success);
 
 @interface FBSDKModelManager : NSObject
 
 + (void)enable;
 + (nullable NSDictionary *)getRules;
-+ (nullable NSString *)getWeightsPath:(NSString *_Nonnull)useCaseKey;
++ (nullable NSString *)getWeightsPath:(NSString *)useCaseKey;
 
 @end
+
+NS_ASSUME_NONNULL_END
 
 #endif

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.h
@@ -29,7 +29,7 @@ typedef void (^FBSDKDownloadCompletionBlock)(BOOL success);
 @interface FBSDKModelManager : NSObject
 
 + (void)enable;
-+ (nullable NSDictionary *)getRules;
++ (nullable NSDictionary *)getRulesForKey:(NSString *)useCaseKey;
 + (nullable NSString *)getWeightsPath:(NSString *)useCaseKey;
 
 @end

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.m
@@ -93,6 +93,7 @@ static NSMutableDictionary<NSString *, id> *_modelInfo;
           }];
         }
       }];
+
       [FBSDKFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:^(BOOL enabled) {
         if (enabled) {
           [self getModelAndRules:ADDRESS_FILTERING_KEY handler:^(BOOL success){

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelManager.m
@@ -45,6 +45,10 @@ static NSString *const VERSION_ID_KEY = @"version_id";
 static NSString *const MODEL_DATA_KEY = @"data";
 static NSString *const ADDRESS_FILTERING_KEY = @"DATA_DETECTION_ADDRESS";
 
+static NSString *const MTMLPrefixKey = @"mtml";
+static NSString *const MTMLTaskAppEventPredKey = @"mtml_app_event_pred";
+static NSString *const MTMLTaskAddressDetectKey = @"mtml_address_detect";
+
 static NSString *_directoryPath;
 static NSMutableDictionary<NSString *, id> *_modelInfo;
 
@@ -84,42 +88,27 @@ NS_ASSUME_NONNULL_BEGIN
       // update cache
       [[NSUserDefaults standardUserDefaults] setObject:modelInfo forKey:MODEL_INFO_KEY];
 
-      [FBSDKFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:^(BOOL enabled) {
+      [FBSDKFeatureManager checkFeature:FBSDKFeatureMTML completionBlock:^(BOOL enabled) {
         if (enabled) {
-          [self _getModelAndRules:SUGGEST_EVENT_KEY handler:^(BOOL success){
-            if (success) {
-              [FBSDKEventInferencer loadWeights];
-              [FBSDKFeatureExtractor loadRules];
-              [FBSDKSuggestedEventsIndexer enable];
-            }
-          }];
+          [self _checkFeaturesAndExecuteForMTML];
+        } else {
+          [self _checkFeaturesAndExecute];
         }
       }];
 
-      [FBSDKFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:^(BOOL enabled) {
-        if (enabled) {
-          [self _getModelAndRules:ADDRESS_FILTERING_KEY handler:^(BOOL success){
-            if (success) {
-              [FBSDKAddressInferencer loadWeights];
-              [FBSDKAddressInferencer initializeDenseFeature];
-              [FBSDKAddressFilterManager enable];
-            }
-          }];
-        }
-      }];
     }];
   });
 }
 
-+ (nullable NSDictionary *)getRules
++ (nullable NSDictionary *)getRulesForKey:(NSString *)useCaseKey
 {
   NSDictionary<NSString *, id> *cachedModelInfo = [[NSUserDefaults standardUserDefaults] objectForKey:MODEL_INFO_KEY];
   if (!cachedModelInfo) {
     return nil;
   }
-  NSDictionary<NSString *, id> *model = [cachedModelInfo objectForKey:SUGGEST_EVENT_KEY];
+  NSDictionary<NSString *, id> *model = [cachedModelInfo objectForKey:useCaseKey];
   if (model && model[VERSION_ID_KEY]) {
-    NSString *filePath = [_directoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%@.rules", SUGGEST_EVENT_KEY, model[VERSION_ID_KEY]]];
+    NSString *filePath = [_directoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%@.rules", useCaseKey, model[VERSION_ID_KEY]]];
     if (filePath) {
       NSData *ruelsData = [NSData dataWithContentsOfFile:filePath options:NSDataReadingMappedIfSafe error:nil];
       NSDictionary *rules = [NSJSONSerialization JSONObjectWithData:ruelsData options:0 error:nil];
@@ -140,6 +129,56 @@ NS_ASSUME_NONNULL_BEGIN
     return [_directoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%@.weights", useCaseKey, model[VERSION_ID_KEY]]];
   }
   return nil;
+}
+
++ (void)_checkFeaturesAndExecuteForMTML
+{
+  [FBSDKFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:^(BOOL enabled) {
+    if (enabled) {
+      [self _getModelAndRules:MTMLTaskAppEventPredKey handler:^(BOOL success) {
+        [FBSDKEventInferencer loadWeightsForKey:MTMLPrefixKey];
+        [FBSDKFeatureExtractor loadRulesForKey:MTMLTaskAppEventPredKey];
+        [FBSDKSuggestedEventsIndexer enable];
+      }];
+    }
+  }];
+
+  [FBSDKFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:^(BOOL enabled) {
+    if (enabled) {
+      [self _getModelAndRules:MTMLTaskAddressDetectKey handler:^(BOOL success) {
+        [FBSDKAddressInferencer loadWeightsForKey:MTMLPrefixKey];
+        [FBSDKAddressInferencer initializeDenseFeature];
+        [FBSDKAddressFilterManager enable];
+      }];
+    }
+  }];
+}
+
++ (void)_checkFeaturesAndExecute
+{
+  [FBSDKFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:^(BOOL enabled) {
+    if (enabled) {
+      [self _getModelAndRules:SUGGEST_EVENT_KEY handler:^(BOOL success){
+        if (success) {
+          [FBSDKEventInferencer loadWeightsForKey:SUGGEST_EVENT_KEY];
+          [FBSDKFeatureExtractor loadRulesForKey:SUGGEST_EVENT_KEY];
+          [FBSDKSuggestedEventsIndexer enable];
+        }
+      }];
+    }
+  }];
+
+  [FBSDKFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:^(BOOL enabled) {
+    if (enabled) {
+      [self _getModelAndRules:ADDRESS_FILTERING_KEY handler:^(BOOL success){
+        if (success) {
+          [FBSDKAddressInferencer loadWeightsForKey:ADDRESS_FILTERING_KEY];
+          [FBSDKAddressInferencer initializeDenseFeature];
+          [FBSDKAddressFilterManager enable];
+        }
+      }];
+    }
+  }];
 }
 
 + (void)_getModelAndRules:(NSString *)useCaseKey
@@ -173,12 +212,19 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }
 
-  // download model asset
+  // download model asset only if not exist before
   NSString *assetUrlString = [model objectForKey:ASSET_URI_KEY];
   NSString *assetFilePath;
   if (assetUrlString.length > 0) {
-    assetFilePath = [_directoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%@.weights", useCaseKey, model[VERSION_ID_KEY]]];
-    [self _download:assetUrlString filePath:assetFilePath queue:queue group:group];
+    NSString *fileName = useCaseKey;
+    if ([useCaseKey hasPrefix:MTMLPrefixKey]) {
+      // all mtml tasks share the same weights file
+      fileName = MTMLPrefixKey;
+    }
+    assetFilePath = [_directoryPath stringByAppendingPathComponent:[NSString stringWithFormat:@"%@_%@.weights", fileName, model[VERSION_ID_KEY]]];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:assetFilePath] == false) {
+      [self _download:assetUrlString filePath:assetFilePath queue:queue group:group];
+    }
   }
 
   // download rules

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TargetConditionals.h"
+
+#if !TARGET_OS_TV
+
+#import <Foundation/Foundation.h>
+
+#import "FBSDKStandaloneModel.hpp"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBSDKModelParser : NSObject
+
++ (std::unordered_map<std::string, mat::MTensor>)parseWeightsData:(NSData *)weightsData;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.h
@@ -26,9 +26,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, FBSDKMTMLTask) {
+    FBSDKMTMLTaskAddressDetect,
+    FBSDKMTMLTaskAppEventPred
+};
+
 @interface FBSDKModelParser : NSObject
 
 + (std::unordered_map<std::string, mat::MTensor>)parseWeightsData:(NSData *)weightsData;
++ (bool)validateWeights:(std::unordered_map<std::string, mat::MTensor>)weights forTask:(FBSDKMTMLTask)task;
++ (bool)validateMTMLWeights:(std::unordered_map<std::string, mat::MTensor>)weights;
 
 @end
 

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.mm
@@ -21,17 +21,10 @@
 #if !TARGET_OS_TV
 
 #import "FBSDKModelParser.h"
+#import "FBSDKModelConstants.h"
 using mat::MTensor;
 using std::string;
 using std::unordered_map;
-
-static NSDictionary<NSString *, NSString *> *const KEYS_MAPPING = @{@"embedding.weight": @"embed.weight",
-                                                                    @"dense1.weight": @"fc1.weight",
-                                                                    @"dense2.weight": @"fc2.weight",
-                                                                    @"dense3.weight": @"fc3.weight",
-                                                                    @"dense1.bias": @"fc1.bias",
-                                                                    @"dense2.bias": @"fc2.bias",
-                                                                    @"dense3.bias": @"fc3.bias"};
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -98,6 +91,56 @@ NS_ASSUME_NONNULL_BEGIN
   } catch (const std::exception &e) {}
 
   return weights;
+}
+
++ (bool)validateWeights:(std::unordered_map<std::string, mat::MTensor>)weights forTask:(FBSDKMTMLTask)task {
+  NSMutableDictionary<NSString *, NSArray *> *weightsInfoDict = [[NSMutableDictionary alloc] init];
+  [weightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  switch (task) {
+    case FBSDKMTMLTaskAddressDetect:
+      [weightsInfoDict addEntriesFromDictionary:AddressDetectSpec];
+      break;
+    case FBSDKMTMLTaskAppEventPred:
+      [weightsInfoDict addEntriesFromDictionary:AppEventPredSpec];
+      break;
+  }
+
+  return [self _checkWeights:weights withExpectedInfo:weightsInfoDict];
+}
+
++ (bool)validateMTMLWeights:(std::unordered_map<std::string, mat::MTensor>)weights {
+    NSMutableDictionary<NSString *, NSArray *> *weightsInfoDict = [[NSMutableDictionary alloc] init];
+  [weightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [weightsInfoDict addEntriesFromDictionary:MTMLSpec];
+  return [self _checkWeights:weights withExpectedInfo:weightsInfoDict];
+}
+
++ (bool)_checkWeights:(std::unordered_map<std::string, mat::MTensor>)weights
+     withExpectedInfo:(NSDictionary<NSString *, NSArray *> *)weightsInfoDict {
+  if (weightsInfoDict.count != weights.size()) {
+    return false;
+  }
+  try {
+    for (NSString *key in weightsInfoDict) {
+      if (weights.count(std::string([key UTF8String])) == 0) {
+        return false;
+      }
+      mat::MTensor tensor = weights[std::string([key UTF8String])];
+      const std::vector<int64_t>& actualSize = tensor.sizes();
+      NSArray *expectedSize = weightsInfoDict[key];
+      if (actualSize.size() != expectedSize.count) {
+        return false;
+      }
+      for (int i = 0; i < expectedSize.count; i++) {
+        if((int)actualSize[i] != (int)[expectedSize[i] intValue]) {
+          return false;
+        }
+      }
+    }
+  } catch (const std::exception &e) {
+    return false;
+  }
+  return true;
 }
 
 @end

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelParser.mm
@@ -1,0 +1,107 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "TargetConditionals.h"
+
+#if !TARGET_OS_TV
+
+#import "FBSDKModelParser.h"
+using mat::MTensor;
+using std::string;
+using std::unordered_map;
+
+static NSDictionary<NSString *, NSString *> *const KEYS_MAPPING = @{@"embedding.weight": @"embed.weight",
+                                                                    @"dense1.weight": @"fc1.weight",
+                                                                    @"dense2.weight": @"fc2.weight",
+                                                                    @"dense3.weight": @"fc3.weight",
+                                                                    @"dense1.bias": @"fc1.bias",
+                                                                    @"dense2.bias": @"fc2.bias",
+                                                                    @"dense3.bias": @"fc3.bias"};
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation FBSDKModelParser
+
++ (unordered_map<string, MTensor>)parseWeightsData:(NSData *)weightsData {
+  unordered_map<string,  MTensor> weights;
+
+  const void *data = weightsData.bytes;
+  NSUInteger totalLength =  weightsData.length;
+
+  if (totalLength < 4) {
+    // Make sure data length is valid
+    return weights;
+  }
+  try {
+    int length;
+    memcpy(&length, data, 4);
+    if (length + 4 > totalLength) {
+      // Make sure data length is valid
+      return weights;
+    }
+
+    char *json = (char *)data + 4;
+    NSDictionary<NSString *, id> *info = [NSJSONSerialization JSONObjectWithData:[NSData dataWithBytes:json length:length]
+                                                                         options:0
+                                                                           error:nil];
+    NSArray<NSString *> *keys = [[info allKeys] sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
+      return [key1 compare:key2];
+    }];
+
+    int totalFloats = 0;
+    float *floats = (float *)(json + length);
+    for (NSString *key in keys) {
+      NSString *finalKey = key;
+      NSString *mapping = [KEYS_MAPPING objectForKey:key];
+      if (mapping) {
+        finalKey = mapping;
+      }
+      std::string s_name([finalKey UTF8String]);
+
+      std::vector<int64_t> v_shape;
+      NSArray<NSString *> *shape = [info objectForKey:key];
+      int count = 1;
+      for (NSNumber *_s in shape) {
+        int i = [_s intValue];
+        v_shape.push_back(i);
+        count *= i;
+      }
+
+      totalFloats += count;
+
+      if ((4 + length + totalFloats * 4) > totalLength) {
+        // Make sure data length is valid
+        break;
+      }
+      MTensor tensor = mat::mempty(v_shape);
+      float *tensor_data = tensor.data<float>();
+      memcpy(tensor_data, floats, sizeof(float) * count);
+      floats += count;
+
+      weights[s_name] = tensor;
+    }
+  } catch (const std::exception &e) {}
+
+  return weights;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelRuntime.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelRuntime.hpp
@@ -24,7 +24,6 @@
 #include <math.h>
 #include <stdint.h>
 #include <unordered_map>
-#include <unordered_set>
 
 #import <Accelerate/Accelerate.h>
 

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKStandaloneModel.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKStandaloneModel.hpp
@@ -144,7 +144,7 @@ namespace mat {
         std::shared_ptr<void> storage_;
     };
 
-    static MTensor mempty(const std::vector<int64_t>& sizes) {
+    static inline MTensor mempty(const std::vector<int64_t>& sizes) {
         return MTensor(sizes);
     }
 } // namespace mat

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBSDKAddressInferencer : NSObject
 
 + (void)initializeDenseFeature;
-+ (void)loadWeights;
++ (void)loadWeightsForKey:(NSString *)useCaseKey;
 + (BOOL)shouldFilterParam:(nullable NSString *)param;
 
 @end

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
@@ -33,19 +33,6 @@
 static NSString *const MODEL_INFO_KEY= @"com.facebook.sdk:FBSDKModelInfo";
 static NSString *const THRESHOLDS_KEY = @"thresholds";
 static NSString *const DATA_DETECTION_ADDRESS_KEY = @"DATA_DETECTION_ADDRESS";
-static NSDictionary<NSString *, NSArray *> *const WEIGHTS_INFO = @{@"embed.weight" : @[@(256), @(64)],
-                                                                    @"convs.0.weight" : @[@(32), @(64), @(2)],
-                                                                    @"convs.0.bias" : @[@(32)],
-                                                                    @"convs.1.weight" : @[@(32), @(64), @(3)],
-                                                                    @"convs.1.bias" : @[@(32)],
-                                                                    @"convs.2.weight" : @[@(32), @(64), @(5)],
-                                                                    @"convs.2.bias" : @[@(32)],
-                                                                    @"fc1.weight": @[@(128), @(126)],
-                                                                    @"fc1.bias": @[@(128)],
-                                                                    @"fc2.weight": @[@(64), @(128)],
-                                                                    @"fc2.bias": @[@(64)],
-                                                                    @"fc3.weight": @[@(2), @(64)],
-                                                                    @"fc3.bias": @[@(2)]};
 
 @implementation FBSDKAddressInferencer : NSObject
 
@@ -72,37 +59,9 @@ static std::vector<float> _denseFeature;
     return;
   }
   std::unordered_map<std::string, mat::MTensor> weights = [FBSDKModelParser parseWeightsData:latestData];
-  if ([self validateWeights:weights]) {
+  if ([FBSDKModelParser validateWeights:weights forTask:FBSDKMTMLTaskAddressDetect]) {
     _weights = weights;
   }
-}
-
-+ (bool)validateWeights: (std::unordered_map<std::string, mat::MTensor>) weights
-{
-  if (WEIGHTS_INFO.count != weights.size()) {
-    return false;
-  }
-  try {
-    for (NSString *key in WEIGHTS_INFO) {
-      if (weights.count(std::string([key UTF8String])) == 0) {
-        return false;
-      }
-      mat::MTensor tensor = weights[std::string([key UTF8String])];
-      const std::vector<int64_t>& actualSize = tensor.sizes();
-      NSArray *expectedSize = WEIGHTS_INFO[key];
-      if (actualSize.size() != expectedSize.count) {
-        return false;
-      }
-      for (int i = 0; i < expectedSize.count; i++) {
-        if((int)actualSize[i] != (int)[expectedSize[i] intValue]) {
-          return false;
-        }
-      }
-    }
-  } catch (const std::exception &e) {
-    return false;
-  }
-  return true;
 }
 
 + (BOOL)shouldFilterParam:(nullable NSString *)param

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
@@ -46,9 +46,9 @@ static std::vector<float> _denseFeature;
   _denseFeature = dense_feature;
 }
 
-+ (void)loadWeights
++ (void)loadWeightsForKey:(NSString *)useCaseKey
 {
-  NSString *path = [FBSDKModelManager getWeightsPath:DATA_DETECTION_ADDRESS_KEY];
+  NSString *path = [FBSDKModelManager getWeightsPath:useCaseKey];
   if (!path) {
     return;
   }

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/RestrictiveDataFilter/FBSDKAddressInferencer.mm
@@ -23,6 +23,7 @@
 #import "FBSDKAddressInferencer.h"
 
 #import "FBSDKModelManager.h"
+#import "FBSDKModelParser.h"
 #import "FBSDKModelRuntime.hpp"
 #import "FBSDKModelUtility.h"
 #import "FBSDKStandaloneModel.hpp"
@@ -45,14 +46,6 @@ static NSDictionary<NSString *, NSArray *> *const WEIGHTS_INFO = @{@"embed.weigh
                                                                     @"fc2.bias": @[@(64)],
                                                                     @"fc3.weight": @[@(2), @(64)],
                                                                     @"fc3.bias": @[@(2)]};
-
-static NSDictionary<NSString *, NSString *> *const WEIGHTS_KEYS = @{@"embedding.weight": @"embed.weight",
-                                                                    @"dense1.weight": @"fc1.weight",
-                                                                    @"dense2.weight": @"fc2.weight",
-                                                                    @"dense3.weight": @"fc3.weight",
-                                                                    @"dense1.bias": @"fc1.bias",
-                                                                    @"dense2.bias": @"fc2.bias",
-                                                                    @"dense3.bias": @"fc3.bias"};
 
 @implementation FBSDKAddressInferencer : NSObject
 
@@ -78,7 +71,7 @@ static std::vector<float> _denseFeature;
   if (!latestData) {
     return;
   }
-  std::unordered_map<std::string, mat::MTensor> weights = [self loadWeights:latestData];
+  std::unordered_map<std::string, mat::MTensor> weights = [FBSDKModelParser parseWeightsData:latestData];
   if ([self validateWeights:weights]) {
     _weights = weights;
   }
@@ -110,69 +103,6 @@ static std::vector<float> _denseFeature;
     return false;
   }
   return true;
-}
-
-+ (std::unordered_map<std::string, mat::MTensor>)loadWeights:(NSData *)weightsData{
-  std::unordered_map<std::string,  mat::MTensor> weights;
-
-  const void *data = weightsData.bytes;
-  NSUInteger totalLength =  weightsData.length;
-
-  int totalFloats = 0;
-  if (weightsData.length < 4) {
-    // Make sure data length is valid
-    return weights;
-  }
-  try {
-    int length;
-    memcpy(&length, data, 4);
-    if (length + 4 > totalLength) {
-      // Make sure data length is valid
-      return weights;
-    }
-
-    char *json = (char *)data + 4;
-    NSDictionary<NSString *, id> *info = [NSJSONSerialization JSONObjectWithData:[NSData dataWithBytes:json length:length]
-                                                                         options:0
-                                                                           error:nil];
-    NSArray<NSString *> *keys = [[info allKeys] sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
-      return [key1 compare:key2];
-    }];
-
-    float *floats = (float *)(json + length);
-    for (NSString *key in keys) {
-      NSString *finalKey = key;
-      NSString *mapping = [WEIGHTS_KEYS objectForKey:key];
-      if (mapping) {
-        finalKey = mapping;
-      }
-      std::string s_name([finalKey UTF8String]);
-
-      std::vector<int64_t> v_shape;
-      NSArray<NSString *> *shape = [info objectForKey:key];
-      int count = 1;
-      for (NSNumber *_s in shape) {
-        int i = [_s intValue];
-        v_shape.push_back(i);
-        count *= i;
-      }
-
-      totalFloats += count;
-
-      if ((4 + length + totalFloats * 4) > totalLength) {
-        // Make sure data length is valid
-        break;
-      }
-      mat::MTensor tensor = mat::mempty(v_shape);
-      float *tensor_data = tensor.data<float>();
-      memcpy(tensor_data, floats, sizeof(float) * count);
-      floats += count;
-
-      weights[s_name] = tensor;
-    }
-  } catch (const std::exception &e) {}
-
-  return weights;
 }
 
 + (BOOL)shouldFilterParam:(nullable NSString *)param

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKEventInferencer.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKEventInferencer.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FBSDKEventInferencer : NSObject
 
-+ (void)loadWeights;
++ (void)loadWeightsForKey:(NSString *)useCaseKey;
 + (NSDictionary<NSString *, NSString *> *)predict:(NSString *)buttonText
                                          viewTree:(NSMutableDictionary<NSString *, id> *)viewTree
                                           withLog:(BOOL)isPrint;

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKEventInferencer.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKEventInferencer.mm
@@ -37,19 +37,6 @@ static NSString *const MODEL_INFO_KEY= @"com.facebook.sdk:FBSDKModelInfo";
 static NSString *const THRESHOLDS_KEY = @"thresholds";
 static NSString *const SUGGESTED_EVENT[4] = {@"fb_mobile_add_to_cart", @"fb_mobile_complete_registration", @"other", @"fb_mobile_purchase"};
 static NSDictionary<NSString *, NSString *> *const DEFAULT_PREDICTION = @{SUGGEST_EVENT_KEY: SUGGESTED_EVENTS_OTHER};
-static NSDictionary<NSString *, NSArray *> *const WEIGHTS_INFO = @{@"embed.weight" : @[@(256), @(64)],
-                                                                   @"convs.0.weight" : @[@(32), @(64), @(2)],
-                                                                   @"convs.0.bias" : @[@(32)],
-                                                                   @"convs.1.weight" : @[@(32), @(64), @(3)],
-                                                                   @"convs.1.bias" : @[@(32)],
-                                                                   @"convs.2.weight" : @[@(32), @(64), @(5)],
-                                                                   @"convs.2.bias" : @[@(32)],
-                                                                   @"fc1.weight": @[@(128), @(126)],
-                                                                   @"fc1.bias": @[@(128)],
-                                                                   @"fc2.weight": @[@(64), @(128)],
-                                                                   @"fc2.bias": @[@(64)],
-                                                                   @"fc3.weight": @[@(4), @(64)],
-                                                                   @"fc3.bias": @[@(4)]};
 
 static std::unordered_map<std::string, mat::MTensor> _weights;
 
@@ -68,37 +55,9 @@ static std::unordered_map<std::string, mat::MTensor> _weights;
     return;
   }
   std::unordered_map<std::string, mat::MTensor> weights = [FBSDKModelParser parseWeightsData:latestData];
-  if ([self validateWeights:weights]) {
+  if ([FBSDKModelParser validateWeights:weights forTask:FBSDKMTMLTaskAppEventPred]) {
     _weights = weights;
   }
-}
-
-+ (bool)validateWeights: (std::unordered_map<std::string, mat::MTensor>) weights
-{
-  if (WEIGHTS_INFO.count != weights.size()) {
-    return false;
-  }
-  try {
-    for (NSString *key in WEIGHTS_INFO) {
-      if (weights.count(std::string([key UTF8String])) == 0) {
-        return false;
-      }
-      mat::MTensor tensor = weights[std::string([key UTF8String])];
-      const std::vector<int64_t>& actualSize = tensor.sizes();
-      NSArray *expectedSize = WEIGHTS_INFO[key];
-      if (actualSize.size() != expectedSize.count) {
-        return false;
-      }
-      for (int i = 0; i < expectedSize.count; i++) {
-        if((int)actualSize[i] != (int)[expectedSize[i] intValue]) {
-          return false;
-        }
-      }
-    }
-  } catch (const std::exception &e) {
-    return false;
-  }
-  return true;
 }
 
 + (NSDictionary<NSString *, NSString *> *)predict:(NSString *)buttonText

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKEventInferencer.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKEventInferencer.mm
@@ -42,9 +42,9 @@ static std::unordered_map<std::string, mat::MTensor> _weights;
 
 @implementation FBSDKEventInferencer : NSObject
 
-+ (void)loadWeights
++ (void)loadWeightsForKey:(NSString *)useCaseKey
 {
-  NSString *path = [FBSDKModelManager getWeightsPath:SUGGEST_EVENT_KEY];
+  NSString *path = [FBSDKModelManager getWeightsPath:useCaseKey];
   if (!path) {
     return;
   }

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKFeatureExtractor.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKFeatureExtractor.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FBSDKFeatureExtractor : NSObject
 
-+ (void)loadRules;
++ (void)loadRulesForKey:(NSString *)useCaseKey;
 + (NSString *)getTextFeature:(NSString *)text
               withScreenName:(NSString *)screenName;
 + (float *)getDenseFeatures:(NSDictionary *)viewHierarchy;

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKFeatureExtractor.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKFeatureExtractor.m
@@ -70,9 +70,9 @@ void sum(float *val0, float *val1);
                     };
 }
 
-+ (void)loadRules
++ (void)loadRulesForKey:(NSString *)useCaseKey
 {
-  _rules = [FBSDKModelManager getRules];
+  _rules = [FBSDKModelManager getRulesForKey:useCaseKey];
 }
 
 + (NSString *)getTextFeature:(NSString *)text

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKFeatureManager.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKFeatureManager.h
@@ -50,13 +50,13 @@ typedef NS_ENUM(NSUInteger, FBSDKFeature)
   FBSDKFeaturePrivacyProtection = 0x00010400,
   FBSDKFeatureSuggestedEvents = 0x00010401,
   FBSDKFeaturePIIFiltering = 0x00010402,
+  FBSDKFeatureMTML = 0x00010403,
   FBSDKFeatureEventDeactivation = 0x00010500,
   /** Instrument */
   FBSDKFeatureInstrument = 0x00020000,
   FBSDKFeatureCrashReport = 0x00020100,
   FBSDKFeatureCrashShield = 0x00020101,
   FBSDKFeatureErrorReport = 0x00020200,
-
 
   // Features in LoginKit
   /** Essential of LoginKit */

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKFeatureManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKFeatureManager.m
@@ -24,36 +24,24 @@
 
 static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatureManager.FBSDKFeature";
 
+NS_ASSUME_NONNULL_BEGIN
+
 @implementation FBSDKFeatureManager
 
 + (void)checkFeature:(FBSDKFeature)feature
      completionBlock:(FBSDKFeatureManagerBlock)completionBlock
 {
   // check locally first
-  NSString *version = [[NSUserDefaults standardUserDefaults] valueForKey:[FBSDKFeatureManagerPrefix stringByAppendingString:[self featureName:feature]]];
+  NSString *version = [[NSUserDefaults standardUserDefaults] valueForKey:[FBSDKFeatureManagerPrefix stringByAppendingString:[self _featureName:feature]]];
   if (version && [version isEqualToString:[FBSDKSettings sdkVersion]]) {
     return;
   }
   // check gk
   [FBSDKGateKeeperManager loadGateKeepers:^(NSError * _Nullable error) {
     if (completionBlock) {
-      completionBlock([FBSDKFeatureManager isEnabled:feature]);
+      completionBlock([FBSDKFeatureManager _isEnabled:feature]);
     }
   }];
-}
-
-+ (BOOL)isEnabled:(FBSDKFeature)feature
-{
-  if (FBSDKFeatureCore == feature) {
-    return YES;
-  }
-
-  FBSDKFeature parentFeature = [self getParentFeature:feature];
-  if (parentFeature == feature) {
-    return [self checkGK:feature];
-  } else {
-    return [FBSDKFeatureManager isEnabled:parentFeature] && [self checkGK:feature];
-  }
 }
 
 + (void)disableFeature:(NSString *)featureName
@@ -61,7 +49,21 @@ static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatu
   [[NSUserDefaults standardUserDefaults] setObject:[FBSDKSettings sdkVersion] forKey:[FBSDKFeatureManagerPrefix stringByAppendingString:featureName]];
 }
 
-+ (FBSDKFeature)getParentFeature:(FBSDKFeature)feature
++ (BOOL)_isEnabled:(FBSDKFeature)feature
+{
+  if (FBSDKFeatureCore == feature) {
+    return YES;
+  }
+
+  FBSDKFeature parentFeature = [self _getParentFeature:feature];
+  if (parentFeature == feature) {
+    return [self _checkGK:feature];
+  } else {
+    return [FBSDKFeatureManager _isEnabled:parentFeature] && [self _checkGK:feature];
+  }
+}
+
++ (FBSDKFeature)_getParentFeature:(FBSDKFeature)feature
 {
   if ((feature & 0xFF) > 0) {
     return feature & 0xFFFFFF00;
@@ -72,16 +74,16 @@ static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatu
   } else return 0;
 }
 
-+ (BOOL)checkGK:(FBSDKFeature)feature
++ (BOOL)_checkGK:(FBSDKFeature)feature
 {
-  NSString *key = [NSString stringWithFormat:@"FBSDKFeature%@", [self featureName:feature]];
-  BOOL defaultValue = [self defaultStatus:feature];
+  NSString *key = [NSString stringWithFormat:@"FBSDKFeature%@", [self _featureName:feature]];
+  BOOL defaultValue = [self _defaultStatus:feature];
 
   return [FBSDKGateKeeperManager boolForKey:key
                                defaultValue:defaultValue];
 }
 
-+ (NSString *)featureName:(FBSDKFeature)feature
++ (NSString *)_featureName:(FBSDKFeature)feature
 {
   NSString *featureName;
   switch (feature) {
@@ -109,7 +111,7 @@ static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatu
   return featureName;
 }
 
-+ (BOOL)defaultStatus:(FBSDKFeature)feature
++ (BOOL)_defaultStatus:(FBSDKFeature)feature
 {
   switch (feature) {
     case FBSDKFeatureRestrictiveDataFiltering:
@@ -134,3 +136,5 @@ static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatu
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKFeatureManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKFeatureManager.m
@@ -93,6 +93,7 @@ static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatu
     case FBSDKFeaturePrivacyProtection: featureName = @"PrivacyProtection"; break;
     case FBSDKFeatureSuggestedEvents: featureName = @"SuggestedEvents"; break;
     case FBSDKFeaturePIIFiltering: featureName = @"PIIFiltering"; break;
+    case FBSDKFeatureMTML: featureName = @"MTML"; break;
     case FBSDKFeatureEventDeactivation: featureName = @"EventDeactivation"; break;
     case FBSDKFeatureInstrument: featureName = @"Instrument"; break;
     case FBSDKFeatureCrashReport: featureName = @"CrashReport"; break;
@@ -121,8 +122,14 @@ static NSString *const FBSDKFeatureManagerPrefix = @"com.facebook.sdk:FBSDKFeatu
     case FBSDKFeaturePrivacyProtection:
     case FBSDKFeatureSuggestedEvents:
     case FBSDKFeaturePIIFiltering:
+    case FBSDKFeatureMTML:
       return NO;
-    default: return YES;
+    case FBSDKFeatureLogin:
+    case FBDSDKFeatureShare:
+    case FBSDKFeatureCore:
+    case FBSDKFeatureAppEvents:
+    case FBSDKFeatureCodelessEvents:
+      return YES;
   }
 }
 

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/ML/FBSDKModelManagerTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/ML/FBSDKModelManagerTests.m
@@ -29,6 +29,7 @@
 @end
 
 @implementation FBSDKModelManagerTests {
+  id _mockFeatureManager;
 }
 
 - (void)setUp {
@@ -46,11 +47,12 @@
       handler(nil, [self _mockResult], nil);
     }
   });
+
+  _mockFeatureManager = OCMClassMock([FBSDKFeatureManager class]);
 }
 
 - (void)testFeatureMTMLEnabled {
-  id mockFeatureManager = OCMClassMock([FBSDKFeatureManager class]);
-  OCMStub([mockFeatureManager checkFeature:FBSDKFeatureMTML completionBlock:OCMOCK_ANY]).andDo(^(NSInvocation *invocation){
+  OCMStub([_mockFeatureManager checkFeature:FBSDKFeatureMTML completionBlock:OCMOCK_ANY]).andDo(^(NSInvocation *invocation){
     FBSDKFeatureManagerBlock block;
     [invocation getArgument:&block atIndex:3];
     if (block) {
@@ -60,8 +62,23 @@
 
   [FBSDKModelManager enable];
 
-  OCMVerify([mockFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:OCMOCK_ANY]);
-  OCMVerify([mockFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:OCMOCK_ANY]);
+  OCMVerify([_mockFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:OCMOCK_ANY]);
+  OCMVerify([_mockFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:OCMOCK_ANY]);
+}
+
+- (void)testFeatureMTMLDisabled {
+  OCMStub([_mockFeatureManager checkFeature:FBSDKFeatureMTML completionBlock:OCMOCK_ANY]).andDo(^(NSInvocation *invocation){
+    FBSDKFeatureManagerBlock block;
+    [invocation getArgument:&block atIndex:3];
+    if (block) {
+      block(false);
+    }
+  });
+
+  [FBSDKModelManager enable];
+
+  OCMVerify([_mockFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:OCMOCK_ANY]);
+  OCMVerify([_mockFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:OCMOCK_ANY]);
 }
 
 - (NSDictionary<NSString *, NSArray *> *)_mockResult

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/ML/FBSDKModelManagerTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/ML/FBSDKModelManagerTests.m
@@ -1,0 +1,72 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import "FBSDKFeatureManager.h"
+#import "FBSDKGraphRequest.h"
+#import "FBSDKGraphRequestConnection.h"
+#import "FBSDKModelManager.h"
+
+@interface FBSDKModelManagerTests : XCTestCase
+@end
+
+@implementation FBSDKModelManagerTests {
+}
+
+- (void)setUp {
+  id mockLocale = OCMClassMock([NSLocale class]);
+  OCMStub([mockLocale currentLocale]).andReturn(mockLocale);
+  OCMStub([mockLocale objectForKey:NSLocaleLanguageCode]).andReturn(@"en");
+
+  id mockRequest = OCMClassMock([FBSDKGraphRequest class]);
+  OCMStub([mockRequest alloc]).andReturn(mockRequest);
+  OCMStub([mockRequest initWithGraphPath:OCMOCK_ANY]).andReturn(mockRequest);
+  OCMStub([mockRequest startWithCompletionHandler:OCMOCK_ANY]).andDo(^(NSInvocation *invocation){
+    FBSDKGraphRequestBlock handler;
+    [invocation getArgument:&handler atIndex:2];
+    if (handler) {
+      handler(nil, [self _mockResult], nil);
+    }
+  });
+}
+
+- (void)testFeatureMTMLEnabled {
+  id mockFeatureManager = OCMClassMock([FBSDKFeatureManager class]);
+  OCMStub([mockFeatureManager checkFeature:FBSDKFeatureMTML completionBlock:OCMOCK_ANY]).andDo(^(NSInvocation *invocation){
+    FBSDKFeatureManagerBlock block;
+    [invocation getArgument:&block atIndex:3];
+    if (block) {
+      block(true);
+    }
+  });
+
+  [FBSDKModelManager enable];
+
+  OCMVerify([mockFeatureManager checkFeature:FBSDKFeatureSuggestedEvents completionBlock:OCMOCK_ANY]);
+  OCMVerify([mockFeatureManager checkFeature:FBSDKFeaturePIIFiltering completionBlock:OCMOCK_ANY]);
+}
+
+- (NSDictionary<NSString *, NSArray *> *)_mockResult
+{
+  return @{@"data": @[@{@"use_case": @"DATA_DETECTION_ADDRESS", @"version_id": @1}]};
+}
+
+@end

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/ML/FBSDKModelParserTests.mm
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/ML/FBSDKModelParserTests.mm
@@ -1,0 +1,140 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+
+#import "FBSDKMOdelConstants.h"
+#import "FBSDKModelParser.h"
+using mat::MTensor;
+using std::string;
+using std::unordered_map;
+using std::vector;
+
+@interface FBSDKModelParserTests : XCTestCase
+{
+  NSMutableDictionary<NSString *, NSArray *> *_mockWeightsInfoDict;
+}
+@end
+
+@implementation FBSDKModelParserTests
+
+- (void)setUp {
+  _mockWeightsInfoDict = [[NSMutableDictionary alloc] init];
+}
+
+- (void)tearDown {
+  [_mockWeightsInfoDict removeAllObjects];
+}
+
+- (void)testValidWeightsForAddressDetect {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [_mockWeightsInfoDict addEntriesFromDictionary:AddressDetectSpec];
+
+  bool validatedRes = [FBSDKModelParser validateWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]
+                                                forTask:FBSDKMTMLTaskAddressDetect];
+
+  XCTAssertTrue(validatedRes);
+}
+
+- (void)testWeightsForAddressDetectWithMissingInfo {
+  [_mockWeightsInfoDict addEntriesFromDictionary:AddressDetectSpec];
+
+  bool validatedRes = [FBSDKModelParser validateWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]
+                                                forTask:FBSDKMTMLTaskAddressDetect];
+
+  XCTAssertFalse(validatedRes);
+}
+
+- (void)testWeightsForAddressDetectWithWrongInfo {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [_mockWeightsInfoDict addEntriesFromDictionary:AppEventPredSpec];
+
+  bool validatedRes = [FBSDKModelParser validateWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]
+                                                forTask:FBSDKMTMLTaskAddressDetect];
+
+  XCTAssertFalse(validatedRes);
+}
+
+- (void)testValidWeightsForAppEventPred {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [_mockWeightsInfoDict addEntriesFromDictionary:AppEventPredSpec];
+
+  bool validatedRes = [FBSDKModelParser validateWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]
+                                                forTask:FBSDKMTMLTaskAppEventPred];
+
+  XCTAssertTrue(validatedRes);
+}
+
+- (void)testWeightsForAppEventPredWithMissingInfo {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+
+  bool validatedRes = [FBSDKModelParser validateWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]
+                                                forTask:FBSDKMTMLTaskAppEventPred];
+
+  XCTAssertFalse(validatedRes);
+}
+
+- (void)testWeightsForAppEventPredWithWrongInfo {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [_mockWeightsInfoDict addEntriesFromDictionary:MTMLSpec];
+
+  bool validatedRes = [FBSDKModelParser validateWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]
+                                                forTask:FBSDKMTMLTaskAppEventPred];
+
+  XCTAssertFalse(validatedRes);
+}
+
+- (void)testValidMTMLWeights {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [_mockWeightsInfoDict addEntriesFromDictionary:MTMLSpec];
+
+  bool validatedRes = [FBSDKModelParser validateMTMLWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]];
+  XCTAssertTrue(validatedRes);
+}
+
+- (void)testMTMLWeightsWithMissingInfo {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+  [_mockWeightsInfoDict addEntriesFromDictionary:AppEventPredSpec];
+
+  bool validatedRes = [FBSDKModelParser validateMTMLWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]];
+  XCTAssertFalse(validatedRes);
+}
+
+- (void)testMTMLWeightsWithWrongInfo {
+  [_mockWeightsInfoDict addEntriesFromDictionary:SharedWeightsInfo];
+
+  bool validatedRes = [FBSDKModelParser validateMTMLWeights:[self _mockWeightsWithRefDict:_mockWeightsInfoDict]];
+  XCTAssertFalse(validatedRes);
+}
+
+- (unordered_map<string, MTensor>)_mockWeightsWithRefDict:(NSDictionary<NSString *, NSArray *> *)dict {
+  unordered_map<string,  MTensor> weights;
+  for (NSString* key in dict) {
+    NSArray<NSNumber *> *values = dict[key];
+    vector<int64_t> shape;
+    for (NSNumber *val in values) {
+      shape.push_back(val.intValue);
+    }
+    MTensor tensor = mat::mempty(shape);
+    weights[string([key UTF8String])] = tensor;
+  }
+
+  return weights;
+}
+
+@end


### PR DESCRIPTION
Summary: Follow up on D19945774, according to Apple's doc (https://developer.apple.com/documentation/dispatch/1447169-dispatch_once), This function is useful for initialization of global data (singletons) in an application. Always call this function before using or testing any variables that are initialized by the block. So move the dispatch_once to where the enable is called and add tests for MTML disabled case.

Differential Revision: D19987719

