### PR TITLE
Fix start app crash

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/FBSDKBasicUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/FBSDKBasicUtility.m
@@ -123,7 +123,8 @@ setJSONStringForObject:(id)object
     }
     return nil;
   }
-  return [FBSDKTypeUtility JSONObjectWithData:data options:NSJSONReadingAllowFragments error:errorRef];
+  id result = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:errorRef];
+  return result == [NSNull null] ? nil : result;
 }
 
 + (NSString *)queryStringWithDictionary:(NSDictionary<id, id> *)dictionary


### PR DESCRIPTION
PR adds a check for `NSNull` to [stop crashing](https://9to5mac.com/2020/07/10/app-crash-facebook-sdk/) apps using the SDK.

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Before changes:
Import the framework to your test app, run the app, check the app is crashing

After changes:
The app is no more crashing

## Test Plan

Import the framework and check the app is not crashing