### PR TITLE
Make pods modular

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -14,16 +14,17 @@ Pod::Spec.new do |s|
                    DESC
 
   s.homepage     = 'https://developers.facebook.com/docs/ios/'
-  s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
+  s.license      = { type: 'Facebook Platform License', file: 'LICENSE' }
   s.author       = 'Facebook'
 
   s.platform     = :ios, :tvos
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '10.0'
 
-  s.source       = { :git => 'https://github.com/facebook/facebook-ios-sdk.git',
-                     :tag => "v#{s.version}"
-                    }
+  s.source       = {
+    git: 'https://github.com/facebook/facebook-ios-sdk.git',
+    tag: "v#{s.version}"
+  }
 
   s.ios.weak_frameworks = 'Accelerate', 'Accounts', 'Social', 'Security', 'QuartzCore', 'CoreGraphics', 'UIKit', 'Foundation', 'AudioToolbox'
   s.tvos.weak_frameworks = 'CoreLocation', 'Security', 'QuartzCore', 'CoreGraphics', 'UIKit', 'Foundation', 'AudioToolbox'
@@ -38,8 +39,11 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Core', 'Basics'
   s.swift_version = '5.0'
-  s.pod_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
-  s.user_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
+  s.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS': '$(inherited) FBSDKCOCOAPODS=1',
+    'DEFINES_MODULE': 'YES'
+  }
+  s.user_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS': '$(inherited) FBSDKCOCOAPODS=1' }
   s.library = 'c++', 'stdc++'
 
   s.subspec 'Basics' do |ss|

--- a/FBSDKGamingServicesKit.podspec
+++ b/FBSDKGamingServicesKit.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
                    DESC
 
   s.homepage     = 'https://developers.facebook.com/docs/ios/'
-  s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
+  s.license      = { type: 'Facebook Platform License', file: 'LICENSE' }
   s.author       = 'Facebook'
 
   s.platform     = :ios
@@ -20,13 +20,15 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.source       = { :git => 'https://github.com/facebook/facebook-ios-sdk.git',
-                     :tag => "v#{s.version}"
-                    }
+  s.source       = {
+    git: 'https://github.com/facebook/facebook-ios-sdk.git',
+    tag: "v#{s.version}"
+  }
 
   s.weak_frameworks = 'Accounts', 'Social', 'Security', 'Foundation'
 
   s.requires_arc = true
+  s.pod_target_xcconfig = { 'DEFINES_MODULE': 'YES' }
   s.prefix_header_contents = '#define FBSDKCOCOAPODS'
 
   s.source_files   = 'FBSDKGamingServicesKit/FBSDKGamingServicesKit/**/*.{h,m}'

--- a/FBSDKLoginKit.podspec
+++ b/FBSDKLoginKit.podspec
@@ -14,16 +14,20 @@ Pod::Spec.new do |s|
                    DESC
 
   s.homepage     = 'https://developers.facebook.com/docs/ios/'
-  s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
+  s.license      = {
+    type: 'Facebook Platform License',
+    file: 'LICENSE'
+  }
   s.author       = 'Facebook'
 
   s.platform     = :ios, :tvos
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '10.0'
 
-  s.source       = { :git => 'https://github.com/facebook/facebook-ios-sdk.git',
-                     :tag => "v#{s.version}"
-                    }
+  s.source       = {
+    git: 'https://github.com/facebook/facebook-ios-sdk.git',
+    tag: "v#{s.version}"
+  }
 
   s.ios.weak_frameworks = 'Accounts', 'Social', 'Security', 'QuartzCore', 'CoreGraphics', 'UIKit', 'Foundation', 'AudioToolbox'
   s.tvos.weak_frameworks = 'AudioToolbox', 'CoreGraphics', 'Foundation', 'QuartzCore', 'Security', 'UIKit'

--- a/FBSDKShareKit.podspec
+++ b/FBSDKShareKit.podspec
@@ -14,16 +14,20 @@ Pod::Spec.new do |s|
                    DESC
 
   s.homepage     = 'https://developers.facebook.com/docs/ios/'
-  s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
+  s.license      = {
+    type: 'Facebook Platform License',
+    file: 'LICENSE'
+  }
   s.author       = 'Facebook'
 
   s.platform     = :ios, :tvos
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '10.0'
 
-  s.source       = { :git => 'https://github.com/facebook/facebook-ios-sdk.git',
-                     :tag => "v#{s.version}"
-                    }
+  s.source       = {
+    git: 'https://github.com/facebook/facebook-ios-sdk.git',
+    tag: "v#{s.version}"
+  }
 
   s.ios.weak_frameworks = 'Accounts', 'AudioToolbox', 'CoreGraphics', 'Foundation', 'QuartzCore', 'Security', 'Social', 'UIKit'
   s.tvos.weak_frameworks = 'AudioToolbox', 'CoreGraphics', 'Foundation', 'QuartzCore', 'Security', 'UIKit'

--- a/FBSDKTVOSKit.podspec
+++ b/FBSDKTVOSKit.podspec
@@ -13,19 +13,26 @@ Pod::Spec.new do |s|
                    DESC
 
   s.homepage     = 'https://developers.facebook.com/docs/tvos'
-  s.license      = { :type => 'Facebook Platform License', :file => 'LICENSE' }
+  s.license      = {
+    type: 'Facebook Platform License',
+    file: 'LICENSE'
+  }
   s.author       = 'Facebook'
 
   s.platform     = :tvos
   s.tvos.deployment_target = '10.0'
 
-  s.source       = { :git => 'https://github.com/facebook/facebook-ios-sdk.git',
-                     :tag => "v#{s.version}" }
+  s.source       = {
+    git: 'https://github.com/facebook/facebook-ios-sdk.git',
+    tag: "v#{s.version}"
+  }
 
   s.source_files   = 'FBSDKTVOSKit/FBSDKTVOSKit/**/*.{h,m}'
   s.public_header_files = 'FBSDKTVOSKit/FBSDKTVOSKit/*.h'
   s.header_dir = 'FBSDKTVOSKit'
-  s.pod_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) FBSDKCOCOAPODS=1' }
+  s.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS': '$(inherited) FBSDKCOCOAPODS=1'
+  }
 
   s.dependency 'FBSDKCoreKit', "~> #{s.version}"
   s.dependency 'FBSDKShareKit', "~> #{s.version}"


### PR DESCRIPTION
Summary:
Cocoapods that combine Swift and ObjC need to enable modules to be statically loaded.

So in the Podfile if you need to include `use_modular_headers!` if you do NOT include `use_frameworks!`.

This is a pain for users who don't care about how we handle modular headers in our SDK so we should make it easy for them to be able to load our libraries statically and still import them as modules.

More info:
http://blog.cocoapods.org/CocoaPods-1.5.0/
https://stackoverflow.com/questions/52910973/how-to-remove-use-frameworks-and-keep-using-swift-pods-on-an-objective-c-projec

Also updates ruby syntax to be more readable.

Differential Revision: D22048806

