### PR TITLE
Expose 'anonymousID' as public function

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.h
@@ -826,6 +826,11 @@ NS_SWIFT_NAME(setUser(email:firstName:lastName:phone:dateOfBirth:gender:city:sta
  */
 + (void)updateUserProperties:(NSDictionary<NSString *, id> *)properties handler:(nullable FBSDKGraphRequestBlock)handler;
 
+/*
+ Returns generated anonymous id that persisted with current install of the app
+ */
++ (NSString *)anonymousID;
+
 #if !TARGET_OS_TV
 /*
   Intended to be used as part of a hybrid webapp.

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
@@ -830,6 +830,11 @@ static NSString *g_overrideAppID = nil;
   [request startWithCompletionHandler:handler];
 }
 
++ (NSString *)anonymousID
+{
+  return [FBSDKBasicUtility anonymousID];
+}
+
 #if !TARGET_OS_TV
 + (void)augmentHybridWKWebView:(WKWebView *)webView {
   // Ensure we can instantiate WebKit before trying this


### PR DESCRIPTION
Summary: Android has exposed this function in `AppEventsLogger`, this is an equivalent change.

Differential Revision: D20575434

