### PR TITLE
Updates product name to ignore static vs dynamic

### DIFF
--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/project.pbxproj
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/project.pbxproj
@@ -242,7 +242,7 @@
 		F4F7CA3523F499600030A346 /* FBSDKCoreKit+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FBSDKCoreKit+Internal.h"; path = "../../../FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKCoreKit+Internal.h"; sourceTree = "<group>"; };
 		F4F7CA3D23F49C110030A346 /* FBSDKCoreKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FBSDKCoreKit.xcodeproj; path = ../FBSDKCoreKit/FBSDKCoreKit.xcodeproj; sourceTree = "<group>"; };
 		F4F7CA6823F49D1B0030A346 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		F4F7CA9923F49D6F0030A346 /* FBSDKGamingServicesKit-Dynamic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = "FBSDKGamingServicesKit-Dynamic.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4F7CA9923F49D6F0030A346 /* FBSDKGamingServicesKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKGamingServicesKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4F7CA9A23F49D6F0030A346 /* FBSDKGamingServicesKit copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "FBSDKGamingServicesKit copy-Info.plist"; path = "/Users/joesusnick/fbsource/fbobjc/ios-sdk/FBSDKGamingServicesKit/FBSDKGamingServicesKit copy-Info.plist"; sourceTree = "<absolute>"; };
 		F4F7CAA123F4A1390030A346 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -275,7 +275,7 @@
 				F4F7C9E123F48F2C0030A346 /* FBSDKGamingServicesKitTests */,
 				F4F7CA1823F4902B0030A346 /* FBSDKGamingServicesKit.framework */,
 				F4F7CA3223F498ED0030A346 /* Frameworks */,
-				F4F7CA9923F49D6F0030A346 /* FBSDKGamingServicesKit-Dynamic.framework */,
+				F4F7CA9923F49D6F0030A346 /* FBSDKGamingServicesKit.framework */,
 				F4F7CA9A23F49D6F0030A346 /* FBSDKGamingServicesKit copy-Info.plist */,
 			);
 			sourceTree = "<group>";
@@ -477,7 +477,7 @@
 			);
 			name = "FBSDKGamingServicesKit-Dynamic";
 			productName = FBSDKGamingServicesKit;
-			productReference = F4F7CA9923F49D6F0030A346 /* FBSDKGamingServicesKit-Dynamic.framework */;
+			productReference = F4F7CA9923F49D6F0030A346 /* FBSDKGamingServicesKit.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -936,7 +936,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.FBSDKGamingServicesKit;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = FBSDKGamingServicesKit;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -960,7 +960,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.FBSDKGamingServicesKit;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = FBSDKGamingServicesKit;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/xcshareddata/xcschemes/FBSDKGamingServicesKit-Dynamic.xcscheme
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/xcshareddata/xcschemes/FBSDKGamingServicesKit-Dynamic.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F4F7CA6A23F49D6F0030A346"
-               BuildableName = "FBSDKGamingServicesKit-Dynamic.framework"
+               BuildableName = "FBSDKGamingServicesKit.framework"
                BlueprintName = "FBSDKGamingServicesKit-Dynamic"
                ReferencedContainer = "container:FBSDKGamingServicesKit.xcodeproj">
             </BuildableReference>
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -46,13 +44,11 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F4F7CA6A23F49D6F0030A346"
-            BuildableName = "FBSDKGamingServicesKit-Dynamic.framework"
+            BuildableName = "FBSDKGamingServicesKit.framework"
             BlueprintName = "FBSDKGamingServicesKit-Dynamic"
             ReferencedContainer = "container:FBSDKGamingServicesKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -64,7 +60,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F4F7CA6A23F49D6F0030A346"
-            BuildableName = "FBSDKGamingServicesKit-Dynamic.framework"
+            BuildableName = "FBSDKGamingServicesKit.framework"
             BlueprintName = "FBSDKGamingServicesKit-Dynamic"
             ReferencedContainer = "container:FBSDKGamingServicesKit.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This is a bit confusing. Before this fix when carthage builds "FBSDKCoreKit-Dynamic" it outputs "FBSDKCoreKit.framework" when it builds "FBSDKGamingServicesKit-Dynamic" it outputs "FBSDKGamingServicesKit-Dynamic.framework". So when we go to archive we get this type of error:

```
$ carthage build --no-skip-current
*** xcodebuild output can be found in /var/folders/s8/c8vg3yzn6hg2rz5lntwtx89951j3dw/T/carthage-xcodebuild.95sn1M.log
*** Building scheme "OCMock" in OCMock.xcodeproj
*** Building scheme "OCMock tvOS" in OCMock.xcodeproj
*** Building scheme "OCMock iOS" in OCMock.xcodeproj
*** Building scheme "OHHTTPStubs Mac Framework" in OHHTTPStubs.xcworkspace
*** Building scheme "OHHTTPStubs iOS Framework" in OHHTTPStubs.xcworkspace
*** Building scheme "OHHTTPStubs tvOS Framework" in OHHTTPStubs.xcworkspace
*** Building scheme "FBSDKCoreKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKCoreKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKGamingServicesKit" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKGamingServicesKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKLoginKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKLoginKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKShareKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKShareKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKTVOSKit_TV-Dynamic" in FacebookSDK.xcworkspace

$ carthage archive --output build/Release/
*** Found Carthage/Build/iOS/FBSDKCoreKit.framework
*** Found Carthage/Build/iOS/FBSDKCoreKit.framework.dSYM
*** Found Carthage/Build/iOS/FBSDKGamingServicesKit-Dynamic.framework
*** Found Carthage/Build/iOS/FBSDKGamingServicesKit-Dynamic.framework.dSYM
*** Found Carthage/Build/iOS/FBSDKLoginKit.framework
*** Found Carthage/Build/iOS/FBSDKLoginKit.framework.dSYM
*** Found Carthage/Build/iOS/FBSDKShareKit.framework
*** Found Carthage/Build/iOS/FBSDKShareKit.framework.dSYM
*** Found Carthage/Build/tvOS/FBSDKCoreKit.framework
*** Found Carthage/Build/tvOS/FBSDKCoreKit.framework.dSYM
*** Found Carthage/Build/tvOS/FBSDKLoginKit.framework
*** Found Carthage/Build/tvOS/FBSDKLoginKit.framework.dSYM
*** Found Carthage/Build/tvOS/FBSDKShareKit.framework
*** Found Carthage/Build/tvOS/FBSDKShareKit.framework.dSYM
*** Found Carthage/Build/iOS/8636DCD9-0818-3947-B8E0-9678FE10987C.bcsymbolmap
*** Found Carthage/Build/iOS/CE86023C-FACA-3BEE-AE55-15AFFF937531.bcsymbolmap
*** Found Carthage/Build/iOS/4B1DE8EC-2AAA-3BF7-A318-88E081DAD156.bcsymbolmap
*** Found Carthage/Build/iOS/36F2834A-B4FE-36F6-B8FB-AC5FAD37E640.bcsymbolmap
*** Found Carthage/Build/iOS/747EBB12-579C-34F9-B18C-10A379891B78.bcsymbolmap
*** Found Carthage/Build/iOS/0DDB2C9E-BEF6-3AD9-B46A-A97C8BAEFB7C.bcsymbolmap
*** Found Carthage/Build/iOS/D3875C08-816B-339B-87B5-B8207BE85B08.bcsymbolmap
*** Found Carthage/Build/iOS/33588C15-0D2E-3DF3-9DCA-886E4CBD49BD.bcsymbolmap
*** Found Carthage/Build/tvOS/FBSDKTVOSKit.framework
*** Found Carthage/Build/iOS/D5140EC3-6DCA-39A2-87C4-38A254C2B932.bcsymbolmap
*** Found Carthage/Build/iOS/C955AD01-1B21-3449-B014-763263335DD0.bcsymbolmap
*** Found Carthage/Build/tvOS/FBSDKTVOSKit.framework.dSYM
*** Found Carthage/Build/iOS/50EC1328-6FC8-3309-8DCE-8BF70F1A1C92.bcsymbolmap
*** Found Carthage/Build/iOS/63770EF7-1451-347A-8296-54F0F9DD538B.bcsymbolmap
*** Found Carthage/Build/iOS/6C63EFD5-2184-32E9-BF76-3029AF244DA1.bcsymbolmap
*** Found Carthage/Build/iOS/384A485C-A021-3449-A316-B81B18D794DD.bcsymbolmap
*** Found Carthage/Build/iOS/EB17D2E0-278F-31CA-98BE-F8717D18B336.bcsymbolmap
*** Found Carthage/Build/iOS/C9EA561D-4CB8-3B21-8237-845C7AACC401.bcsymbolmap
*** Found Carthage/Build/tvOS/278962AC-77F5-3BD0-9723-6FACF76FC4BC.bcsymbolmap
*** Found Carthage/Build/tvOS/C6B7A5CC-41A1-3BD1-AF7A-710255898963.bcsymbolmap
*** Found Carthage/Build/tvOS/06B16E66-9997-344A-A234-646F6FDF26BB.bcsymbolmap
*** Found Carthage/Build/tvOS/53B6D2FD-8B74-3CAD-B075-B0BB8B1DBEA1.bcsymbolmap
*** Found Carthage/Build/tvOS/E7895656-43B6-3443-B2BA-E1AFF2932F46.bcsymbolmap
*** Found Carthage/Build/tvOS/98E7040F-727D-3A08-B989-EECBD5326B7B.bcsymbolmap
*** Found Carthage/Build/tvOS/03AB1183-58F8-3AB3-96DD-27E479D50346.bcsymbolmap
*** Found Carthage/Build/tvOS/E5CACDB4-ED3A-32A4-8ECF-24D7B90E1A0D.bcsymbolmap
Could not find any copies of FBSDKCoreKit.framework, FBSDKGamingServicesKit-Dynamic.framework, FBSDKGamingServicesKit.framework, FBSDKLoginKit.framework, FBSDKShareKit.framework, FBSDKTVOSKit.framework. Make sure you're in the project's root and that the frameworks have already been built using 'carthage build --no-skip-current'.
```

After this fix, when carthage builds "FBSDKGamingServicesKit-Dynamic.framework" the output binary is named: "FBSDKGamingServicesKit.framework" and can be found for archiving.

## Test Plan

Test Plan: Run the commands in the description. Archiving should succeed.
