### PR TITLE
Removing redundant dependency from Podspec

### DIFF
--- a/FBSDKGamingServicesKit.podspec
+++ b/FBSDKGamingServicesKit.podspec
@@ -29,7 +29,6 @@ Pod::Spec.new do |s|
 
   s.source_files   = 'FBSDKGamingServicesKit/FBSDKGamingServicesKit/**/*.{h,m}'
   s.public_header_files = 'FBSDKGamingServicesKit/FBSDKGamingServicesKit/*.{h}'
-  s.dependency 'FBSDKCoreKit', "~> #{s.version}"
   s.dependency 'FBSDKShareKit', "~> #{s.version}"
 
 end


### PR DESCRIPTION
Summary: Noticed this while debugging separate issue. Explicit dependency on FBSDKCoreKit is redundant since FBSDKShareKit has FBSDKCoreKit as a dependency. Should be able to remove this safely.

Reviewed By: tianqibt

Differential Revision: D20741017

