### PR TITLE
Fix the failure of building swift package to support c++11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -136,5 +136,6 @@ let package = Package(
             dependencies: ["FacebookCore", "FBSDKGamingServicesKit"],
             path: "FBSDKGamingServicesKit/FBSDKGamingServicesKit/Swift"
         ),
-    ]
+    ],
+    cxxLanguageStandard: CXXLanguageStandard.cxx11
 )


### PR DESCRIPTION
Summary:
Add c++11 supporting for SPM to align with other build configuration

Previously, the swift package build failed because it was not supporting c++ initializer list constructor
https://pxl.cl/14W7Q

Differential Revision: D20980386

