### PR TITLE
Reduce the number of iterations in the tests that use random data from 1000 to 100

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Codeless/FBSDKEventBindingTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Codeless/FBSDKEventBindingTests.m
@@ -121,7 +121,7 @@
 
 - (void)testParsing
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSDictionary *sampleData = [FBSDKSampleEventBinding getSampleDictionary];
     [FBSDKEventBindingManager parseArray:@[[Fuzzer randomizeWithJson:sampleData]]];
   }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsConfigurationManagerTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsConfigurationManagerTests.m
@@ -39,7 +39,7 @@
 
 - (void)testParsingResponses
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     [FBSDKAppEventsConfigurationManager _processResponse:RawAppEventsConfigurationResponseFixtures.random error:nil];
   }
 }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/SuggestedEvent/FBSDKFeatureExtractorTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/SuggestedEvent/FBSDKFeatureExtractorTests.m
@@ -262,7 +262,7 @@
 
 - (void)testGetDenseFeatureParsing
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSDictionary *viewHierarchy = [_viewHierarchy copy];
     [FBSDKFeatureExtractor getDenseFeatures:[Fuzzer randomizeWithJson:viewHierarchy]];
   }
@@ -363,7 +363,7 @@
 
 - (void)testLoadRulesForKey
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     [FBSDKFeatureExtractor loadRulesForKey:Fuzzer.random];
   }
 }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Basics/FBSDKTypeUtilityTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Basics/FBSDKTypeUtilityTests.m
@@ -66,7 +66,7 @@
 - (void)testIsValidJSONWithRandomValues
 {
   // Should not crash for any given value
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     [FBSDKTypeUtility isValidJSONObject:Fuzzer.random];
   }
 }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/FBSDKErrorConfigurationTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/FBSDKErrorConfigurationTests.m
@@ -79,7 +79,7 @@
 
 - (void)testParsingRandomName
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : Fuzzer.random,
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[@459] }], },
@@ -96,7 +96,7 @@
 
 - (void)testParsingRandomSubcodes
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[Fuzzer.random] }], },
@@ -113,7 +113,7 @@
 
 - (void)testParsingRandomCodes
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : Fuzzer.random, @"subcodes" : @[@459] }], },
@@ -130,7 +130,7 @@
 
 - (void)testParsingRandomItemDictionaries
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[Fuzzer.random], },
@@ -147,7 +147,7 @@
 
 - (void)testParsingRandomItems
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : Fuzzer.random, },
@@ -164,7 +164,7 @@
 
 - (void)testParsingRandomRecoveryMessage
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[@459] }], },
@@ -181,7 +181,7 @@
 
 - (void)testParsingRandomRecoveryOptionsArray
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[@459] }], },
@@ -198,7 +198,7 @@
 
 - (void)testParsingRandomRecoveryOptions
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[@459] }], },
@@ -215,7 +215,7 @@
 
 - (void)testParsingRecoveryMessageWithoutOptions
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[@459] }], },
@@ -231,7 +231,7 @@
 
 - (void)testParsingRecoveryOptionsWithoutMessage
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = @[
       @{ @"name" : @"other",
          @"items" : @[@{ @"code" : @190, @"subcodes" : @[@459] }], },
@@ -247,7 +247,7 @@
 
 - (void)testParsingRandomEntries
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     NSArray *array = [Fuzzer randomizeWithJson:rawErrorCodeConfiguration];
 
     FBSDKErrorConfiguration *configuration = [[FBSDKErrorConfiguration alloc] initWithDictionary:nil];

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/FBSDKInternalUtilityTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/FBSDKInternalUtilityTests.m
@@ -140,7 +140,7 @@
   NSMutableSet *expiredPermissions = [NSMutableSet set];
 
   // A lack of a runtime crash is considered a success here.
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     [FBSDKInternalUtility extractPermissionsFromResponse:SampleRawRemotePermissionList.randomValues
                                       grantedPermissions:grantedPermissions
                                      declinedPermissions:declinedPermissions

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/ServerConfiguration/FBSDKServerConfigurationManagerTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/ServerConfiguration/FBSDKServerConfigurationManagerTests.m
@@ -38,7 +38,7 @@
 
 - (void)testParsingResponses
 {
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     [FBSDKServerConfigurationManager processLoadRequestResponse:RawServerConfigurationResponseFixtures.random error:nil appID:nil];
   }
 }


### PR DESCRIPTION
Summary:
This should shave off a couple of seconds from the test suite.

There were 2 tests that were taking more than one second when running `buck test :`, FBSDKErrorConfigurationTests and FBSDKServerConfigurationManagerTests.

Before:
```
...
PASS    <100ms  4 Passed   0 Skipped   0 Failed   FBSDKCrashShieldTests
PASS      1.4s 13 Passed   0 Skipped   0 Failed   FBSDKErrorConfigurationTests
PASS    <100ms  3 Passed   0 Skipped   0 Failed   FBSDKEventBindingTests
...
PASS    <100ms  5 Passed   0 Skipped   0 Failed   FBSDKSafeCastTests
PASS      1.1s  1 Passed   0 Skipped   0 Failed   FBSDKServerConfigurationManagerTests
PASS    <100ms 171 Passed   0 Skipped   0 Failed   FBSDKServerConfigurationTests
...
```

After:
```
...
PASS    <100ms  4 Passed   0 Skipped   0 Failed   FBSDKCrashShieldTests
PASS     144ms 13 Passed   0 Skipped   0 Failed   FBSDKErrorConfigurationTests
PASS    <100ms  3 Passed   0 Skipped   0 Failed   FBSDKEventBindingTests
...
PASS    <100ms  5 Passed   0 Skipped   0 Failed   FBSDKSafeCastTests
PASS     815ms  1 Passed   0 Skipped   0 Failed   FBSDKServerConfigurationManagerTests
PASS    <100ms 171 Passed   0 Skipped   0 Failed   FBSDKServerConfigurationTests
...
```

Differential Revision: D24773919

