### PR TITLE
Omits testing tools from Carthage build step

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -142,6 +142,11 @@ setup_sdk() {
   } >>"$SDK_DIR"/Configurations/TestAppIdAndSecret.xcconfig
 }
 
+# Micro-optimization to removes testing tools in checkouts directory so they aren't built
+slim_carthage() {
+  rm -rf Carthage/Checkouts
+}
+
 # Bump Version
 bump_version() {
   local new_version=${1:-}
@@ -302,6 +307,8 @@ build_sdk() {
   }
 
   build_carthage() {
+    slim_carthage
+
     carthage build --no-skip-current
 
     if [ "${1:-}" == "--archive" ]; then
@@ -459,6 +466,8 @@ release_sdk() {
     }
 
     release_swift_dynamic() {
+      slim_carthage
+
       carthage build --no-skip-current
       carthage archive --output build/Release/
       # This is a little unintuitive. Carthage outputs are based on module name instead of
@@ -491,6 +500,8 @@ release_sdk() {
 
     # Release frameworks in dynamic (mostly for Carthage)
     release_dynamic() {
+      slim_carthage
+
       carthage build --no-skip-current
       carthage archive --output build/Release/
       mv build/Release/FBSDKCoreKit.framework.zip build/Release/FacebookSDK_Dynamic.framework.zip


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Small optimization to cut down on build times for the Travis CI steps that run `carthage build`.
In local tests I was able to save ~2 minutes but this will likely be far more on the travis machines.

## Test Plan

Test Plan: 
Before:

```
time carthage build --no-skip-current
*** xcodebuild output can be found in /var/folders/s8/c8vg3yzn6hg2rz5lntwtx89951j3dw/T/carthage-xcodebuild.95sn1M.log
*** Building scheme "OCMock" in OCMock.xcodeproj
*** Building scheme "OCMock tvOS" in OCMock.xcodeproj
*** Building scheme "OCMock iOS" in OCMock.xcodeproj
*** Building scheme "OHHTTPStubs Mac Framework" in OHHTTPStubs.xcworkspace
*** Building scheme "OHHTTPStubs iOS Framework" in OHHTTPStubs.xcworkspace
*** Building scheme "OHHTTPStubs tvOS Framework" in OHHTTPStubs.xcworkspace
*** Building scheme "FBSDKCoreKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKCoreKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKGamingServicesKit" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKGamingServicesKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKLoginKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKLoginKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKShareKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKShareKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKTVOSKit_TV-Dynamic" in FacebookSDK.xcworkspace
carthage build --no-skip-current  228.46s user 86.58s system 83% cpu 6:19.35 total
```

After:

```
time carthage build --no-skip-current
*** xcodebuild output can be found in /var/folders/s8/c8vg3yzn6hg2rz5lntwtx89951j3dw/T/carthage-xcodebuild.2VP6fQ.log
*** Building scheme "FBSDKCoreKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKCoreKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKGamingServicesKit" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKGamingServicesKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKLoginKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKLoginKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKShareKit_TV-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKShareKit-Dynamic" in FacebookSDK.xcworkspace
*** Building scheme "FBSDKTVOSKit_TV-Dynamic" in FacebookSDK.xcworkspace
carthage build --no-skip-current  145.05s user 51.46s system 75% cpu 4:21.66 total
```
