### PR TITLE
Fixing debugger crash in  mixed CocoaPod - SPM projects

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKCoreKitImport.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKCoreKitImport.h
@@ -23,7 +23,7 @@
 
 // Even though this file is not available from projects using SPM,
 // it is available when building the packages themselves so we need to include this check.
-#if SWIFT_PACKAGE
+#if FBSDK_SWIFT_PACKAGE
 #import <FBSDKCoreKit.h>
 #else
 #import <FBSDKCoreKit/FBSDKCoreKit.h>

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKCoreKitImport.h
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKCoreKitImport.h
@@ -23,7 +23,7 @@
 
 // Even though this file is not available from projects using SPM,
 // it is available when building the packages themselves so we need to include this check.
-#if SWIFT_PACKAGE
+#if FBSDK_SWIFT_PACKAGE
 #import <FBSDKCoreKit.h>
 #else
 #import <FBSDKCoreKit/FBSDKCoreKit.h>

--- a/Package.swift
+++ b/Package.swift
@@ -99,6 +99,7 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("Internal"),
                 .headerSearchPath("../../FBSDKCoreKit/FBSDKCoreKit/Internal"),
+                .define("FBSDK_SWIFT_PACKAGE", to: nil, .when(platforms: [.iOS], configuration: nil)),
             ]
         ),
         .target(
@@ -114,6 +115,7 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("Internal"),
                 .headerSearchPath("../../FBSDKCoreKit/FBSDKCoreKit/Internal"),
+                .define("FBSDK_SWIFT_PACKAGE", to: nil, .when(platforms: [.iOS], configuration: nil)),
             ]
         ),
         .target(


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Fixes #1360

This is pretty wild. To reproduce the issue create a new sample project with the following pods:

```
  pod 'FBSDKCoreKit'
  pod 'FBSDKLoginKit'
  pod 'FBSDKShareKit'
```

Run the project with a breakpoint.

Result:
Debugger works as expected.

Then add an arbitrary Swift Package. I used Alamofire to test this.
`https://github.com/alamofire/alamofire`

Run the project with a breakpoint.

Result:
Debugger is broken.

**Why this is happening:**
It seems that during compile time, the macro SWIFT_PACKAGE is not available but it is available at runtime.

**Solution**
Use a more specific macro to identify when we are building the Swift Package for the SDK and not rely on the system provided macro.

## Test Plan

Test Plan: Follow repro instructions with the new code. Should be able to access symbols in the debugger.
