### PR TITLE
Fix implicitly logged flag

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
@@ -455,7 +455,7 @@ static NSString *g_overrideAppID = nil;
   [[FBSDKAppEvents singleton] instanceLogEvent:eventName
                                     valueToSum:valueToSum
                                     parameters:parameters
-                            isImplicitlyLogged:(BOOL)parameters[FBSDKAppEventParameterImplicitlyLogged]
+                            isImplicitlyLogged:[parameters[FBSDKAppEventParameterImplicitlyLogged] boolValue]
                                    accessToken:accessToken];
 }
 


### PR DESCRIPTION
Summary: Non-nil object will be converted to `YES` with `(BOOL)`, though current code works coincidently, it's wrong.

Differential Revision: D20853552

