### PR TITLE
Remove the line from .gitattributes that treats pbxproj files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 *.strings diff=localizablestrings
-*.pbxproj binary merge=union


### PR DESCRIPTION
Summary:
The "*.pbxproj binary merge=union" line was added in a prior commit (D18655686 (https://github.com/facebook/facebook-ios-sdk/commit/c54b37a25c5b407959b6c087931bb8c34bb1c163)) as a way to automatically resolve merge conflicts in Xcode project files based on this article: https://thoughtbot.com/blog/xcode-and-git-bridging-the-gap

The article doesn't specify why the pbxproj file should be treated as a binary, however one side effect is that the `git diff` command will no longer show changes in the project file.

For example if a project file is changed it will just show the following:
```
Binary files a/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/project.pbxproj and b/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/project.pbxproj differ
```

It doesn't seem like the binary attribute is necessary to use the merge=union strategy as the following article
https://roadfiresoftware.com/2015/09/automatically-resolving-git-merge-conflicts-in-xcodes-project-pbxproj/

However I'm not convinced that we need the merge=union strategy since resolving conflicts in project files is fairly simple and mostly only occurs when two files have been added in the same location in the project. Even then the conflict is easy to resolve.

Furthermore it doesn't look like this strategy works reliably. This StackOverflow answer indicates that the user tried this strategy and ended up removing it since it didn't work in about 1 of 4 cases: https://stackoverflow.com/a/18275082. (When it doesn't work it will prevent the project from being opened at all and would have to fixed manually anyway).

And finally, if there is a conflict between two similarly named files that have been added to the location in the project file, resolving the conflict manually allows the alphabetical order of the files to be corrected if needed.

Reviewed By: joesus

Differential Revision: D24762186

