### PR TITLE
Remove UIKit version checks

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.h
@@ -28,15 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 #define FBSDK_CANOPENURL_MSQRD_PLAYER @"msqrdplayer"
 #define FBSDK_CANOPENURL_SHARE_EXTENSION @"fbshareextension"
 
-typedef NS_ENUM(int32_t, FBSDKUIKitVersion)
-{
-  FBSDKUIKitVersion_6_0 = 0x0944,
-  FBSDKUIKitVersion_6_1 = 0x094C,
-  FBSDKUIKitVersion_7_0 = 0x0B57,
-  FBSDKUIKitVersion_7_1 = 0x0B77,
-  FBSDKUIKitVersion_8_0 = 0x0CF6,
-} NS_SWIFT_NAME(FBUIKit.Version);
-
 /**
  Describes the callback for appLinkFromURLInBackground.
  @param object the FBSDKAppLink representing the deferred App Link
@@ -79,19 +70,6 @@ NS_SWIFT_NAME(InternalUtility)
  The version of the operating system on which the process is executing.
  */
 @property (class, nonatomic, assign, readonly) NSOperatingSystemVersion operatingSystemVersion;
-
-/**
- Tests whether the orientation should be manually adjusted for views outside of the root view controller.
-
- With the legacy layout the developer must worry about device orientation when working with views outside of
- the window's root view controller and apply the correct rotation transform and/or swap a view's width and height
- values.  If the application was linked with UIKit on iOS 7 or earlier or the application is running on iOS 7 or earlier
- then we need to use the legacy layout code.  Otherwise if the application was linked with UIKit on iOS 8 or later and
- the application is running on iOS 8 or later, UIKit handles all of the rotation complexity and the origin is always in
- the top-left and no rotation transform is necessary.
- @return YES if if the orientation must be manually adjusted, otherwise NO.
- */
-@property (class, nonatomic, assign, readonly) BOOL shouldManuallyAdjustOrientation;
 
 /*
  Checks if the app is Unity.
@@ -173,20 +151,6 @@ NS_SWIFT_NAME(InternalUtility)
  @return YES if the bundle identifier refers to the Safari app, otherwise NO.
  */
 + (BOOL)isSafariBundleIdentifier:(NSString *)bundleIdentifier;
-
-/**
-  Tests whether the UIKit version that the current app was linked to is at least the specified version.
- @param version The version to test against.
- @return YES if the linked UIKit version is greater than or equal to the specified version, otherwise NO.
- */
-+ (BOOL)isUIKitLinkTimeVersionAtLeast:(FBSDKUIKitVersion)version;
-
-/**
-  Tests whether the UIKit version in the runtime is at least the specified version.
- @param version The version to test against.
- @return YES if the runtime UIKit version is greater than or equal to the specified version, otherwise NO.
- */
-+ (BOOL)isUIKitRunTimeVersionAtLeast:(FBSDKUIKitVersion)version;
 
 /**
   Checks equality between 2 objects.

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKInternalUtility.m
@@ -212,28 +212,6 @@ static BOOL ShouldOverrideHostWithGamingDomain(NSString *hostPrefix)
     || [bundleIdentifier isEqualToString:@"com.apple.SafariViewService"]);
 }
 
-+ (BOOL)isUIKitLinkTimeVersionAtLeast:(FBSDKUIKitVersion)version
-{
-  static int32_t linkTimeMajorVersion;
-  static dispatch_once_t getVersionOnce;
-  dispatch_once(&getVersionOnce, ^{
-    int32_t linkTimeVersion = NSVersionOfLinkTimeLibrary("UIKit");
-    linkTimeMajorVersion = [self getMajorVersionFromFullLibraryVersion:linkTimeVersion];
-  });
-  return (version <= linkTimeMajorVersion);
-}
-
-+ (BOOL)isUIKitRunTimeVersionAtLeast:(FBSDKUIKitVersion)version
-{
-  static int32_t runTimeMajorVersion;
-  static dispatch_once_t getVersionOnce;
-  dispatch_once(&getVersionOnce, ^{
-    int32_t runTimeVersion = NSVersionOfRunTimeLibrary("UIKit");
-    runTimeMajorVersion = [self getMajorVersionFromFullLibraryVersion:runTimeVersion];
-  });
-  return (version <= runTimeMajorVersion);
-}
-
 + (int32_t)getMajorVersionFromFullLibraryVersion:(int32_t)version
 {
   // Negative values returned by NSVersionOfRunTimeLibrary/NSVersionOfLinkTimeLibrary
@@ -282,19 +260,10 @@ static BOOL ShouldOverrideHostWithGamingDomain(NSString *hostPrefix)
         case 1:
           operatingSystemVersion.majorVersion = [[FBSDKTypeUtility array:components objectAtIndex:0] integerValue];
           break;
-        case 0:
-          operatingSystemVersion.majorVersion = ([self isUIKitLinkTimeVersionAtLeast:FBSDKUIKitVersion_7_0] ? 7 : 6);
-          break;
       }
     }
   });
   return operatingSystemVersion;
-}
-
-+ (BOOL)shouldManuallyAdjustOrientation
-{
-  return (![self isUIKitLinkTimeVersionAtLeast:FBSDKUIKitVersion_8_0]
-    || ![self isUIKitRunTimeVersionAtLeast:FBSDKUIKitVersion_8_0]);
 }
 
 + (NSURL *)URLWithScheme:(NSString *)scheme

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
@@ -262,27 +262,6 @@ static FBSDKWebDialog *g_currentDialog = nil;
   return YES;
 }
 
-- (CGAffineTransform)_transformForOrientation
-{
-  // iOS 8 simply adjusts the application frame to adapt to the current orientation and deprecated the concept of
-  // interface orientations
-  if ([FBSDKInternalUtility shouldManuallyAdjustOrientation]) {
-    switch (FBSDKInternalUtility.statusBarOrientation) {
-      case UIInterfaceOrientationLandscapeLeft:
-        return CGAffineTransformMakeRotation(M_PI * 1.5);
-      case UIInterfaceOrientationLandscapeRight:
-        return CGAffineTransformMakeRotation(M_PI / 2);
-      case UIInterfaceOrientationPortraitUpsideDown:
-        return CGAffineTransformMakeRotation(-M_PI);
-      case UIInterfaceOrientationPortrait:
-      case UIInterfaceOrientationUnknown:
-        // don't adjust the orientation
-        break;
-    }
-  }
-  return CGAffineTransformIdentity;
-}
-
 - (CGRect)_applicationFrameForOrientation
 {
   CGRect applicationFrame = _dialogView.window.screen.bounds;
@@ -305,19 +284,7 @@ static FBSDKWebDialog *g_currentDialog = nil;
   applicationFrame.size.width -= insets.left + insets.right;
   applicationFrame.size.height -= insets.top + insets.bottom;
 
-  if ([FBSDKInternalUtility shouldManuallyAdjustOrientation]) {
-    switch (FBSDKInternalUtility.statusBarOrientation) {
-      case UIInterfaceOrientationLandscapeLeft:
-      case UIInterfaceOrientationLandscapeRight:
-        return CGRectMake(0, 0, CGRectGetHeight(applicationFrame), CGRectGetWidth(applicationFrame));
-      case UIInterfaceOrientationPortraitUpsideDown:
-      case UIInterfaceOrientationPortrait:
-      case UIInterfaceOrientationUnknown:
-        return applicationFrame;
-    }
-  } else {
-    return applicationFrame;
-  }
+  return applicationFrame;
 }
 
 - (void)_updateViewsWithScale:(CGFloat)scale
@@ -325,15 +292,13 @@ static FBSDKWebDialog *g_currentDialog = nil;
             animationDuration:(CFTimeInterval)animationDuration
                    completion:(FBSDKBoolBlock)completion
 {
-  CGAffineTransform transform;
+  CGAffineTransform transform = _dialogView.transform;
   CGRect applicationFrame = [self _applicationFrameForOrientation];
   if (scale == 1.0) {
-    transform = _dialogView.transform;
     _dialogView.transform = CGAffineTransformIdentity;
     _dialogView.frame = applicationFrame;
     _dialogView.transform = transform;
   }
-  transform = CGAffineTransformScale([self _transformForOrientation], scale, scale);
   void (^updateBlock)(void) = ^{
     self->_dialogView.transform = transform;
     self->_dialogView.center = CGPointMake(


### PR DESCRIPTION
Summary:
The `FBSDKUIKitVersion` enum was only being used to check if the version was at least 8. Our minimum supported version is now 9 so there is no reason to keep this check.

Basically afaict this was all to deal with orientation changes prior to iOS 8 so it can all go.

Differential Revision: D24397387

