### PR TITLE
Fix Swift Package Manager error for Xcode 12.5

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/include/include
+++ b/FBSDKLoginKit/FBSDKLoginKit/include/include
@@ -1,1 +1,0 @@
-../../../FBSDKCoreKit/FBSDKCoreKit/include

--- a/FBSDKShareKit/FBSDKShareKit/include/include
+++ b/FBSDKShareKit/FBSDKShareKit/include/include
@@ -1,1 +1,0 @@
-../../../FBSDKCoreKit/FBSDKCoreKit/include


### PR DESCRIPTION
Summary:
12.5 Beta errors on loading a package with nested 'include' directories. At one point we needed this in order to access internal headers from CoreKit.

Checked this fix with Xcode 12.5_Beta, Xcode 11.2, and Xcode 11.7 so either that workaround was never needed or it was needed before 11.2 and was fixed.

Differential Revision: D26227309

