### PR TITLE
Update 'statusBarOrientation' callsites to be compatible through all supported iOS versions

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKAppLinkReturnToRefererView.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKAppLinkReturnToRefererView.m
@@ -24,6 +24,7 @@
 
 #import "FBSDKAppLink.h"
 #import "FBSDKAppLinkTarget.h"
+#import "FBSDKInternalUtility.h"
 
 static const CGFloat FBSDKMarginX = 8.5f;
 static const CGFloat FBSDKMarginY = 8.5f;
@@ -160,7 +161,7 @@ static const CGFloat FBSDKCloseButtonHeight = 12.0;
             break;
     }
     if (include && !application.statusBarHidden) {
-        BOOL landscape = UIInterfaceOrientationIsLandscape(application.statusBarOrientation);
+        BOOL landscape = UIInterfaceOrientationIsLandscape(FBSDKInternalUtility.statusBarOrientation);
         CGRect statusBarFrame = application.statusBarFrame;
         return landscape ? CGRectGetWidth(statusBarFrame) : CGRectGetHeight(statusBarFrame);
     }

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.h
@@ -283,6 +283,11 @@ NS_SWIFT_NAME(InternalUtility)
 + (nullable UIViewController *)topMostViewController;
 
 /**
+  returns interface orientation for the key window.
+ */
++ (UIInterfaceOrientation)statusBarOrientation;
+
+/**
   Converts NSData to a hexadecimal UTF8 String.
  */
 + (nullable NSString *)hexadecimalStringFromData:(NSData *)data;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -556,6 +556,17 @@ static NSMapTable *_transientObjects;
   return topController;
 }
 
++ (UIInterfaceOrientation)statusBarOrientation
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+  if (@available(iOS 13.0, *)) {
+    return [self findWindow].windowScene.interfaceOrientation;
+  }
+#else
+  return UIApplication.sharedApplication.statusBarOrientation;
+#endif
+}
+
 + (NSString *)hexadecimalStringFromData:(NSData *)data
 {
   NSUInteger dataLength = data.length;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
@@ -29,6 +29,7 @@
 #import "FBSDKSettings.h"
 #import "FBSDKTypeUtility.h"
 #import "FBSDKWebDialogView.h"
+#import "FBSDKInternalUtility.h"
 
 #define FBSDK_WEB_DIALOG_SHOW_ANIMATION_DURATION 0.2
 #define FBSDK_WEB_DIALOG_DISMISS_ANIMATION_DURATION 0.3
@@ -267,7 +268,7 @@ static FBSDKWebDialog *g_currentDialog = nil;
   // iOS 8 simply adjusts the application frame to adapt to the current orientation and deprecated the concept of
   // interface orientations
   if ([FBSDKInternalUtility shouldManuallyAdjustOrientation]) {
-    switch ([UIApplication sharedApplication].statusBarOrientation) {
+    switch (FBSDKInternalUtility.statusBarOrientation) {
       case UIInterfaceOrientationLandscapeLeft:
         return CGAffineTransformMakeRotation(M_PI * 1.5);
       case UIInterfaceOrientationLandscapeRight:
@@ -303,7 +304,7 @@ static FBSDKWebDialog *g_currentDialog = nil;
   applicationFrame.size.height -= insets.top + insets.bottom;
 
   if ([FBSDKInternalUtility shouldManuallyAdjustOrientation]) {
-    switch ([UIApplication sharedApplication].statusBarOrientation) {
+    switch (FBSDKInternalUtility.statusBarOrientation) {
       case UIInterfaceOrientationLandscapeLeft:
       case UIInterfaceOrientationLandscapeRight:
         return CGRectMake(0, 0, CGRectGetHeight(applicationFrame), CGRectGetWidth(applicationFrame));


### PR DESCRIPTION
Summary: Update `statusBarOrientation` call sites to call a new method on `FBSDKBridgeAPI` that is compatible across all current supported iOS versions 8-13.

Reviewed By: joesus

Differential Revision: D21284393

