### PR TITLE
Fix Rsync Step

### DIFF
--- a/scripts/xcode/build-universal-framework.sh
+++ b/scripts/xcode/build-universal-framework.sh
@@ -55,11 +55,8 @@ xcodebuild -target "${TARGET}" \
 cp -R "${BUILD_DIR}/${CONFIGURATION}-iphoneos/${PROJECT_NAME}.framework" "${UNIVERSAL_BUILD_FOLDER}/"
 
 # Step 3. Copy the swiftmodule files created during the simulator build
-# TODO: remove the conditional check when we drop support for Xcode 11
-if [ -f "${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule/" ]; then
-  rsync -a "${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule/" \
-    "${UNIVERSAL_BUILD_FOLDER}/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule"
-fi
+rsync -a "${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule/" \
+  "${UNIVERSAL_BUILD_FOLDER}/${PROJECT_NAME}.framework/Modules/${PROJECT_NAME}.swiftmodule" || true
 
 # Step 4. Create universal binary file using lipo and place the combined executable in the copied framework directory
 lipo -create -output "${UNIVERSAL_BUILD_FOLDER}/${PROJECT_NAME}.framework/${PROJECT_NAME}" "${BUILD_DIR}/${CONFIGURATION}-iphonesimulator/${PROJECT_NAME}.framework/${PROJECT_NAME}" "${BUILD_DIR}/${CONFIGURATION}-iphoneos/${PROJECT_NAME}.framework/${PROJECT_NAME}"


### PR DESCRIPTION
Summary:
I made some faulty assumptions about why I was getting an rsync warning so I gated it behind a file check. This led to a false positive where it appeared that the files were being synced when they were not.

This updated code ignores the output of the step when it fails since it will fail for GamingServicesKit (because it contains no Swift files at the moment).

Reviewed By: tianqibt

Differential Revision: D24339344

