### PR TITLE
[Bug] Facebook login form automatically closes when FB SDK

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -106,6 +106,12 @@ static UIApplicationState _applicationState;
   [[FBSDKAppEvents singleton] registerNotifications];
 
   [delegate application:[UIApplication sharedApplication] didFinishLaunchingWithOptions:launchOptions];
+  // In case of sdk autoInit enabled sdk expects one appDidBecomeActive notification after app launch and has some logic to ignore it.
+  // if sdk autoInit disabled app won't receive appDidBecomeActive on app launch and will ignore the first one it gets instead of handling it.
+  // Send first applicationDidBecomeActive notification manually
+  if ([UIApplication sharedApplication].applicationState == UIApplicationStateActive) {
+    [delegate applicationDidBecomeActive:nil];
+  }
 
   [FBSDKFeatureManager checkFeature:FBSDKFeatureInstrument completionBlock:^(BOOL enabled) {
     if (enabled) {

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -101,6 +101,7 @@ static UIApplicationState _applicationState;
   NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
   [defaultCenter addObserver:delegate selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
   [defaultCenter addObserver:delegate selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
+  [defaultCenter addObserver:delegate selector:@selector(applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
 
   [[FBSDKAppEvents singleton] registerNotifications];
 
@@ -266,6 +267,17 @@ static UIApplicationState _applicationState;
   for (id<FBSDKApplicationObserving> observer in observers) {
     if ([observer respondsToSelector:@selector(applicationDidBecomeActive:)]) {
       [observer applicationDidBecomeActive:notification.object];
+    }
+  }
+}
+
+- (void)applicationWillResignActive:(NSNotification *)notification
+{
+  _applicationState = UIApplicationStateInactive;
+  NSArray<id<FBSDKApplicationObserving>> *observers = [_applicationObservers copy];
+  for (id<FBSDKApplicationObserving> observer in observers) {
+    if ([observer respondsToSelector:@selector(applicationWillResignActive:)]) {
+      [observer applicationWillResignActive:notification.object];
     }
   }
 }

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKApplicationObserving.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKApplicationObserving.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @optional
 - (void)applicationDidBecomeActive:(nullable UIApplication *)application;
+- (void)applicationWillResignActive:(nullable UIApplication *)application;
 - (void)applicationDidEnterBackground:(nullable UIApplication *)application;
 - (BOOL)application:(UIApplication *)application
 didFinishLaunchingWithOptions:(nullable NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions;

--- a/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKApplicationDelegateTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKApplicationDelegateTests.m
@@ -42,6 +42,7 @@ static id g_mockNSBundle;
 
 - (void)_logSDKInitialize;
 - (void)applicationDidBecomeActive:(NSNotification *)notification;
+- (void)applicationWillResignActive:(NSNotification *)notification;
 
 @end
 
@@ -108,4 +109,20 @@ static id g_mockNSBundle;
   id notification = OCMClassMock([NSNotification class]);
   [_delegate applicationDidBecomeActive:notification];
 }
+
+-(void)testAppNotifyObserversWhenAppWillResignActive {
+
+  id observer = OCMStrictProtocolMock(@protocol(FBSDKApplicationObserving));
+  [_delegate addObserver:observer];
+
+  NSNotification *notification = OCMClassMock([NSNotification class]);
+  id application = OCMClassMock([UIApplication class]);
+  [OCMStub([notification object]) andReturn:application];
+  OCMExpect([observer applicationWillResignActive:application]);
+
+  [_delegate applicationWillResignActive:notification];
+
+  OCMVerify([observer applicationWillResignActive:application]);
+}
+
 @end


### PR DESCRIPTION

- [X] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [X] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

### Fix for the reported Facebook login form automatically closes when FB SDK is not autoinitialized on startup reported as [github issue](https://github.com/facebook/facebook-ios-sdk/issues/1447) and [dev portal issue](https://developers.facebook.com/support/bugs/758221278262132/)

**Issue description:**
When SDK autoinitialization disabled and a user taps on "Continue with Facebook" button Facebook log in form opens and closes, so a user has to tap the button again to show Log in form

Why it happens:
With SDK autoInit enabled SDK expects one `appDidBecomeActive` notification to come right after `appDidFinishLaunching` notification and [FBSDKBridgeAPI](https://github.com/facebook/facebook-ios-sdk/blob/master/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPI.m#L79
) has some logic to handle this first `appDidBecomeActive`. When SDK autoInit disabled SDK never receives this "first" event required to do some extra setup, so the set up will happen when the app receives any `appDidBecomeActive` not the one send on app launch.

on iOS 11+ Facebook SDK is using SFAuthenticationSession or ASWebAuthenticationSession for the log in flow. During that flow app changes state several times (please see table below), so the first `appDidBecomeActive` the app receives will be ignored so the Login form is closed automatically.

[active_state_1]:https://user-images.githubusercontent.com/2070801/89175101-5913ea00-d587-11ea-86dd-130cf8d84881.png
[active_state_2]:https://user-images.githubusercontent.com/2070801/89175104-5b764400-d587-11ea-8e3a-20663ccb3912.png
[resign_active]:https://user-images.githubusercontent.com/2070801/89175106-5ca77100-d587-11ea-8ada-1122e99311c4.png

App in active state | applicationWillResignActive | applicationDidBecomeActive
 --- | --- | --- 
![active_state_1] |![resign_active] |![active_state_2]

[Send appDidBecome active notification manually if SDK autoInit disabled](https://github.com/facebook/facebook-ios-sdk/commit/0d9749c3075ce179d2b3107ed637c2e809e7f404) commit should fix the issue as in this case the SDK won't treat login flow app state change as the an sdk initialization process.

Changing `id<FBSDKAuthenticationSession> _authenticationSession` state handling from [bool to enum](https://github.com/facebook/facebook-ios-sdk/commit/c12799e374a90ba59287900d515ce3a415293aaf) should bring a bit more transparency about the current state of the authenticationSession. As you could see this change also ignores `active` param for FBSDKAuthenticationSession handling, this is because the session will be canceled by the system if we try to start it in other state than active, so active param could be ignored

## Test Plan
Please use this [branch](https://github.com/TatyanaLeschenok/facebook-ios-sdk/tree/fb-login-samle-app-disable-autoinit-use-fixed-sdk) for tests. It uses FacebookLoginSample app with autoInit disabled and Facebook SDK version with the proposed fixed

Test user:
username: dlavnwqgjo_1594919337@tfbnw.net
password: testpwd