### PR TITLE
Fix "implicit conversion loses integer precision"

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelRuntime.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKModelRuntime.hpp
@@ -93,7 +93,7 @@ static MTensor embedding(const char *texts, const int seq_length, const MTensor&
   float *y_data = y.mutable_data();
   for (int i = 0; i < n_examples; i++) {
     for (int j = 0; j < seq_length; j++) {
-      memcpy(y_data, w_data + vec[i * seq_length + j] * embedding_size, embedding_size * sizeof(float));
+      memcpy(y_data, w_data + vec[i * seq_length + j] * embedding_size, (size_t)(embedding_size * sizeof(float)));
       y_data += embedding_size;
     }
   }
@@ -147,7 +147,7 @@ static MTensor conv1D(const MTensor& x, const MTensor& w) {
             temp_w_data[m * input_size + k] = w_data[(m * input_size + k) * output_size + o];
           }
         }
-        vDSP_dotpr(temp_x_data, 1, temp_w_data, 1, &sum, kernel_size * input_size);
+        vDSP_dotpr(temp_x_data, 1, temp_w_data, 1, &sum, (size_t)(kernel_size * input_size));
         y_data[(n * (output_size * (seq_len - kernel_size + 1)) + i * output_size + o)] = sum;
       }
     }

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKTensor.hpp
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/ML/FBSDKTensor.hpp
@@ -70,7 +70,7 @@ public:
     for (auto size : sizes) {
       capacity_ *= size;
     }
-    storage_ = std::shared_ptr<void>(MAllocateMemory(capacity_ * sizeof(float)), MFreeMemory);
+    storage_ = std::shared_ptr<void>(MAllocateMemory((size_t)capacity_ * sizeof(float)), MFreeMemory);
   }
 
   MAT_ALWAYS_INLINE int64_t count() const {
@@ -104,7 +104,7 @@ public:
     }
     if (count > capacity_) {
       capacity_ = count;
-      storage_.reset(MAllocateMemory(capacity_ * sizeof(float)), MFreeMemory);
+      storage_.reset(MAllocateMemory((size_t)capacity_ * sizeof(float)), MFreeMemory);
     }
     sizes_ = sizes;
   }


### PR DESCRIPTION
Summary: Fix the error of "implicit conversion loses integer precision: 'long long' to 'size_t' (aka 'unsigned long') [-Werror,-Wshorten-64-to-32]"

Differential Revision: D20978555

