### PR TITLE
Fixing crash where IGFBSDKAccessToken doesn't fully follow FBSDKAccessToken

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -43,6 +43,13 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift)
 
 @implementation FBSDKInternalUtility
 
+static BOOL ShouldOverrideHostWithGamingDomain(NSString *hostPrefix) {
+  return
+  [[FBSDKAccessToken currentAccessToken] respondsToSelector:@selector(graphDomain)] &&
+  [[FBSDKAccessToken currentAccessToken].graphDomain isEqualToString:@"gaming"] &&
+  ([hostPrefix isEqualToString:@"graph."] || [hostPrefix isEqualToString:@"graph-video."]);
+}
+
 #pragma mark - Class Methods
 
 + (NSString *)appURLScheme
@@ -144,8 +151,7 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift)
   }
 
   NSString *host =
-  ([hostPrefix isEqualToString:@"graph."] || [hostPrefix isEqualToString:@"graph-video."]) &&
-  [[FBSDKAccessToken currentAccessToken].graphDomain isEqualToString:@"gaming"]
+  ShouldOverrideHostWithGamingDomain(hostPrefix)
   ? @"fb.gg"
   : @"facebook.com";
 


### PR DESCRIPTION
Summary: Ensuring compatibility with the Instagram SDK.

Reviewed By: joesus

Differential Revision: D21281232

