### PR TITLE
Adding a class that wraps Gaming video upload

### DIFF
--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.m
@@ -21,8 +21,8 @@
 @implementation FBSDKGamingImageUploaderConfiguration
 
 - (instancetype)initWithImage:(UIImage * _Nonnull)image
-                caption:(NSString * _Nullable)caption
-shouldLaunchMediaDialog:(BOOL)shouldLaunchMediaDialog
+                      caption:(NSString * _Nullable)caption
+      shouldLaunchMediaDialog:(BOOL)shouldLaunchMediaDialog
 {
   if (self = [super init]) {
     _image = image;

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h
@@ -16,23 +16,20 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#import <Foundation/Foundation.h>
+
 #if defined FBSDKCOCOAPODS || defined BUCK
-
-#import <FBSDKGamingServicesKit/FBSDKFriendFinderDialog.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingImageUploader.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.h>
 #import <FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h>
-
 #else
-
-#import "FBSDKFriendFinderDialog.h"
-#import "FBSDKGamingImageUploader.h"
-#import "FBSDKGamingImageUploaderConfiguration.h"
 #import "FBSDKGamingServiceCompletionHandler.h"
-#import "FBSDKGamingVideoUploader.h"
-#import "FBSDKGamingVideoUploaderConfiguration.h"
-
 #endif
 
+@class FBSDKGamingVideoUploaderConfiguration;
+
+NS_SWIFT_NAME(GamingVideoUploader)
+@interface FBSDKGamingVideoUploader : NSObject
+
++ (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
+                andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler;
+
+@end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.m
@@ -1,0 +1,133 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "FBSDKGamingVideoUploader.h"
+
+#import "FBSDKCoreKit+Internal.h"
+#import "FBSDKGamingVideoUploaderConfiguration.h"
+#import "FBSDKVideoUploader.h"
+
+static FBSDKGamingVideoUploader *executingUploader = nil;
+
+@interface FBSDKGamingVideoUploader() <FBSDKVideoUploaderDelegate>
+{
+  NSFileHandle *_fileHandle;
+  FBSDKGamingServiceCompletionHandler _completionHandler;
+}
+@end
+
+@implementation FBSDKGamingVideoUploader
+
++ (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
+                andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+{
+  if ([FBSDKAccessToken currentAccessToken] == nil) {
+    completionHandler(false, [FBSDKError
+                              errorWithCode:FBSDKErrorAccessTokenRequired
+                              message:@"A valid access token is required to upload Images"]);
+
+    return;
+  }
+
+  if (configuration.videoURL == nil) {
+    completionHandler(false, [FBSDKError
+                              errorWithCode:FBSDKErrorInvalidArgument
+                              message:@"Attempting to upload a nil videoURL"]);
+
+    return;
+  }
+
+  NSFileHandle *const fileHandle =
+  [NSFileHandle
+   fileHandleForReadingFromURL:configuration.videoURL
+   error:nil];
+
+  if ((unsigned long)[fileHandle seekToEndOfFile] == 0) {
+    completionHandler(false, [FBSDKError
+                              errorWithCode:FBSDKErrorInvalidArgument
+                              message:@"Attempting to upload an empty video file"]);
+
+    return;
+  }
+
+  executingUploader =
+  [[FBSDKGamingVideoUploader alloc]
+   initWithFileHandle:fileHandle
+   completionHandler:completionHandler];
+
+  FBSDKVideoUploader *const videoUploader =
+  [[FBSDKVideoUploader alloc]
+   initWithVideoName:[configuration.videoURL lastPathComponent]
+   videoSize:(unsigned long)[fileHandle seekToEndOfFile]
+   parameters:@{}
+   delegate:executingUploader];
+
+  [videoUploader start];
+}
+
+- (instancetype)initWithFileHandle:(NSFileHandle *)fileHandle
+                 completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+{
+  if (self = [super init]) {
+    _fileHandle = fileHandle;
+    _completionHandler = completionHandler;
+  }
+  return self;
+}
+
+- (void)safeCompleteWithResult:(BOOL)result
+                      andError:(NSError *)error
+{
+  if (_completionHandler != nil) {
+    _completionHandler(result, error);
+  }
+  executingUploader = nil;
+}
+
+#pragma mark - FBSDKVideoUploaderDelegate
+
+- (NSData *)videoChunkDataForVideoUploader:(FBSDKVideoUploader *)videoUploader
+                               startOffset:(NSUInteger)startOffset
+                                 endOffset:(NSUInteger)endOffset
+{
+  NSUInteger chunkSize = endOffset - startOffset;
+  [_fileHandle seekToFileOffset:startOffset];
+  NSData *videoChunkData = [_fileHandle readDataOfLength:chunkSize];
+  if (videoChunkData == nil || videoChunkData.length != chunkSize) {
+    return nil;
+  }
+  return videoChunkData;
+}
+
+- (void)videoUploader:(FBSDKVideoUploader *)videoUploader
+didCompleteWithResults:(NSDictionary<NSString *, id> *)results
+{
+  [self
+   safeCompleteWithResult:[results[@"success"] boolValue]
+   andError:nil];
+}
+
+- (void)videoUploader:(FBSDKVideoUploader *)videoUploader
+     didFailWithError:(NSError *)error
+{
+  [self
+   safeCompleteWithResult:true
+   andError:error];
+}
+
+@end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h
@@ -16,23 +16,21 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if defined FBSDKCOCOAPODS || defined BUCK
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-#import <FBSDKGamingServicesKit/FBSDKFriendFinderDialog.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingImageUploader.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h>
+NS_ASSUME_NONNULL_BEGIN
 
-#else
+NS_SWIFT_NAME(GamingVideoUploaderConfiguration)
+@interface FBSDKGamingVideoUploaderConfiguration : NSObject
 
-#import "FBSDKFriendFinderDialog.h"
-#import "FBSDKGamingImageUploader.h"
-#import "FBSDKGamingImageUploaderConfiguration.h"
-#import "FBSDKGamingServiceCompletionHandler.h"
-#import "FBSDKGamingVideoUploader.h"
-#import "FBSDKGamingVideoUploaderConfiguration.h"
+@property (nonatomic, strong, readonly, nonnull) NSURL *videoURL;
+@property (nonatomic, strong, readonly, nullable) NSString *caption;
 
-#endif
+- (instancetype)initWithVideoURL:(NSURL * _Nonnull)videoURL
+                         caption:(NSString * _Nullable)caption;
 
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.m
@@ -16,23 +16,18 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if defined FBSDKCOCOAPODS || defined BUCK
-
-#import <FBSDKGamingServicesKit/FBSDKFriendFinderDialog.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingImageUploader.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h>
-#import <FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h>
-
-#else
-
-#import "FBSDKFriendFinderDialog.h"
-#import "FBSDKGamingImageUploader.h"
-#import "FBSDKGamingImageUploaderConfiguration.h"
-#import "FBSDKGamingServiceCompletionHandler.h"
-#import "FBSDKGamingVideoUploader.h"
 #import "FBSDKGamingVideoUploaderConfiguration.h"
 
-#endif
+@implementation FBSDKGamingVideoUploaderConfiguration
 
+- (instancetype)initWithVideoURL:(NSURL * _Nonnull)videoURL
+                         caption:(NSString * _Nullable)caption;
+{
+  if (self = [super init]) {
+    _videoURL = videoURL;
+    _caption = caption;
+  }
+  return self;
+}
+
+@end

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.h
@@ -18,15 +18,6 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
-
-#import "FBSDKShareVideo.h"
-#import "FBSDKSharing.h"
-
 @protocol FBSDKVideoUploaderDelegate;
 
 /**
@@ -50,12 +41,6 @@ NS_SWIFT_NAME(VideoUploader)
  */
 - (instancetype)initWithVideoName:(NSString *)videoName videoSize:(NSUInteger)videoSize parameters:(NSDictionary *)parameters delegate:(id<FBSDKVideoUploaderDelegate>)delegate
 NS_DESIGNATED_INITIALIZER;
-
-
-/**
-  The video to be uploaded.
- */
-@property (readonly, copy, nonatomic) FBSDKShareVideo *video;
 
 /**
   Optional parameters for video uploads. See Graph API documentation for the full list of parameters https://developers.facebook.com/docs/graph-api/reference/video

--- a/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/FBSDKVideoUploader.m
@@ -20,20 +20,14 @@
 
 #import <Foundation/Foundation.h>
 
-#if defined BUCK || defined FBSDKCOCOAPODS
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#else
-@import FBSDKCoreKit;
-#endif
-
-#import "FBSDKShareConstants.h"
-
 #ifdef FBSDKCOCOAPODS
 #import <FBSDKCoreKit/FBSDKCoreKit+Internal.h>
 #else
 #import "FBSDKCoreKit+Internal.h"
 #endif
+
 #import "FBSDKShareDefines.h"
+#import "FBSDKShareConstants.h"
 
 static NSString *const FBSDKVideoUploaderDefaultGraphNode = @"me";
 static NSString *const FBSDKVideoUploaderEdge = @"videos";


### PR DESCRIPTION
Summary:
We want to provide a clean way for 3rd party devs to implement the gaming video upload call. This adds a simple wrapper around the video upload logic.

Follows a similar style to GamingImageUploader.

Differential Revision: D20122377

