### PR TITLE
Fix swiftlint warnings in the facebook-ios-sdk

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -34,6 +34,8 @@ nesting:
   type_level: 2
 private_outlet:
   allow_private_set: true
+type_name:
+  excluded: [RawAppEventsConfigurationResponseFixtures]
 
 disabled_rules:
   - attributes
@@ -55,6 +57,7 @@ disabled_rules:
   - discouraged_optional_collection
   - function_default_parameter_at_end
   - todo
+  - trailing_comma
 
 opt_in_rules:
   - array_init
@@ -153,7 +156,6 @@ opt_in_rules:
   - switch_case_alignment
   - syntactic_sugar
   - trailing_closure
-  - trailing_comma
   - trailing_newline
   - trailing_semicolon
   - trailing_whitespace

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Helpers/SampleGraphRequest.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Helpers/SampleGraphRequest.swift
@@ -17,9 +17,10 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import Foundation
+
 @testable import FBSDKCoreKit
 
-@objc public class SampleGraphRequest : NSObject {
+@objc public class SampleGraphRequest: NSObject {
 
   @objc public static let valid = create()
   @objc public static var withOutdatedVersionWithAttachment = create(

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Helpers/SampleGraphRequestConnection.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Helpers/SampleGraphRequestConnection.swift
@@ -17,9 +17,10 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import Foundation
+
 @testable import FBSDKCoreKit
 
-@objc public class SampleGraphRequestConnection : NSObject {
+@objc public class SampleGraphRequestConnection: NSObject {
 
   @objc public static var empty: GraphRequestConnection {
     GraphRequestConnection()

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Helpers/SampleRawRemotePermissions.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Helpers/SampleRawRemotePermissions.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 @objc
-public class SampleRawRemotePermissionList : NSObject {
+public class SampleRawRemotePermissionList: NSObject {
 
   @objc
   public static var missingPermissions: [String: Any] {
@@ -118,9 +118,7 @@ public class SampleRawRemotePermissionList : NSObject {
 
 }
 
-@objc public class SampleRawRemotePermission : NSObject {
+@objc public class SampleRawRemotePermission: NSObject {
 
   @objc public static let missingTopLevelKey: [String: Any] = [:]
-
-
 }

--- a/testing/TestXcodeIntegration/TestXcodeIntegration/AppDelegate.swift
+++ b/testing/TestXcodeIntegration/TestXcodeIntegration/AppDelegate.swift
@@ -19,14 +19,12 @@
 import UIKit
 
 import FBSDKCoreKit
+import FBSDKGamingServicesKit
 import FBSDKLoginKit
 import FBSDKShareKit
-import FBSDKGamingServicesKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -46,6 +44,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
 }

--- a/testing/TestXcodeIntegration/TestXcodeIntegration/SceneDelegate.swift
+++ b/testing/TestXcodeIntegration/TestXcodeIntegration/SceneDelegate.swift
@@ -22,7 +22,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -57,6 +56,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
-
-
 }


### PR DESCRIPTION
Summary:
This commit fixes the current swiftlint warnings in the SDK.

- Added a blank line between "import Foundation" and "testable import FBSDKCoreKit" to fix sorted_imports.
- Excluded "RawAppEventsConfigurationResponseFixtures" in .swiftlint.yml for the type_name violation.
- Ignored the trailing_comma rule to allow trailing commas.

The following warnings were fixed:
```
warning: Colon Violation: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. (colon)
warning: Type Name Violation: Type name should be between 3 and 40 characters long: 'RawAppEventsConfigurationResponseFixtures' (type_name)
warning: Sorted Imports Violation: Imports should be sorted. (sorted_imports)
warning: Vertical Whitespace Violation: Limit vertical whitespace to a single empty line. Currently 2. (vertical_whitespace)
```

Reviewed By: joesus

Differential Revision: D24691969

