### PR TITLE
Update 'statusBarOrientation' callsites to be compatible through all …

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKAppLinkReturnToRefererView.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKAppLinkReturnToRefererView.m
@@ -24,6 +24,7 @@
 
 #import "FBSDKAppLink.h"
 #import "FBSDKAppLinkTarget.h"
+#import "FBSDKInternalUtility.h"
 
 static const CGFloat FBSDKMarginX = 8.5f;
 static const CGFloat FBSDKMarginY = 8.5f;
@@ -160,7 +161,7 @@ static const CGFloat FBSDKCloseButtonHeight = 12.0;
             break;
     }
     if (include && !application.statusBarHidden) {
-        BOOL landscape = UIInterfaceOrientationIsLandscape(application.statusBarOrientation);
+        BOOL landscape = UIInterfaceOrientationIsLandscape(FBSDKInternalUtility.statusBarOrientation);
         CGRect statusBarFrame = application.statusBarFrame;
         return landscape ? CGRectGetWidth(statusBarFrame) : CGRectGetHeight(statusBarFrame);
     }

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.h
@@ -282,6 +282,13 @@ NS_SWIFT_NAME(InternalUtility)
  */
 + (nullable UIViewController *)topMostViewController;
 
+#if !TARGET_OS_TV
+/**
+  returns interface orientation for the key window.
+ */
++ (UIInterfaceOrientation)statusBarOrientation;
+#endif
+
 /**
   Converts NSData to a hexadecimal UTF8 String.
  */

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -556,6 +556,21 @@ static NSMapTable *_transientObjects;
   return topController;
 }
 
+#if !TARGET_OS_TV
++ (UIInterfaceOrientation)statusBarOrientation
+{
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+  if (@available(iOS 13.0, *)) {
+    return [self findWindow].windowScene.interfaceOrientation;
+  } else {
+    return UIInterfaceOrientationUnknown;
+  }
+#else
+  return UIApplication.sharedApplication.statusBarOrientation;
+#endif
+}
+#endif
+
 + (NSString *)hexadecimalStringFromData:(NSData *)data
 {
   NSUInteger dataLength = data.length;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
@@ -29,6 +29,7 @@
 #import "FBSDKSettings.h"
 #import "FBSDKTypeUtility.h"
 #import "FBSDKWebDialogView.h"
+#import "FBSDKInternalUtility.h"
 
 #define FBSDK_WEB_DIALOG_SHOW_ANIMATION_DURATION 0.2
 #define FBSDK_WEB_DIALOG_DISMISS_ANIMATION_DURATION 0.3
@@ -267,7 +268,7 @@ static FBSDKWebDialog *g_currentDialog = nil;
   // iOS 8 simply adjusts the application frame to adapt to the current orientation and deprecated the concept of
   // interface orientations
   if ([FBSDKInternalUtility shouldManuallyAdjustOrientation]) {
-    switch ([UIApplication sharedApplication].statusBarOrientation) {
+    switch (FBSDKInternalUtility.statusBarOrientation) {
       case UIInterfaceOrientationLandscapeLeft:
         return CGAffineTransformMakeRotation(M_PI * 1.5);
       case UIInterfaceOrientationLandscapeRight:
@@ -303,7 +304,7 @@ static FBSDKWebDialog *g_currentDialog = nil;
   applicationFrame.size.height -= insets.top + insets.bottom;
 
   if ([FBSDKInternalUtility shouldManuallyAdjustOrientation]) {
-    switch ([UIApplication sharedApplication].statusBarOrientation) {
+    switch (FBSDKInternalUtility.statusBarOrientation) {
       case UIInterfaceOrientationLandscapeLeft:
       case UIInterfaceOrientationLandscapeRight:
         return CGRectMake(0, 0, CGRectGetHeight(applicationFrame), CGRectGetWidth(applicationFrame));


### PR DESCRIPTION
…supported iOS versions (#1363)

Summary:
Pull Request resolved: https://github.com/facebook/facebook-ios-sdk/pull/1363

Update `statusBarOrientation` call sites to call a new method on `FBSDKBridgeAPI` that is compatible across all current supported iOS versions 8-13.

Reviewed By: joesus

Differential Revision: D21284393

fbshipit-source-id: feb22a6b32c46b86fdac5b66b90f96e1f5fb64af

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [ ] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
