### PR TITLE
Remove global initializers for NSString

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.m
@@ -46,8 +46,8 @@ static NSString *const REPLACEMENT_STRING = @"_removed_";
 {
   self = [super init];
   if (self) {
-    _eventName = eventName;
-    _restrictiveParams = restrictiveParams;
+    _eventName = [eventName copy];
+    _restrictiveParams = [restrictiveParams copy];
   }
 
   return self;
@@ -164,15 +164,6 @@ static NSMutableSet<NSString *> *_restrictedEvents;
 }
 
 #pragma mark Helper functions
-
-+ (BOOL)isMatchedWithPattern:(NSString *)pattern
-                        text:(NSString *)text
-{
-  NSRegularExpression *regex = [[NSRegularExpression alloc] initWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:nil];
-  NSUInteger matches = [regex numberOfMatchesInString:text options:0 range:NSMakeRange(0, text.length)];
-  return matches > 0;
-}
-
 
 + (BOOL)isRestrictedEvent:(NSString *)eventName
 {

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.m
@@ -24,7 +24,6 @@
 
 static NSString *const RESTRICTIVE_PARAM_KEY = @"restrictive_param";
 static NSString *const PROCESS_EVENT_NAME_KEY = @"process_event_name";
-static NSString *const REPLACEMENT_STRING = @"_removed_";
 
 @interface FBSDKRestrictiveEventFilter : NSObject
 
@@ -146,7 +145,7 @@ static NSMutableSet<NSString *> *_restrictedEvents;
 
   for (NSDictionary<NSString *, NSDictionary<NSString *, id> *> *event in events) {
    if ([FBSDKRestrictiveDataFilterManager isRestrictedEvent:event[@"event"][@"_eventName"]]) {
-      [event[@"event"] setValue:REPLACEMENT_STRING forKey:@"_eventName"];
+      [event[@"event"] setValue:@"_removed_" forKey:@"_eventName"];
     }
   }
 }

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.mm
@@ -24,9 +24,6 @@
 #import "FBSDKTypeUtility.h"
 #import "FBSDKServerConfigurationManager.h"
 
-static NSString *const RESTRICTIVE_PARAM_KEY = @"restrictive_param";
-static NSString *const PROCESS_EVENT_NAME_KEY = @"process_event_name";
-
 @interface FBSDKRestrictiveEventFilter : NSObject
 
 @property (nonatomic, readonly, copy) NSString *eventName;
@@ -67,6 +64,8 @@ static NSMutableSet<NSString *> *_restrictedEvents;
 
 + (void)updateFilters:(nullable NSDictionary<NSString *, id> *)restrictiveParams
 {
+  static NSString *const RESTRICTIVE_PARAM_KEY = @"restrictive_param";
+
   restrictiveParams = [FBSDKTypeUtility dictionaryValue:restrictiveParams];
   if (restrictiveParams.count > 0) {
     @synchronized (self) {
@@ -84,7 +83,7 @@ static NSMutableSet<NSString *> *_restrictedEvents;
                                                                                                       restrictiveParams:eventInfo[RESTRICTIVE_PARAM_KEY]];
            [FBSDKTypeUtility array:eventFilterArray addObject:restrictiveEventFilter];
          }
-         if (restrictiveParams[eventName][PROCESS_EVENT_NAME_KEY]) {
+         if (restrictiveParams[eventName][@"process_event_name"]) {
            [restrictedEventSet addObject:eventName];
          }
        }

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.mm
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Integrity/FBSDKRestrictiveDataFilterManager.mm
@@ -16,6 +16,8 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#import <atomic>
+
 #import "FBSDKRestrictiveDataFilterManager.h"
 
 #import "FBSDKBasicUtility.h"
@@ -56,7 +58,9 @@ static NSString *const PROCESS_EVENT_NAME_KEY = @"process_event_name";
 
 @implementation FBSDKRestrictiveDataFilterManager
 
-static BOOL isRestrictiveEventFilterEnabled = NO;
+namespace {
+  std::atomic<BOOL> g_isRestrictiveEventFilterEnabled;
+}
 
 static NSMutableArray<FBSDKRestrictiveEventFilter *>  *_params;
 static NSMutableSet<NSString *> *_restrictedEvents;
@@ -108,7 +112,7 @@ static NSMutableSet<NSString *> *_restrictedEvents;
 + (NSDictionary<NSString *,id> *)processParameters:(NSDictionary<NSString *,id> *)parameters
                                          eventName:(NSString *)eventName
 {
-  if (!isRestrictiveEventFilterEnabled) {
+  if (!g_isRestrictiveEventFilterEnabled) {
     return parameters;
   }
   if (parameters) {
@@ -139,7 +143,7 @@ static NSMutableSet<NSString *> *_restrictedEvents;
 
 + (void)processEvents:(NSMutableArray<NSDictionary<NSString *, id> *> *)events
 {
-  if (!isRestrictiveEventFilterEnabled) {
+  if (!g_isRestrictiveEventFilterEnabled) {
     return;
   }
 
@@ -155,9 +159,12 @@ static NSMutableSet<NSString *> *_restrictedEvents;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     NSDictionary<NSString *, id> *restrictiveParams = [FBSDKServerConfigurationManager cachedServerConfiguration].restrictiveParams;
+
+    // TODO, this just checks that the pointer is null... it doesn't check
+    // anything in the dictionary... uhh.
     if (restrictiveParams) {
       [FBSDKRestrictiveDataFilterManager updateFilters:restrictiveParams];
-      isRestrictiveEventFilterEnabled = YES;
+      g_isRestrictiveEventFilterEnabled = YES;
     }
   });
 }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Integrity/FBSDKRestrictiveDataFilterTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Integrity/FBSDKRestrictiveDataFilterTests.m
@@ -104,5 +104,44 @@
   XCTAssertNil(type2);
 }
 
+- (void)testProcessEventCanHandleAnEmptyArray
+{
+  NSMutableArray *a = nil;
+  XCTAssertNoThrow([FBSDKRestrictiveDataFilterManager processEvents:a]);
+}
+
+- (void)testProcessEventCanHandleMissingKeys
+{
+  NSDictionary<NSString *, NSDictionary<NSString *, id> *> *event = @{
+    @"some_event": @{}
+  };
+  XCTAssertNoThrow([FBSDKRestrictiveDataFilterManager processEvents:@[event]]);
+}
+
+- (void)testProcessEventDoesntReplaceEventNameIfNotRestricted
+{
+  NSDictionary<NSString *, NSDictionary<NSString *, id> *> *event = @{
+    @"event": @{
+        @"_eventName": [NSNull null],
+    }
+  };
+  [FBSDKRestrictiveDataFilterManager processEvents:@[event]];
+
+  // It's not restricted, it shouldn't change.
+  XCTAssertEqual(event[@"event"][@"_eventName"], [NSNull null]);
+}
+
+- (void)testProcessEventDoesntReplaceEventNameIfNotRestricted
+{
+  NSDictionary<NSString *, NSDictionary<NSString *, id> *> *event = @{
+    @"event": @{
+        @"_eventName": [NSNull null],
+    }
+  };
+  [FBSDKRestrictiveDataFilterManager restricte];
+
+  // It's not restricted, it shouldn't change.
+  XCTAssertEqual(event[@"event"][@"_eventName"], [NSNull null]);
+}
 
 @end

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Integrity/FBSDKRestrictiveDataFilterTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Integrity/FBSDKRestrictiveDataFilterTests.m
@@ -32,7 +32,6 @@
 + (void)updateFilters:(nullable NSDictionary<NSString *, id> *)restrictiveParams;
 + (NSString *)getMatchedDataTypeWithEventName:(NSString *)eventName
                                      paramKey:(NSString *)paramKey;
-+ (BOOL)isDeprecatedEvent:(NSString *)eventName;
 
 @end
 

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Integrity/FBSDKRestrictiveDataFilterTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Integrity/FBSDKRestrictiveDataFilterTests.m
@@ -33,13 +33,10 @@
 + (NSString *)getMatchedDataTypeWithEventName:(NSString *)eventName
                                      paramKey:(NSString *)paramKey;
 + (BOOL)isDeprecatedEvent:(NSString *)eventName;
-+ (BOOL)isMatchedWithPattern:(NSString *)pattern
-                        text:(NSString *)text;
 
 @end
 
 @interface FBSDKRestrictiveDataFilterTests : XCTestCase
-
 @end
 
 @implementation FBSDKRestrictiveDataFilterTests
@@ -68,149 +65,6 @@
   OCMStub([mockServerConfigurationManager cachedServerConfiguration]).andReturn(mockServerConfiguration);
 
   [FBSDKRestrictiveDataFilterManager enable];
-}
-
-- (void)tearDown
-{
-  [super tearDown];
-}
-
-- (void)testIsMatchedWithPatternPhoneNumber
-{
-  NSString *pattern = @"^phone$|phone number|cell phone|mobile phone|^mobile$";
-  NSString *text1 = @"phone";
-  NSString *text2 = @"phone number";
-  NSString *text3 = @"cell phone";
-  NSString *text4 = @"mobile phone";
-  NSString *text5 = @"mobile";
-
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text1]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text2]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text3]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text4]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text5]);
-
-  NSString *text6 = @"cell_phone";
-  NSString *text7 = @"phone_number";
-
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text6]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text7]);
-}
-
-- (void)testIsMatchedWithPatternSSN
-{
-  NSString *pattern = @"^ssn$|social security number|social security";
-  NSString *text1 = @"ssn";
-  NSString *text2 = @"SSN";
-  NSString *text3 = @"social security number";
-  NSString *text4 = @"social security";
-
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text1]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text2]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text3]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text4]);
-
-  NSString *text5 = @"ssn1";
-  NSString *text6 = @"social";
-
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text5]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text6]);
-}
-
-- (void)testIsMatchedWithPatternPassword
-{
-  NSString *pattern = @"password|passcode|passId";
-  NSString *text1 = @"password";
-  NSString *text2 = @"passcode";
-  NSString *text3 = @"passID";
-
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text1]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text2]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text3]);
-
-  NSString *text4 = @"ssn";
-  NSString *text5 = @"social";
-
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text4]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text5]);
-}
-
-- (void)testIsMatchedWithPatternFirstName
-{
-  NSString *pattern = @"firstname|first_name|first name";
-  NSString *text1 = @"firstname";
-  NSString *text2 = @"first_name";
-  NSString *text3 = @"first name";
-
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text1]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text2]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text3]);
-
-  NSString *text4 = @"lastname";
-  NSString *text5 = @"last_name";
-  NSString *text6 = @"last name";
-  NSString *text7 = @"middlename";
-  NSString *text8 = @"middle_name";
-  NSString *text9 = @"middle name";
-
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text4]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text5]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text6]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text7]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text8]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text9]);
-}
-
-- (void)testIsMatchedWithPatternLastName
-{
-  NSString *pattern = @"lastname|last_name|last name";
-  NSString *text1 = @"lastname";
-  NSString *text2 = @"last_name";
-  NSString *text3 = @"last name";
-
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text1]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text2]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text3]);
-
-  NSString *text4 = @"firstname";
-  NSString *text5 = @"first_name";
-  NSString *text6 = @"first name";
-  NSString *text7 = @"middlename";
-  NSString *text8 = @"middle_name";
-  NSString *text9 = @"middle name";
-
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text4]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text5]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text6]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text7]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text8]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text9]);
-}
-
-- (void)testIsMatchedWithPatternDateOfBirth
-{
-  NSString *pattern = @"date_of_birth|<dob>|dob>|birthdate|userbirthday|dateofbirth|date of birth|<dob_|dobd|dobm|doby";
-  NSString *text1 = @"date_of_birth";
-  NSString *text2 = @"<dob>";
-  NSString *text3 = @"birthdate";
-  NSString *text4 = @"userbirthday";
-  NSString *text5 = @"dateofbirth";
-  NSString *text6 = @"date of birth";
-
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text1]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text2]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text3]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text4]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text5]);
-  XCTAssertTrue([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text6]);
-
-  NSString *text7 = @"dob_";
-  NSString *text8 = @"date";
-  NSString *text9 = @"bday";
-
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text7]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text8]);
-  XCTAssertFalse([FBSDKRestrictiveDataFilterManager isMatchedWithPattern:pattern text:text9]);
 }
 
 - (void)testFilterByParams
@@ -250,5 +104,6 @@
   NSString *type2= [FBSDKRestrictiveDataFilterManager getMatchedDataTypeWithEventName:testEventName paramKey:@"reservation number"];
   XCTAssertNil(type2);
 }
+
 
 @end


### PR DESCRIPTION
Summary: Since these things are in the global namespace, we have to initialize them whenever the SDK code loads. In this case, just inline the strings, or put the static inside the method that they are used.

Differential Revision: D22530105

