### PR TITLE
Add fields parameters where obviously missing

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKSuggestedEventsIndexer.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKSuggestedEventsIndexer.m
@@ -273,8 +273,10 @@ static NSMutableSet<NSString *> *_unconfirmedEvents;
 
   FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc]
                                 initWithGraphPath:[NSString stringWithFormat:@"%@/suggested_events", [FBSDKSettings appID]]
-                                parameters:@{@"event_name" : event,
-                                             @"metadata" : metadata, }
+                                parameters:@{
+                                  @"event_name" : event,
+                                  @"metadata" : metadata,
+                                }
                                 HTTPMethod:FBSDKHTTPMethodPOST];
   [request startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {}];
   return;

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKTestUsersManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKTestUsersManager.m
@@ -199,7 +199,7 @@ static NSMutableDictionary<NSString *, FBSDKTestUsersManager *> *gInstancesDicti
 - (void)removeTestAccount:(NSString *)userId completionHandler:(FBSDKErrorBlock)handler
 {
   FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:userId
-                                                                 parameters:@{}
+                                                                 parameters:@{@"fields" : @""}
                                                                 tokenString:self.appAccessToken
                                                                     version:nil
                                                                  HTTPMethod:@"DELETE"];
@@ -284,7 +284,7 @@ static NSMutableDictionary<NSString *, FBSDKTestUsersManager *> *gInstancesDicti
           self->_accounts[userId][kAccountsDictionaryTokenKey] = token;
           expectedTestAccounts++;
           [permissionConnection addRequest:[[FBSDKGraphRequest alloc] initWithGraphPath:[NSString stringWithFormat:@"%@?fields=permissions", userId]
-                                                                             parameters:@{}
+                                                                             parameters:@{@"fields" : @""}
                                                                             tokenString:self.appAccessToken
                                                                                 version:nil
                                                                              HTTPMethod:FBSDKHTTPMethodGET]

--- a/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphRequest.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphRequest.m
@@ -44,13 +44,17 @@ FBSDKHTTPMethod FBSDKHTTPMethodDELETE = @"DELETE";
 
 - (instancetype)initWithGraphPath:(NSString *)graphPath
 {
-  return [self initWithGraphPath:graphPath parameters:@{}];
+  return [self initWithGraphPath:graphPath parameters:@{@"fields" : @""}];
 }
 
 - (instancetype)initWithGraphPath:(NSString *)graphPath
                        HTTPMethod:(FBSDKHTTPMethod)method
 {
-  return [self initWithGraphPath:graphPath parameters:@{} HTTPMethod:method];
+  if (method == FBSDKHTTPMethodGET) {
+    return [self initWithGraphPath:graphPath parameters:@{@"fields" : @""} HTTPMethod:method];
+  } else {
+    return [self initWithGraphPath:graphPath parameters:@{} HTTPMethod:method];
+  }
 }
 
 - (instancetype)initWithGraphPath:(NSString *)graphPath

--- a/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKGraphRequestTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKGraphRequestTests.m
@@ -36,7 +36,7 @@ static NSDictionary<NSString *, NSString *> *const _mockParameters(void)
   return @{@"fields" : @""};
 }
 
-static NSDictionary<NSString *, NSString *> *const _mockEmptyParamter(void)
+static NSDictionary<NSString *, NSString *> *const _mockEmptyParameters(void)
 {
   return @{};
 }
@@ -57,13 +57,21 @@ static NSDictionary<NSString *, NSString *> *const _mockEmptyParamter(void)
 
 #pragma mark - Tests
 
+- (void)testDefaultGETParameters
+{
+  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath];
+
+  [_mockConnection addRequest:request
+            completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
+  [self verifyRequest:request expectedGraphPath:_mockGraphPath expectedParameters:_mockParameters() expectedTokenString:nil expectedVersion:_mockDefaultVersion expectedMethod:FBSDKHTTPMethodGET];
+}
+
 - (void)testGraphRequestGETWithEmptyParameters
 {
-  FBSDKGraphRequest *request1 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath];
-  FBSDKGraphRequest *request2 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParamter()];
-  FBSDKGraphRequest *request3 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParamter() flags:FBSDKGraphRequestFlagNone];
-  FBSDKGraphRequest *request4 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParamter() tokenString:nil version:_mockDefaultVersion HTTPMethod:FBSDKHTTPMethodGET];
-  FBSDKGraphRequest *request5 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParamter() tokenString:nil version:_mockDefaultVersion HTTPMethod:FBSDKHTTPMethodGET];
+  FBSDKGraphRequest *request1 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParameters()];
+  FBSDKGraphRequest *request2 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParameters() flags:FBSDKGraphRequestFlagNone];
+  FBSDKGraphRequest *request3 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParameters() tokenString:nil version:_mockDefaultVersion HTTPMethod:FBSDKHTTPMethodGET];
+  FBSDKGraphRequest *request4 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParameters() tokenString:nil version:_mockDefaultVersion HTTPMethod:FBSDKHTTPMethodGET];
 
   [_mockConnection addRequest:request1
             completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
@@ -73,11 +81,9 @@ static NSDictionary<NSString *, NSString *> *const _mockEmptyParamter(void)
             completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
   [_mockConnection addRequest:request4
             completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
-  [_mockConnection addRequest:request5
-            completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
 
   for (FBSDKGraphRequestMetadata *metadata in _mockConnection.requests) {
-    [self verifyRequest:metadata.request expectedGraphPath:_mockGraphPath expectedParameters:_mockEmptyParamter() expectedTokenString:nil expectedVersion:_mockDefaultVersion expectedMethod:FBSDKHTTPMethodGET];
+    [self verifyRequest:metadata.request expectedGraphPath:_mockGraphPath expectedParameters:_mockEmptyParameters() expectedTokenString:nil expectedVersion:_mockDefaultVersion expectedMethod:FBSDKHTTPMethodGET];
   }
 }
 
@@ -102,21 +108,27 @@ static NSDictionary<NSString *, NSString *> *const _mockEmptyParamter(void)
   }
 }
 
+- (void)testDefaultPOSTParameters
+{
+  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath HTTPMethod:FBSDKHTTPMethodPOST];
+
+  [_mockConnection addRequest:request
+            completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
+  [self verifyRequest:request expectedGraphPath:_mockGraphPath expectedParameters:_mockEmptyParameters() expectedTokenString:nil expectedVersion:_mockDefaultVersion expectedMethod:FBSDKHTTPMethodPOST];
+}
+
 - (void)testGraphRequestPOSTWithEmptyParameters
 {
-  FBSDKGraphRequest *request1 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath HTTPMethod:FBSDKHTTPMethodPOST];
-  FBSDKGraphRequest *request2 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParamter() HTTPMethod:FBSDKHTTPMethodPOST];
-  FBSDKGraphRequest *request3 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParamter() tokenString:nil version:_mockDefaultVersion HTTPMethod:FBSDKHTTPMethodPOST];
+  FBSDKGraphRequest *request1 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParameters() HTTPMethod:FBSDKHTTPMethodPOST];
+  FBSDKGraphRequest *request2 = [[FBSDKGraphRequest alloc] initWithGraphPath:_mockGraphPath parameters:_mockEmptyParameters() tokenString:nil version:_mockDefaultVersion HTTPMethod:FBSDKHTTPMethodPOST];
 
   [_mockConnection addRequest:request1
             completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
   [_mockConnection addRequest:request2
             completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
-  [_mockConnection addRequest:request3
-            completionHandler:^(FBSDKGraphRequestConnection *conn, id result, NSError *error) {}];
 
   for (FBSDKGraphRequestMetadata *metadata in _mockConnection.requests) {
-    [self verifyRequest:metadata.request expectedGraphPath:_mockGraphPath expectedParameters:_mockEmptyParamter() expectedTokenString:nil expectedVersion:_mockDefaultVersion expectedMethod:FBSDKHTTPMethodPOST];
+    [self verifyRequest:metadata.request expectedGraphPath:_mockGraphPath expectedParameters:_mockEmptyParameters() expectedTokenString:nil expectedVersion:_mockDefaultVersion expectedMethod:FBSDKHTTPMethodPOST];
   }
 }
 
@@ -140,7 +152,7 @@ static NSDictionary<NSString *, NSString *> *const _mockEmptyParamter(void)
   NSString *baseURL = [FBSDKInternalUtility
                        facebookURLWithHostPrefix:_mockPrefix
                        path:_mockGraphPath
-                       queryParameters:_mockEmptyParamter()
+                       queryParameters:_mockEmptyParameters()
                        defaultVersion:_mockDefaultVersion
                        error:NULL].absoluteString;
   NSString *url = [FBSDKGraphRequest serializeURL:baseURL


### PR DESCRIPTION
Summary: This adds an empty fields parameter to call sites that are clearly missing one. This should cut down on issues like this one - https://github.com/facebook/facebook-ios-sdk/issues/1403

Differential Revision: D24422317

