### PR TITLE
fix issues: crash when parsing JSON object with `null` and not guardi…

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/FBSDKTypeUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Basics/Internal/FBSDKTypeUtility.m
@@ -183,6 +183,11 @@
   @catch (NSException *exception) {
      NSLog(@"FBSDKJSONSerialization - dataWithJSONObject:options:error failed: %@", exception.reason);
   }
+  
+  if ([data isEqual:[NSNull null]]) {
+     return nil;
+  }
+  
   return data;
 }
 
@@ -199,6 +204,11 @@
   @catch (NSException *exception) {
      NSLog(@"FBSDKJSONSerialization - JSONObjectWithData:options:error failed: %@", exception.reason);
   }
+  
+  if ([object isEqual:[NSNull null]]) {
+    return nil;
+  }
+  
   return object;
 }
 


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

## Issues 
- [1430](https://github.com/facebook/facebook-ios-sdk/issues/1430)
- [1432](https://github.com/facebook/facebook-ios-sdk/issues/1432)
Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

1. In my case, in the response in the `serverConfigurationRequest`, the value for `restrictive_data_filter_params` is `null`. Yes!!! `null` is a valid value in [`JSON` starndard](https://www.json.org/json-en.html).  
![image](https://user-images.githubusercontent.com/7471672/87173868-f5d8c400-c308-11ea-81fd-699c5443a43e.png)

2. Then after FB using `[NSJSONSerialization JSONObjectWithData: options: error:]` to serialize this object, it returns `NSNull` object without error, which is under expectation from Apple side. According to Apple's doc, `NSNull` is a singleton object. Yes!!!, it is a valid object, not like `nil`, which you can guard using `if (obj)` statement 
 
![image](https://user-images.githubusercontent.com/7471672/87174136-57009780-c309-11ea-9a0a-ca24369e96f9.png)


3. So, when FB try to use `if (serializedObj) { ... }` to guard this edge cases in many places, it is actually useless. Here `serializedObj` is a singleton object, the result is YES then it continues to send message, then, `unrecoginized selector` .  This issue haven't been fixed. Next time, when the server side sends an another object with `null`, we will see another disaster, a third disaster. 

So,  I made these changes for 3 reason: 

1. `null` is a valid value in [`JSON` starndard](https://www.json.org/json-en.html).  
2. `[NSJSONSerialization JSONObjectWithData: options: error:]` will return `NSNull` singleton object for `null` value in Object, it is under expectation. 
3. There are too many places in this SDK using the result of `[NSJSONSerialization JSONObjectWithData: options: error:]` without check `NSNull`.  This is could be an easier way to handle this edge case.



## Test Plan

Test Plan: **Add your test plan here**
