### PR TITLE
fix crash on FBSDKWebViewAppLinkResolverWebViewDelegate

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKWebViewAppLinkResolver.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKWebViewAppLinkResolver.m
@@ -94,13 +94,13 @@ static NSString *const FBSDKWebViewAppLinkResolverShouldFallbackKey = @"should_f
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
-  if (self.hasLoaded) {
-    self.didFinishLoad(webView);
-    decisionHandler(WKNavigationActionPolicyCancel);
-  }
-
-  self.hasLoaded = YES;
-  decisionHandler(WKNavigationActionPolicyAllow);
+    if (self.hasLoaded) {
+        self.didFinishLoad(webView);
+        decisionHandler(WKNavigationActionPolicyCancel);
+    } else {
+        self.hasLoaded = YES;
+        decisionHandler(WKNavigationActionPolicyAllow);
+    }
 }
 
 @end


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

It should solve this crash

https://github.com/facebook/facebook-ios-sdk/issues/1596#issuecomment-768204527
