### PR TITLE
Fix FBSDKLoginButton nonce property attributes

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.h
@@ -106,7 +106,7 @@ NS_SWIFT_NAME(FBLoginButton)
   Gets or sets an optional nonce to use for login attempts. A valid nonce must be a non-empty string without whitespace.
  An invalid nonce will not be set. Instead, default unique nonces will be used for login attempts.
  */
-@property (assign, nonatomic, nullable) NSString *nonce;
+@property (copy, nonatomic, nullable) NSString *nonce;
 
 @end
 

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKLoginButton.m
@@ -84,7 +84,7 @@ static const CGFloat kPaddingBetweenLogoTitle = 8.0;
 - (void)setNonce:(NSString *)nonce
 {
   if ([FBSDKNonceUtility isValidNonce:nonce]) {
-    _nonce = nonce;
+    _nonce = [nonce copy];
   } else {
     _nonce = nil;
     [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorDeveloperErrors


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

The attributes for the `nonce` property of the `FBSDKLoginButton` are incorrect and lead to build errors.

In scenarios where the [`objc-property-assign-on-object-type`](https://clang.llvm.org/docs/DiagnosticsReference.html#wobjc-property-assign-on-object-type) flag is enabled and warnings are treated as errors, the build fails with: `FBSDKLoginKit.framework/Headers/FBSDKLoginButton.h:109:1: 'assign' property of object type may become a dangling reference; consider using 'unsafe_unretained'`