### PR TITLE
Adds dependent ShareKit podspec to linting for GamingServicesKit

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -384,6 +384,10 @@ lint_sdk() {
         dependent_spec="--include-podspecs=FBSDK{Core,Share,Login}Kit.podspec"
       fi
 
+      if [ "$spec" == FBSDKGamingServicesKit ]; then
+        dependent_spec="--include-podspecs=FBSDK{Core,Share}Kit.podspec"
+      fi
+
       echo ""
       echo "Running lib lint command:"
       echo "pod lib lint" "$spec" $dependent_spec "$@"


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

GamingServicesKit has two podspec linting dependencies. Core and Share. This change accounts for that.

## Test Plan

Test Plan: CI
