### PR TITLE
Fix NS_SWIFT_NAME issues 2/n

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKGateKeeperManager.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKGateKeeperManager.h
@@ -27,6 +27,7 @@ typedef NSString *const FBSDKGateKeeperKey NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAM
 typedef void (^FBSDKGKManagerBlock)(NSError * _Nullable error)
 NS_SWIFT_NAME(GKManagerBlock);
 
+NS_SWIFT_NAME(GateKeeperManager)
 @interface FBSDKGateKeeperManager : NSObject
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;


### PR DESCRIPTION
Summary: Adds a Swift name for FBSDKGateKeeperManager so that there's no compiler warning about invalid subtype `GateKeeperKey`

Differential Revision: D24399076

