### PR TITLE
Fix NS_SWIFT_NAME issues 1/n

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIProtocolType.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/BridgeAPI/FBSDKBridgeAPIProtocolType.h
@@ -20,12 +20,11 @@
 
 #if !TARGET_OS_TV
 
-#import <Foundation/Foundation.h>
+ #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSUInteger, FBSDKBridgeAPIProtocolType)
-{
+typedef NS_ENUM(NSUInteger, FBSDKBridgeAPIProtocolType) {
   FBSDKBridgeAPIProtocolTypeNative,
   FBSDKBridgeAPIProtocolTypeWeb,
-} NS_SWIFT_NAME(BridgeAPIProtocol.Type);
+};
 
 #endif


### PR DESCRIPTION
Summary: Fixes issue with BridgeAPIProtocol since it's not actually possible to have a nested type in a Swift protocol. This causes a warning in xcode.

Differential Revision: D24397014

