### PR TITLE
Fix CircleCI job error about user interface idiom deprecation

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKWebViewAppLinkResolver.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKWebViewAppLinkResolver.m
@@ -265,10 +265,7 @@ static NSString *const FBSDKWebViewAppLinkResolverShouldFallbackKey = @"should_f
     NSMutableArray<FBSDKAppLinkTarget *> *linkTargets = [NSMutableArray array];
 
     NSArray *platformData = nil;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    const UIUserInterfaceIdiom idiom = UI_USER_INTERFACE_IDIOM();
-#pragma clang diagnostic pop
+    const UIUserInterfaceIdiom idiom = UIDevice.currentDevice.userInterfaceIdiom;
     if (idiom == UIUserInterfaceIdiomPad) {
         platformData = @[ appLinkDict[FBSDKWebViewAppLinkResolverIPadKey] ?: @{},
                           appLinkDict[FBSDKWebViewAppLinkResolverIOSKey] ?: @{} ];

--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/Resolver/FBSDKAppLinkResolver.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/Resolver/FBSDKAppLinkResolver.m
@@ -83,7 +83,7 @@ static NSString *const kAppLinksKey = @"app_links";
 {
   if (self = [super init]) {
     self.cachedFBSDKAppLinks = [NSMutableDictionary dictionary];
-    self.userInterfaceIdiom = UI_USER_INTERFACE_IDIOM();
+    self.userInterfaceIdiom = UIDevice.currentDevice.userInterfaceIdiom;
     self.requestBuilder = builder;
   }
   return self;
@@ -178,7 +178,7 @@ static NSString *const kAppLinksKey = @"app_links";
  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 + (instancetype)resolver
 {
-  return [[self alloc] initWithUserInterfaceIdiom:UI_USER_INTERFACE_IDIOM()];
+  return [[self alloc] initWithUserInterfaceIdiom:UIDevice.currentDevice.userInterfaceIdiom];
 }
 
  #pragma clang diagnostic pop

--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/Resolver/FBSDKAppLinkResolverRequestBuilder.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/Resolver/FBSDKAppLinkResolverRequestBuilder.m
@@ -50,7 +50,7 @@ static NSString *const kAppLinksKey = @"app_links";
 - (instancetype)init
 {
   if ((self = [super init])) {
-    _userInterfaceIdiom = UI_USER_INTERFACE_IDIOM();
+    _userInterfaceIdiom = UIDevice.currentDevice.userInterfaceIdiom;
   }
 
   return self;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialogView.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialogView.m
@@ -116,7 +116,7 @@
   [super layoutSubviews];
 
   CGRect bounds = self.bounds;
-  if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+  if (UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
     CGFloat horizontalInset = CGRectGetWidth(bounds) * 0.2;
     CGFloat verticalInset = CGRectGetHeight(bounds) * 0.2;
     UIEdgeInsets iPadInsets = UIEdgeInsetsMake(verticalInset, horizontalInset, verticalInset, horizontalInset);


### PR DESCRIPTION
Summary:
CircleCI is failing with the error:
```
error: 'UI_USER_INTERFACE_IDIOM' is deprecated: first deprecated in macCatalyst 13.0 - Use -[UIDevice userInterfaceIdiom] directly. [-Werror,-Wdeprecated-declarations]
```

Differential Revision: D24265594

