### PR TITLE
Un-Deprecating Messenger Sharing

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.h
@@ -43,7 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
  - Any other types that are not one of the four supported types listed above
  */
 NS_SWIFT_NAME(MessageDialog)
-DEPRECATED_FOR_MESSENGER
 @interface FBSDKMessageDialog : NSObject <FBSDKSharingDialog>
 
 /**

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSendButton.h
@@ -35,7 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  Tapping the receiver will invoke the FBSDKShareDialog with the attached shareContent.  If the dialog cannot
  be shown, the button will be disable.
  */
-DEPRECATED_FOR_MESSENGER
 NS_SWIFT_NAME(FBSendButton)
 @interface FBSDKSendButton : FBSDKButton <FBSDKSharingButton>
 

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareConstants.h
@@ -18,10 +18,6 @@
 
 #import <Foundation/Foundation.h>
 
-#ifndef DEPRECATED_FOR_MESSENGER
-#define DEPRECATED_FOR_MESSENGER DEPRECATED_MSG_ATTRIBUTE("Sharing to Messenger via the SDK is unsupported. https://developers.facebook.com/docs/messenger-platform/changelog/#20190610. Sharing should be performed by the native share sheet.")
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0


### PR DESCRIPTION
Summary: Facebook Messenger Sharing will be available starting on May 3rd, 2020. This removes the deprecation warnings. The schedule of the upcoming release means that this will ship after the Messenger changes are live.

Reviewed By: Mxiim

Differential Revision: D20151263

