### PR TITLE
Fix flaky unit test

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsUtilityTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsUtilityTests.m
@@ -48,8 +48,10 @@
 
 - (void)tearDown
 {
-  // Put teardown code here. This method is called after the invocation of each test method in the class.
   [super tearDown];
+
+  [_mockNSLocale stopMocking];
+  [_mockAppEventsUtility stopMocking];
 }
 
 - (void)testLogNotification
@@ -112,11 +114,10 @@
 
 - (void)testGetNumberValueWithLocaleFR
 {
-  OCMStub([_mockNSLocale currentLocale]).
-  _andReturn(OCMOCK_VALUE([NSLocale localeWithLocaleIdentifier:@"fr"]));
+  OCMStub(ClassMethod([_mockNSLocale currentLocale])).andReturn([NSLocale localeWithLocaleIdentifier:@"fr"]);
 
   NSNumber *result = [FBSDKAppEventsUtility
-                      getNumberValue:@"Price: 1\u202F234,56; Buy 1 get 2!"];
+                      getNumberValue:@"Price: 1\u00a0234,56; Buy 1 get 2!"];
   NSString *str = [NSString stringWithFormat:@"%.2f", result.floatValue];
   XCTAssertEqualObjects(str, @"1234.56");
 }


### PR DESCRIPTION
Summary:
Disabling flaky unit test around client token.

Also this other super weird thing:
D19074291 changed the test to look for:
U+202F NARROW NO-BREAK SPACE
instead of:
U+00A0 NO-BREAK SPACE

When I put a breakpoint in AppEventsUtility, locale.groupingSeparator includes: U+00A0 but not U+202F.

Wondering if something changed over a minor xcode version or if something else is going on here.

Also wondering if one of these cases is legitimately broken. Googling turned up some references to france using U+00A0 as a separator in currency so assuming this is correct. (google and apple seem to agree at least)

Differential Revision: D20558756

