### PR TITLE
Updating GameRequest to use Safari to prevent relogin

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestDialog.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKGameRequestDialog.m
@@ -221,7 +221,7 @@ static FBSDKGameRequestFrictionlessRecipientCache *_recipientCache = nil;
   __weak typeof(self) weakSelf = self;
   [[FBSDKBridgeAPI sharedInstance]
    openBridgeAPIRequest:request
-   useSafariViewController:true
+   useSafariViewController:false
    fromViewController:topMostViewController
    completionBlock:^(FBSDKBridgeAPIResponse *response) {
     [weakSelf _handleBridgeAPIResponse:response];


### PR DESCRIPTION
Summary: Linking out to Safari to handle GameRequests

Reviewed By: joesus

Differential Revision: D21030357

