### PR TITLE
Bump min os version for aggregate pod

### DIFF
--- a/FacebookSDK.podspec
+++ b/FacebookSDK.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
 
   s.platform     = :ios, :tvos
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '10.0'
 
   s.source       = { :git => 'https://github.com/facebook/facebook-ios-sdk.git',


### PR DESCRIPTION
Summary: CocoaPod publishing will fail since aggregate CocoaPod `FacebookSDK` has a minimum version lower than its dependencies. This fixes that.

Reviewed By: Mxiim

Differential Revision: D24600872

