### PR TITLE
Fix FBSDKCoreKit_Basics.zip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
       - attach_workspace:
           at: .
       - run: |
-          xcodebuild build \
+          xcodebuild clean build \
             -workspace FacebookSDK.xcworkspace \
             -scheme << parameters.scheme >> \
             -configuration << parameters.configuration >>

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -442,7 +442,7 @@ release_sdk() {
     # Release frameworks in static
     release_static() {
       release_basics() {
-        xcodebuild build \
+        xcodebuild clean build \
          -workspace FacebookSDK.xcworkspace \
          -scheme BuildCoreKitBasics \
          -configuration Release | xcpretty
@@ -461,12 +461,12 @@ release_sdk() {
         cd ..
       }
 
-      xcodebuild build \
+      xcodebuild clean build \
        -workspace FacebookSDK.xcworkspace \
        -scheme BuildAllKits \
        -configuration Release | xcpretty
 
-      xcodebuild build \
+      xcodebuild clean build \
        -workspace FacebookSDK.xcworkspace \
        -scheme BuildAllKits_TV \
        -configuration Release | xcpretty


### PR DESCRIPTION
Summary: `release_basics ` was the last job for releasing, however, due to the cache in `BUILD_ROOT`, it's actually `FBSDKCoreKit.framework` from `BuildAllKits` ended up with being shipped as Basics module.

Differential Revision: D24724966

