### PR TITLE
Sharing Delegate Nullability Fix

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit.xcodeproj/project.pbxproj
+++ b/FBSDKShareKit/FBSDKShareKit.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 		F487DC7C231EC4CC008416A9 /* FBSDKShareButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 895D8FE31A5F44E9006B16EF /* FBSDKShareButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F487DC80231EC4CC008416A9 /* FBSDKLikeDialog.h in Headers */ = {isa = PBXBuildFile; fileRef = 89D05A761A9FE4CB00609300 /* FBSDKLikeDialog.h */; };
 		F487DC81231EC4CC008416A9 /* FBSDKGameRequestContent.h in Headers */ = {isa = PBXBuildFile; fileRef = 89F2037E1AA922DB0053499E /* FBSDKGameRequestContent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F4D7A84724520A6700A12EE5 /* FakeSharingDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F4D7A84624520A6700A12EE5 /* FakeSharingDelegate.m */; };
 		F4E7517223EA18C20061BBFC /* FBSDKMessageDialogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E7516823EA18C10061BBFC /* FBSDKMessageDialogTests.m */; };
 		F4E7517D23EA19010061BBFC /* FBSDKSendButton.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E7517423EA19000061BBFC /* FBSDKSendButton.m */; };
 		F4E7517E23EA19010061BBFC /* FBSDKSendButton.m in Sources */ = {isa = PBXBuildFile; fileRef = F4E7517423EA19000061BBFC /* FBSDKSendButton.m */; };
@@ -725,6 +726,8 @@
 		F4430BAD2322AF65004C3925 /* Enums+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Enums+Extensions.swift"; path = "Swift/Enums+Extensions.swift"; sourceTree = "<group>"; };
 		F483F4CA233AC91700703DE3 /* FBSDKShareKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKShareKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F487DC86231EC4CC008416A9 /* FBSDKShareKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FBSDKShareKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4D7A84524520A6700A12EE5 /* FakeSharingDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FakeSharingDelegate.h; sourceTree = "<group>"; };
+		F4D7A84624520A6700A12EE5 /* FakeSharingDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FakeSharingDelegate.m; sourceTree = "<group>"; };
 		F4E7516823EA18C10061BBFC /* FBSDKMessageDialogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKMessageDialogTests.m; sourceTree = "<group>"; };
 		F4E7517323EA19000061BBFC /* FBSDKMessageDialog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKMessageDialog.h; sourceTree = "<group>"; };
 		F4E7517423EA19000061BBFC /* FBSDKSendButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKSendButton.m; sourceTree = "<group>"; };
@@ -1082,6 +1085,8 @@
 		9D46C5FF1A11E5D800A0DDB6 /* FBSDKShareKitTests */ = {
 			isa = PBXGroup;
 			children = (
+				F4D7A84524520A6700A12EE5 /* FakeSharingDelegate.h */,
+				F4D7A84624520A6700A12EE5 /* FakeSharingDelegate.m */,
 				F4E7516823EA18C10061BBFC /* FBSDKMessageDialogTests.m */,
 				89FC8C431AC99B8A004187B2 /* FBSDKShareDialogTests.m */,
 				896A52A11B795AAB00E3A6AB /* FBSDKShareKitTestUtility.h */,
@@ -1904,6 +1909,7 @@
 				896DE2251A9E33CC00195731 /* FBSDKShareVideoTests.m in Sources */,
 				F4E7517223EA18C20061BBFC /* FBSDKMessageDialogTests.m in Sources */,
 				EAC370A31AAE3A9C000F0F04 /* FBSDKGameRequestContentTests.m in Sources */,
+				F4D7A84724520A6700A12EE5 /* FakeSharingDelegate.m in Sources */,
 				896B8C851A7967290074220D /* FBSDKShareUtilityTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKMessageDialog.m
@@ -209,18 +209,20 @@
   NSMutableDictionary * parameters = [NSMutableDictionary dictionaryWithObjectsAndKeys:FBSDKAppEventsDialogOutcomeValue_Failed, FBSDKAppEventParameterDialogOutcome, nil];
   if (error) {
     parameters[FBSDKAppEventParameterDialogErrorMessage] = [NSString stringWithFormat:@"%@", error];
-  }
 
-  [FBSDKAppEvents logInternalEvent:FBSDKAppEventNameFBSDKEventMessengerShareDialogResult
-                        parameters:parameters
-                isImplicitlyLogged:YES
-                       accessToken:[FBSDKAccessToken currentAccessToken]];
+    [FBSDKAppEvents logInternalEvent:FBSDKAppEventNameFBSDKEventMessengerShareDialogResult
+                          parameters:parameters
+                  isImplicitlyLogged:YES
+                         accessToken:[FBSDKAccessToken currentAccessToken]];
 
-  if (!_delegate) {
+    if (!_delegate) {
+      return;
+    }
+
+    [_delegate sharer:self didFailWithError:error];
+  } else {
     return;
   }
-
-  [_delegate sharer:self didFailWithError:error];
 }
 
 - (void)_logDialogShow

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKSharing.h
@@ -109,7 +109,7 @@ NS_SWIFT_NAME(SharingDelegate)
  @param sharer The FBSDKSharing that completed.
  @param error The error.
  */
-- (void)sharer:(id<FBSDKSharing>)sharer didFailWithError:(NSError * _Nullable)error;
+- (void)sharer:(id<FBSDKSharing>)sharer didFailWithError:(NSError *)error;
 
 /**
   Sent to the delegate when the sharer is cancelled.

--- a/FBSDKShareKit/FBSDKShareKitTests/FakeSharingDelegate.h
+++ b/FBSDKShareKit/FBSDKShareKitTests/FakeSharingDelegate.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#import "FBSDKSharing.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FakeSharingDelegate : NSObject<FBSDKSharingDelegate>
+
+@property (nonatomic) NSDictionary<NSString *, id> *capturedResults;
+@property (nonatomic) NSError *capturedError;
+@property (nonatomic) BOOL didCancel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBSDKShareKit/FBSDKShareKitTests/FakeSharingDelegate.m
+++ b/FBSDKShareKit/FBSDKShareKitTests/FakeSharingDelegate.m
@@ -1,0 +1,35 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "FakeSharingDelegate.h"
+
+@implementation FakeSharingDelegate
+
+- (void)sharer:(nonnull id<FBSDKSharing>)sharer didCompleteWithResults:(nonnull NSDictionary<NSString *,id> *)results {
+  self.capturedResults = results;
+}
+
+- (void)sharer:(nonnull id<FBSDKSharing>)sharer didFailWithError:(nonnull NSError *)error {
+  self.capturedError = error;
+}
+
+- (void)sharerDidCancel:(nonnull id<FBSDKSharing>)sharer {
+  self.didCancel = true;
+}
+
+@end


### PR DESCRIPTION
Summary: Decided making the error in the share delegate callback nullable was nonsense. Better to fix the callsites so it can't be called with a null error.

Differential Revision: D21208377

