### PR TITLE
Linker bug

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -43,7 +43,11 @@ Pod::Spec.new do |s|
     'GCC_PREPROCESSOR_DEFINITIONS': '$(inherited) FBSDKCOCOAPODS=1',
     'DEFINES_MODULE': 'YES'
   }
-  s.user_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS': '$(inherited) FBSDKCOCOAPODS=1' }
+  s.user_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS': '$(inherited) FBSDKCOCOAPODS=1',
+    'LIBRARY_SEARCH_PATHS': "$(inherited) ${DT_TOOLCHAIN_DIR}/usr/lib/swift/${PLATFORM_NAME}",
+    'OTHER_LDFLAGS': "$(inherited) -Xlinker -add_ast_path -L /usr/lib/swift"
+  }
   s.library = 'c++', 'stdc++'
 
   s.subspec 'Basics' do |ss|


### PR DESCRIPTION
Summary:
Cocoapods defaults to using dynamic frameworks. For users of static frameworks they will have linker errors if they include no Swift code.

Including a Swift file changes the linker command run by Xcode to include "$DT_TOOLCHAIN_DIR/usr/lib/swift/$SDK_ROOT".

Since we don't want to ask users to include an empty Swift file. We can include this linker flag ourselves in the podspec.

Differential Revision: D23437904

