### PR TITLE
Fix a multi-thread issue in the initialization.

### DIFF
--- a/Sources/FBSDKCoreKit_Basics/FBSDKCrashHandler.m
+++ b/Sources/FBSDKCoreKit_Basics/FBSDKCrashHandler.m
@@ -85,8 +85,7 @@ static BOOL _isTurnedOff;
 
 + (void)sendCrashLogs
 {
-  NSArray<id<FBSDKCrashObserving>> *observers = [_observers copy];
-  for (id<FBSDKCrashObserving> observer in observers) {
+  for (id<FBSDKCrashObserving> observer in _observers) {
     if (observer && [observer respondsToSelector:@selector(didReceiveCrashLogs:)]) {
       NSArray<NSDictionary<NSString *, id> *> *filteredCrashLogs = [self filterCrashLogs:observer.prefixes processedCrashLogs:_processedCrashLogs];
       [observer didReceiveCrashLogs:filteredCrashLogs];
@@ -138,22 +137,26 @@ static BOOL _isTurnedOff;
     installSignalsHandler();
     _processedCrashLogs = [self getProcessedCrashLogs];
   });
-  if (![_observers containsObject:observer]) {
-    [_observers addObject:observer];
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^(void) {
-      [self generateMethodMapping:observer];
-    });
-    [self sendCrashLogs];
+  @synchronized (_observers) {
+    if (![_observers containsObject:observer]) {
+      [_observers addObject:observer];
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^(void) {
+        [self generateMethodMapping:observer];
+      });
+      [self sendCrashLogs];
+    }
   }
 }
 
 + (void)removeObserver:(id<FBSDKCrashObserving>)observer
 {
-  if ([_observers containsObject:observer]) {
-    [_observers removeObject:observer];
-    if (_observers.count == 0) {
-      [FBSDKCrashHandler uninstallExceptionsHandler];
-      uninstallSignalsHandler();
+  @synchronized (_observers) {
+    if ([_observers containsObject:observer]) {
+      [_observers removeObject:observer];
+      if (_observers.count == 0) {
+        [FBSDKCrashHandler uninstallExceptionsHandler];
+        uninstallSignalsHandler();
+      }
     }
   }
 }


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

There are few crashes in our app during the initialization. When the app initializes both of Facebook SDK and Facebook Audience Network SDK in the close timing, the app will crash due to the multiple access to the variable (_observers).

## Test Plan

I've created a simplified example to describe the issue. The app will crash without `@synchronized`.
https://gist.github.com/firewood/54ce08372aec55e43dfc245ae285ad4a
