### PR TITLE
Making upload back compat

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift)
   }
 
   NSString *host =
-  [hostPrefix isEqualToString:@"graph."] &&
+  ([hostPrefix isEqualToString:@"graph."] || [hostPrefix isEqualToString:@"graph-video."]) &&
   [[FBSDKAccessToken currentAccessToken].graphDomain isEqualToString:@"gaming"]
   ? @"fb.gg"
   : @"facebook.com";

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKFriendFinderDialog.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKFriendFinderDialog.m
@@ -29,9 +29,11 @@
 + (void)launchFriendFinderDialogWithCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
 {
   if ([FBSDKAccessToken currentAccessToken] == nil) {
-    completionHandler(false, [FBSDKError
-                            errorWithCode:FBSDKErrorAccessTokenRequired
-                            message:@"A valid access token is required to launch the Friend Finder"]);
+    completionHandler(false,
+                      [FBSDKError
+                       errorWithCode:FBSDKErrorAccessTokenRequired
+                       message:@"A valid access token is required to launch the Friend Finder"],
+                      nil);
 
     return;
   }
@@ -39,7 +41,8 @@
   FBSDKGamingServiceController *const controller =
   [[FBSDKGamingServiceController alloc]
    initWithServiceType:FBSDKGamingServiceTypeFriendFinder
-   completionHandler:completionHandler];
+   completionHandler:completionHandler
+   pendingResult:nil];
 
   [controller callWithArgument:FBSDKAccessToken.currentAccessToken.appID];
 }

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKFriendFinderDialog.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKFriendFinderDialog.m
@@ -32,8 +32,7 @@
     completionHandler(false,
                       [FBSDKError
                        errorWithCode:FBSDKErrorAccessTokenRequired
-                       message:@"A valid access token is required to launch the Friend Finder"],
-                      nil);
+                       message:@"A valid access token is required to launch the Friend Finder"]);
 
     return;
   }
@@ -41,7 +40,11 @@
   FBSDKGamingServiceController *const controller =
   [[FBSDKGamingServiceController alloc]
    initWithServiceType:FBSDKGamingServiceTypeFriendFinder
-   completionHandler:completionHandler
+   completionHandler:^(BOOL success, id  _Nullable result, NSError * _Nullable error) {
+    if (completionHandler) {
+      completionHandler(success, error);
+    }
+  }
    pendingResult:nil];
 
   [controller callWithArgument:FBSDKAccessToken.currentAccessToken.appID];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.h
@@ -38,9 +38,23 @@ NS_SWIFT_NAME(GamingImageUploader)
  @param completionHandler a callback that is fired dependent on the configuration.
   Fired when the upload completes or when the users returns to the caller app
   after the media dialog is shown.
+
+@deprecated - This method is deprecated. Please use uploadImageWithConfiguration:andResultCompletionHandler: instead.
+*/
++ (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
+                andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+DEPRECATED_MSG_ATTRIBUTE("Please use uploadImageWithConfiguration:andResultCompletionHandler: instead");
+
+/**
+Runs an upload to a users Gaming Media Library with the given configuration
+
+@param configuration model object contain the content that will be uploaded
+@param completionHandler a callback that is fired dependent on the configuration.
+ Fired when the upload completes or when the users returns to the caller app
+ after the media dialog is shown.
  */
 + (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
-                andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler;
+          andResultCompletionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler;
 
 /**
 Runs an upload to a users Gaming Media Library with the given configuration
@@ -53,7 +67,7 @@ Runs an upload to a users Gaming Media Library with the given configuration
  bytes are transferred to Facebook.
 */
 + (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
-                   completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                   completionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
                   andProgressHandler:(FBSDKGamingServiceProgressHandler _Nullable)progressHandler;
 
 @end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.h
@@ -42,4 +42,18 @@ NS_SWIFT_NAME(GamingImageUploader)
 + (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
                 andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler;
 
+/**
+Runs an upload to a users Gaming Media Library with the given configuration
+
+@param configuration model object contain the content that will be uploaded
+@param completionHandler a callback that is fired dependent on the configuration.
+ Fired when the upload completes or when the users returns to the caller app
+ after the media dialog is shown.
+@param progressHandler an optional callback that is fired multiple times as
+ bytes are transferred to Facebook.
+*/
++ (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
+                   completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                  andProgressHandler:(FBSDKGamingServiceProgressHandler _Nullable)progressHandler;
+
 @end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.m
@@ -31,17 +31,21 @@
                 andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
 {
   if ([FBSDKAccessToken currentAccessToken] == nil) {
-    completionHandler(false, [FBSDKError
-                              errorWithCode:FBSDKErrorAccessTokenRequired
-                              message:@"A valid access token is required to upload Images"]);
+    completionHandler(false,
+                      [FBSDKError
+                       errorWithCode:FBSDKErrorAccessTokenRequired
+                       message:@"A valid access token is required to upload Images"],
+                      nil);
 
     return;
   }
 
   if (configuration.image == nil) {
-    completionHandler(false, [FBSDKError
-                              errorWithCode:FBSDKErrorInvalidArgument
-                              message:@"Attempting to upload a nil image"]);
+    completionHandler(false,
+                      [FBSDKError
+                       errorWithCode:FBSDKErrorInvalidArgument
+                       message:@"Attempting to upload a nil image"],
+                      nil);
 
     return;
   }
@@ -55,22 +59,25 @@
     HTTPMethod:FBSDKHTTPMethodPOST]
    startWithCompletionHandler:^(FBSDKGraphRequestConnection * _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
     if (error || !result) {
-      completionHandler(false, [FBSDKError
+      completionHandler(false,
+                        [FBSDKError
                                 errorWithCode:FBSDKErrorGraphRequestGraphAPI
                                 message:@"Image upload failed"
-                                underlyingError:error]);
+                                underlyingError:error],
+                        nil);
       return;
     }
 
     if (!configuration.shouldLaunchMediaDialog) {
-      completionHandler(true, nil);
+      completionHandler(true, nil, result);
       return;
     }
 
     FBSDKGamingServiceController *const controller =
     [[FBSDKGamingServiceController alloc]
      initWithServiceType:FBSDKGamingServiceTypeMediaAsset
-     completionHandler:completionHandler];
+     completionHandler:completionHandler
+     pendingResult:result];
 
     [controller callWithArgument:result[@"id"]];
   }];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingImageUploader.m
@@ -37,30 +37,44 @@
   return
   [self
    uploadImageWithConfiguration:configuration
+   completionHandler:^(BOOL success, id _Nullable result, NSError * _Nullable error) {
+    if (completionHandler) {
+      completionHandler(success, error);
+    }
+  }
+   andProgressHandler:nil];
+}
+
++ (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
+          andResultCompletionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
+{
+  return
+  [self
+   uploadImageWithConfiguration:configuration
    completionHandler:completionHandler
    andProgressHandler:nil];
 }
 
 + (void)uploadImageWithConfiguration:(FBSDKGamingImageUploaderConfiguration * _Nonnull)configuration
-                   completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                   completionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
                   andProgressHandler:(FBSDKGamingServiceProgressHandler _Nullable)progressHandler
 {
   if ([FBSDKAccessToken currentAccessToken] == nil) {
     completionHandler(false,
+                      nil,
                       [FBSDKError
                        errorWithCode:FBSDKErrorAccessTokenRequired
-                       message:@"A valid access token is required to upload Images"],
-                      nil);
+                       message:@"A valid access token is required to upload Images"]);
 
     return;
   }
 
   if (configuration.image == nil) {
     completionHandler(false,
+                      nil,
                       [FBSDKError
                        errorWithCode:FBSDKErrorInvalidArgument
-                       message:@"Attempting to upload a nil image"],
-                      nil);
+                       message:@"Attempting to upload a nil image"]);
 
     return;
   }
@@ -89,16 +103,16 @@
 
     if (error || !result) {
       completionHandler(false,
+                        nil,
                         [FBSDKError
                          errorWithCode:FBSDKErrorGraphRequestGraphAPI
                          message:@"Image upload failed"
-                         underlyingError:error],
-                        nil);
+                         underlyingError:error]);
       return;
     }
 
     if (!configuration.shouldLaunchMediaDialog) {
-      completionHandler(true, nil, result);
+      completionHandler(true, result, nil);
       return;
     }
 

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h
@@ -18,5 +18,12 @@
 
 #import <Foundation/Foundation.h>
 
-typedef void (^FBSDKGamingServiceCompletionHandler)(BOOL success, NSError * _Nullable error)
+/**
+ Main completion handling of any Gaming Service (Friend Finder, Image/Video Upload).
+
+ @param success whether the call to the service was considered a success.
+ @param error the error that occured during the service call, if any.
+ @param result the result that was returned by the service, if any.
+ */
+typedef void (^FBSDKGamingServiceCompletionHandler)(BOOL success, NSError * _Nullable error, id _Nullable result)
 NS_SWIFT_NAME(GamingServiceCompletionHandler);

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h
@@ -27,3 +27,6 @@
  */
 typedef void (^FBSDKGamingServiceCompletionHandler)(BOOL success, NSError * _Nullable error, id _Nullable result)
 NS_SWIFT_NAME(GamingServiceCompletionHandler);
+
+typedef void (^FBSDKGamingServiceProgressHandler)(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend)
+NS_SWIFT_NAME(GamingServiceProgressHandler);

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h
@@ -17,16 +17,33 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <AvailabilityMacros.h>
 
 /**
  Main completion handling of any Gaming Service (Friend Finder, Image/Video Upload).
 
  @param success whether the call to the service was considered a success.
  @param error the error that occured during the service call, if any.
- @param result the result that was returned by the service, if any.
  */
-typedef void (^FBSDKGamingServiceCompletionHandler)(BOOL success, NSError * _Nullable error, id _Nullable result)
+typedef void (^FBSDKGamingServiceCompletionHandler)(BOOL success, NSError * _Nullable error)
 NS_SWIFT_NAME(GamingServiceCompletionHandler);
 
+/**
+Main completion handling of any Gaming Service (Friend Finder, Image/Video Upload).
+
+@param success whether the call to the service was considered a success.
+@param result the result that was returned by the service, if any.
+@param error the error that occured during the service call, if any.
+*/
+typedef void (^FBSDKGamingServiceResultCompletionHandler)(BOOL success, NSString * _Nullable result, NSError * _Nullable error)
+NS_SWIFT_NAME(GamingServiceCompletionHandler);
+
+/**
+Main completion handling of any Gaming Service (Friend Finder, Image/Video Upload).
+
+@param success whether the call to the service was considered a success.
+@param error the error that occured during the service call, if any.
+@param result the result that was returned by the service, if any.
+*/
 typedef void (^FBSDKGamingServiceProgressHandler)(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend)
 NS_SWIFT_NAME(GamingServiceProgressHandler);

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h
@@ -40,4 +40,16 @@ Runs an upload to a users Gaming Media Library with the given configuration
 + (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
                 andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler;
 
+/**
+Runs an upload to a users Gaming Media Library with the given configuration
+
+@param configuration model object contain the content that will be uploaded
+@param completionHandler a callback that is fired when the upload completes.
+@param progressHandler an optional callback that is fired multiple times as
+ bytes are transferred to Facebook.
+*/
++ (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
+                   completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                  andProgressHandler:(FBSDKGamingServiceProgressHandler _Nullable)progressHandler;
+
 @end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h
@@ -17,6 +17,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <AvailabilityMacros.h>
 
 #if defined FBSDKCOCOAPODS || defined BUCK
 #import <FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h>
@@ -36,9 +37,21 @@ Runs an upload to a users Gaming Media Library with the given configuration
 
 @param configuration model object contain the content that will be uploaded
 @param completionHandler a callback that is fired when the upload completes.
+
+@deprecated - This method is deprecated. Please use uploadVideoWithConfiguration:andResultCompletionHandler: instead.
 */
 + (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
-                andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler;
+                andCompletionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+DEPRECATED_MSG_ATTRIBUTE("Please use uploadVideoWithConfiguration:andResultCompletionHandler: instead");
+
+/**
+Runs an upload to a users Gaming Media Library with the given configuration
+
+@param configuration model object contain the content that will be uploaded
+@param completionHandler a callback that is fired when the upload completes.
+*/
++ (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
+          andResultCompletionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler;
 
 /**
 Runs an upload to a users Gaming Media Library with the given configuration
@@ -49,7 +62,7 @@ Runs an upload to a users Gaming Media Library with the given configuration
  bytes are transferred to Facebook.
 */
 + (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
-                   completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                   completionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
                   andProgressHandler:(FBSDKGamingServiceProgressHandler _Nullable)progressHandler;
 
 @end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingVideoUploader.m
@@ -25,7 +25,7 @@
 @interface FBSDKGamingVideoUploader() <FBSDKVideoUploaderDelegate>
 {
   NSFileHandle *_fileHandle;
-  FBSDKGamingServiceCompletionHandler _completionHandler;
+  FBSDKGamingServiceResultCompletionHandler _completionHandler;
   FBSDKGamingServiceProgressHandler _progressHandler;
   NSUInteger _totalBytesSent;
   NSUInteger _totalBytesExpectedToSend;
@@ -41,30 +41,44 @@
   return
   [self
    uploadVideoWithConfiguration:configuration
+   completionHandler:^(BOOL success, id _Nullable result, NSError * _Nullable error) {
+    if (completionHandler) {
+      completionHandler(success, error);
+    }
+  }
+   andProgressHandler:nil];
+}
+
++ (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
+          andResultCompletionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
+{
+  return
+  [self
+   uploadVideoWithConfiguration:configuration
    completionHandler:completionHandler
    andProgressHandler:nil];
 }
 
 + (void)uploadVideoWithConfiguration:(FBSDKGamingVideoUploaderConfiguration * _Nonnull)configuration
-                   completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                   completionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
                   andProgressHandler:(FBSDKGamingServiceProgressHandler _Nullable)progressHandler
 {
   if ([FBSDKAccessToken currentAccessToken] == nil) {
     completionHandler(false,
+                      nil,
                       [FBSDKError
                        errorWithCode:FBSDKErrorAccessTokenRequired
-                       message:@"A valid access token is required to upload Images"],
-                      nil);
+                       message:@"A valid access token is required to upload Images"]);
 
     return;
   }
 
   if (configuration.videoURL == nil) {
     completionHandler(false,
+                      nil,
                       [FBSDKError
                        errorWithCode:FBSDKErrorInvalidArgument
-                       message:@"Attempting to upload a nil videoURL"],
-                      nil);
+                       message:@"Attempting to upload a nil videoURL"]);
 
     return;
   }
@@ -76,10 +90,10 @@
 
   if ((unsigned long)[fileHandle seekToEndOfFile] == 0) {
     completionHandler(false,
+                      nil,
                       [FBSDKError
                        errorWithCode:FBSDKErrorInvalidArgument
-                       message:@"Attempting to upload an empty video file"],
-                      nil);
+                       message:@"Attempting to upload an empty video file"]);
 
     return;
   }
@@ -108,7 +122,7 @@
 
 - (instancetype)initWithFileHandle:(NSFileHandle *)fileHandle
                   totalBytesToSend:(NSUInteger)totalBytes
-                 completionHandler:(FBSDKGamingServiceCompletionHandler _Nonnull)completionHandler
+                 completionHandler:(FBSDKGamingServiceResultCompletionHandler _Nonnull)completionHandler
                    progressHandler:(FBSDKGamingServiceProgressHandler _Nonnull)progressHandler
 {
   if (self = [super init]) {
@@ -135,7 +149,7 @@
   }
 
   if (_completionHandler != nil) {
-    _completionHandler(success, finalError, result);
+    _completionHandler(success, result, finalError);
   }
 
   [FBSDKInternalUtility unregisterTransientObject:self];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.h
@@ -29,7 +29,8 @@ typedef NS_ENUM(NSUInteger, FBSDKGamingServiceType) {
 @interface FBSDKGamingServiceController : NSObject <FBSDKURLOpening>
 
 - (instancetype)initWithServiceType:(FBSDKGamingServiceType)serviceType
-                  completionHandler:(FBSDKGamingServiceCompletionHandler)completionHandler;
+                  completionHandler:(FBSDKGamingServiceCompletionHandler)completionHandler
+                      pendingResult:(id)pendingResult;
 
 - (void)callWithArgument:(NSString *)argument;
 

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSUInteger, FBSDKGamingServiceType) {
 @interface FBSDKGamingServiceController : NSObject <FBSDKURLOpening>
 
 - (instancetype)initWithServiceType:(FBSDKGamingServiceType)serviceType
-                  completionHandler:(FBSDKGamingServiceCompletionHandler)completionHandler
+                  completionHandler:(FBSDKGamingServiceResultCompletionHandler)completionHandler
                       pendingResult:(id)pendingResult;
 
 - (void)callWithArgument:(NSString *)argument;

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.m
@@ -50,14 +50,17 @@ static NSURL* FBSDKGamingServicesUrl(FBSDKGamingServiceType serviceType, NSStrin
 {
   FBSDKGamingServiceType _serviceType;
   FBSDKGamingServiceCompletionHandler _completionHandler;
+  id _pendingResult;
 }
 
 - (instancetype)initWithServiceType:(FBSDKGamingServiceType)serviceType
                   completionHandler:(FBSDKGamingServiceCompletionHandler)completionHandler
+                      pendingResult:(id)pendingResult
 {
   if (self = [super init]) {
     _serviceType = serviceType;
     _completionHandler = completionHandler;
+    _pendingResult = pendingResult;
   }
   return self;
 }
@@ -82,14 +85,18 @@ static NSURL* FBSDKGamingServicesUrl(FBSDKGamingServiceType serviceType, NSStrin
   }
 
   if (error) {
-    _completionHandler(false, [FBSDKError
-                               errorWithCode:FBSDKErrorBridgeAPIInterruption
-                               message:@"Error occured while interacting with Gaming Services"
-                               underlyingError:error]);
+    _completionHandler(false,
+                       [FBSDKError
+                        errorWithCode:FBSDKErrorBridgeAPIInterruption
+                        message:@"Error occured while interacting with Gaming Services"
+                        underlyingError:error],
+                       nil);
   } else {
-    _completionHandler(false, [FBSDKError
-                               errorWithCode:FBSDKErrorBridgeAPIInterruption
-                               message:@"An Unknown error occured while interacting with Gaming Services"]);
+    _completionHandler(false,
+                       [FBSDKError
+                        errorWithCode:FBSDKErrorBridgeAPIInterruption
+                        message:@"An Unknown error occured while interacting with Gaming Services"],
+                       nil);
   }
 
   _completionHandler = nil;
@@ -97,7 +104,7 @@ static NSURL* FBSDKGamingServicesUrl(FBSDKGamingServiceType serviceType, NSStrin
 
 - (void)completeSuccessfully
 {
-  _completionHandler(true, nil);
+  _completionHandler(true, nil, _pendingResult);
   _completionHandler = nil;
 }
 

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.m
@@ -49,12 +49,12 @@ static NSURL* FBSDKGamingServicesUrl(FBSDKGamingServiceType serviceType, NSStrin
 @implementation FBSDKGamingServiceController
 {
   FBSDKGamingServiceType _serviceType;
-  FBSDKGamingServiceCompletionHandler _completionHandler;
+  FBSDKGamingServiceResultCompletionHandler _completionHandler;
   id _pendingResult;
 }
 
 - (instancetype)initWithServiceType:(FBSDKGamingServiceType)serviceType
-                  completionHandler:(FBSDKGamingServiceCompletionHandler)completionHandler
+                  completionHandler:(FBSDKGamingServiceResultCompletionHandler)completionHandler
                       pendingResult:(id)pendingResult
 {
   if (self = [super init]) {
@@ -86,17 +86,17 @@ static NSURL* FBSDKGamingServicesUrl(FBSDKGamingServiceType serviceType, NSStrin
 
   if (error) {
     _completionHandler(false,
+                       nil,
                        [FBSDKError
-                        errorWithCode:FBSDKErrorBridgeAPIInterruption
-                        message:@"Error occured while interacting with Gaming Services"
-                        underlyingError:error],
-                       nil);
+                       errorWithCode:FBSDKErrorBridgeAPIInterruption
+                       message:@"Error occured while interacting with Gaming Services"
+                       underlyingError:error]);
   } else {
     _completionHandler(false,
+                       nil,
                        [FBSDKError
                         errorWithCode:FBSDKErrorBridgeAPIInterruption
-                        message:@"An Unknown error occured while interacting with Gaming Services"],
-                       nil);
+                        message:@"An Unknown error occured while interacting with Gaming Services"]);
   }
 
   _completionHandler = nil;
@@ -104,7 +104,7 @@ static NSURL* FBSDKGamingServicesUrl(FBSDKGamingServiceType serviceType, NSStrin
 
 - (void)completeSuccessfully
 {
-  _completionHandler(true, nil, _pendingResult);
+  _completionHandler(true, _pendingResult, nil);
   _completionHandler = nil;
 }
 

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKFriendFinderDialogTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKFriendFinderDialogTests.m
@@ -51,7 +51,7 @@
 
   __block BOOL actioned = false;
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorAccessTokenRequired, "Expected error requiring a valid access token");
     actioned = true;
   }];
@@ -70,7 +70,7 @@
   id expectation = [self expectationWithDescription:@"callback"];
 
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     [expectation fulfill];
   }];
 
@@ -91,7 +91,7 @@
 
   id expectation = [self expectationWithDescription:@"callback"];
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertFalse(success);
     XCTAssert(error.code == FBSDKErrorBridgeAPIInterruption);
     [expectation fulfill];
@@ -112,7 +112,7 @@
 
   __block BOOL actioned = false;
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertTrue(success);
     actioned = true;
   }];
@@ -131,7 +131,7 @@
 
   __block BOOL actioned = false;
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertTrue(success);
     actioned = true;
   }];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKFriendFinderDialogTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKFriendFinderDialogTests.m
@@ -51,7 +51,7 @@
 
   __block BOOL actioned = false;
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorAccessTokenRequired, "Expected error requiring a valid access token");
     actioned = true;
   }];
@@ -70,7 +70,7 @@
   id expectation = [self expectationWithDescription:@"callback"];
 
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
     [expectation fulfill];
   }];
 
@@ -91,7 +91,7 @@
 
   id expectation = [self expectationWithDescription:@"callback"];
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
     XCTAssertFalse(success);
     XCTAssert(error.code == FBSDKErrorBridgeAPIInterruption);
     [expectation fulfill];
@@ -112,7 +112,7 @@
 
   __block BOOL actioned = false;
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
     XCTAssertTrue(success);
     actioned = true;
   }];
@@ -131,7 +131,7 @@
 
   __block BOOL actioned = false;
   [FBSDKFriendFinderDialog
-   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   launchFriendFinderDialogWithCompletionHandler:^(BOOL success, NSError * _Nullable error) {
     XCTAssertTrue(success);
     actioned = true;
   }];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingImageUploaderTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingImageUploaderTests.m
@@ -72,7 +72,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorAccessTokenRequired, "Expected error requiring a valid access token");
     actioned = true;
   }];
@@ -87,7 +87,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:nilImageConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorInvalidArgument, "Expected error requiring a non nil image");
     actioned = true;
   }];
@@ -102,7 +102,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorGraphRequestGraphAPI, "Expected error from Graph API");
     actioned = true;
   }];
@@ -117,7 +117,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssertTrue(success);
     XCTAssertNil(error);
     actioned = true;
@@ -134,7 +134,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     actioned = true;
   }];
 
@@ -157,7 +157,7 @@
 
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     [expectation fulfill];
   }];
 
@@ -185,7 +185,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssertTrue(success);
     actioned = true;
   }];
@@ -212,7 +212,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssertTrue(success);
     actioned = true;
   }];
@@ -236,7 +236,7 @@
   __block BOOL progressActioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   completionHandler:^(BOOL success, NSError * _Nullable error, id  _Nullable result) {
+   completionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(success);
     XCTAssertEqual(result[@"id"], @"foo");
     completionActioned = true;

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingImageUploaderTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingImageUploaderTests.m
@@ -151,6 +151,8 @@
            options:[OCMArg any]
            completionHandler:([OCMArg invokeBlockWithArgs:@(false), nil])]);
 
+  // This will cause an lint warning, ignore it, this is an external sdk test
+  // @lint-ignore FBOBJCDISCOURAGEDFUNCTION
   id expectation = [self expectationWithDescription:@"callback"];
 
   [FBSDKGamingImageUploader
@@ -234,10 +236,18 @@
 
 - (void)stubGraphRequestWithResult:(id)result error:(NSError *)error
 {
-  id mock = OCMClassMock([FBSDKGraphRequest class]);
-  OCMStub([mock alloc]).andReturn(mock);
-  OCMStub([mock initWithGraphPath:[OCMArg any] parameters:[OCMArg any] HTTPMethod:[OCMArg any]]).andReturn(mock);
-  OCMStub([mock startWithCompletionHandler:[OCMArg checkWithBlock:^BOOL(id obj) {
+  id mockRequest = OCMClassMock([FBSDKGraphRequest class]);
+  OCMStub([mockRequest alloc]).andReturn(mockRequest);
+  OCMStub([mockRequest initWithGraphPath:[OCMArg any] parameters:[OCMArg any] HTTPMethod:[OCMArg any]]).andReturn(mockRequest);
+
+  __block id delegate;
+  id mockConnection = OCMClassMock([FBSDKGraphRequestConnection class]);
+  OCMStub([mockConnection alloc]).andReturn(mockConnection);
+  OCMStub([mockConnection setDelegate:[OCMArg checkWithBlock:^BOOL(id obj) {
+    delegate = obj;
+    return true;
+  }]]);
+  OCMStub([mockConnection addRequest:[OCMArg isEqual:mockRequest] completionHandler:[OCMArg checkWithBlock:^BOOL(id obj) {
     ((FBSDKGraphRequestBlock) obj)(nil, result, error);
     return true;
   }]]);

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingImageUploaderTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingImageUploaderTests.m
@@ -72,7 +72,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorAccessTokenRequired, "Expected error requiring a valid access token");
     actioned = true;
   }];
@@ -87,7 +87,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:nilImageConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorInvalidArgument, "Expected error requiring a non nil image");
     actioned = true;
   }];
@@ -102,7 +102,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorGraphRequestGraphAPI, "Expected error from Graph API");
     actioned = true;
   }];
@@ -117,7 +117,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertTrue(success);
     XCTAssertNil(error);
     actioned = true;
@@ -134,7 +134,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     actioned = true;
   }];
 
@@ -155,7 +155,7 @@
 
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     [expectation fulfill];
   }];
 
@@ -183,7 +183,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertTrue(success);
     actioned = true;
   }];
@@ -210,7 +210,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingImageUploader
    uploadImageWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertTrue(success);
     actioned = true;
   }];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingVideoUploaderTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingVideoUploaderTests.m
@@ -66,7 +66,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorAccessTokenRequired, "Expected error requiring a valid access token");
     actioned = true;
   }];
@@ -81,7 +81,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:nilVideoConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorInvalidArgument, "Expected error requiring a non nil video url");
     actioned = true;
   }];
@@ -97,7 +97,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:badVideoConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorInvalidArgument, "Expected error requiring a non nil video url");
     actioned = true;
   }];
@@ -117,7 +117,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == expectedError.code);
     actioned = true;
   }];
@@ -137,7 +137,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssert(error.code == FBSDKErrorUnknown);
     actioned = true;
   }];
@@ -161,7 +161,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
     XCTAssertTrue(success);
     actioned = true;
   }];

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingVideoUploaderTests.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/FBSDKGamingVideoUploaderTests.m
@@ -66,7 +66,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorAccessTokenRequired, "Expected error requiring a valid access token");
     actioned = true;
   }];
@@ -81,7 +81,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:nilVideoConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorInvalidArgument, "Expected error requiring a non nil video url");
     actioned = true;
   }];
@@ -97,7 +97,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:badVideoConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorInvalidArgument, "Expected error requiring a non nil video url");
     actioned = true;
   }];
@@ -117,7 +117,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == expectedError.code);
     actioned = true;
   }];
@@ -137,7 +137,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssert(error.code == FBSDKErrorUnknown);
     actioned = true;
   }];
@@ -161,7 +161,7 @@
   __block BOOL actioned = false;
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   andCompletionHandler:^(BOOL success, NSError * _Nullable error, id result) {
+   andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
     XCTAssertTrue(success);
     actioned = true;
   }];
@@ -193,7 +193,7 @@
 
   [FBSDKGamingVideoUploader
    uploadVideoWithConfiguration:_mockConfig
-   completionHandler:^(BOOL success, NSError * _Nullable error, id  _Nullable result) {}
+   completionHandler:^(BOOL success, id result, NSError * _Nullable error) {}
    andProgressHandler:^(int64_t bytesSent, int64_t totalBytesSent, int64_t totalBytesExpectedToSend) {
     ProgressCheck(bytesSent, totalBytesSent, totalBytesExpectedToSend);
   }];


### PR DESCRIPTION
Summary: Deprecating `completionHandler:(FBSDKGamingServiceCompletionHandler)completionHandler` in favor of the new `completionHandler:(FBSDKGamingServiceResultCompletionHandler)completionHandler` which can carry a result.

Reviewed By: joesus

Differential Revision: D20844271

