### PR TITLE
Header import fix

### DIFF
--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/FBSDKGamingServiceController.h
@@ -19,7 +19,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FBSDKCoreKit+Internal.h"
-#import "../FBSDKGamingServiceCompletionHandler.h"
+#import <FBSDKGamingServiceCompletionHandler.h>
 
 typedef NS_ENUM(NSUInteger, FBSDKGamingServiceType) {
   FBSDKGamingServiceTypeFriendFinder,


### PR DESCRIPTION
Summary:
This fails when using header map features in buck. Fix header import.
Determine the correct `#import` path via
`~/bin/hmaptool dump xxx#header-mode-symlink-tree-with-header-map,headers.hmap`

Differential Revision: D22358255

