### PR TITLE
Adding ability to return to the caller app during Oauth

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m
@@ -103,10 +103,16 @@ typedef void (^FBSDKAuthenticationCompletionHandler)(NSURL *_Nullable callbackUR
          annotation:(id)annotation
 {
   id<FBSDKURLOpening> pendingURLOpen = _pendingURLOpen;
-  BOOL canOpenURL =   [pendingURLOpen canOpenURL:url
-                                  forApplication:application
-                               sourceApplication:sourceApplication
-                                      annotation:annotation];
+
+  if ([pendingURLOpen respondsToSelector:@selector(shouldStopPropagationOfURL:)]
+      && [pendingURLOpen shouldStopPropagationOfURL:url]) {
+    return YES;
+  }
+
+  BOOL canOpenURL = [pendingURLOpen canOpenURL:url
+                                forApplication:application
+                             sourceApplication:sourceApplication
+                                    annotation:annotation];
 
   void (^completePendingOpenURLBlock)(void) = ^{
     self->_pendingURLOpen = nil;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKURLOpening.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKURLOpening.h
@@ -43,6 +43,9 @@ NS_SWIFT_NAME(URLOpening)
 
 - (BOOL)isAuthenticationURL:(NSURL *)url;
 
+@optional
+- (BOOL)shouldStopPropagationOfURL:(NSURL *)url;
+
 @end
 
 #endif

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginManager.m
@@ -553,6 +553,13 @@ typedef NS_ENUM(NSInteger, FBSDKLoginManagerState) {
   return [url.path hasSuffix:FBSDKOauthPath];
 }
 
+- (BOOL)shouldStopPropagationOfURL:(NSURL *)url
+{
+  return
+  [url.scheme hasPrefix:[NSString stringWithFormat:@"fb%@", [FBSDKSettings appID]]]
+  && [url.host isEqualToString:@"no-op"];
+}
+
 @end
 
 #endif


### PR DESCRIPTION
Summary: This adds the ability to link back to the caller app via the url fb{APP_ID}://no-op. Without this change, the login flow killed is when you link back.

Reviewed By: joesus

Differential Revision: D20015635

