### PR TITLE
AtePublisher Refactor

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -908,6 +908,16 @@
 		F441669D25CAFF3300DAB0A5 /* FBSDKCoreKit_Basics.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A11B5024E36E5200D4C010 /* FBSDKCoreKit_Basics.h */; };
 		F44166B825CAFFE700DAB0A5 /* FBSDKURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A11B4F24E36E5200D4C010 /* FBSDKURLSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F44166EB25CAFFE700DAB0A5 /* FBSDKURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = F4A11B4F24E36E5200D4C010 /* FBSDKURLSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F443A27D25D1F45E0093AB78 /* FBSDKAppEventsPublishAteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F443A27C25D1F45E0093AB78 /* FBSDKAppEventsPublishAteTests.m */; };
+		F443A2B925D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = F443A2B725D20A530093AB78 /* FBSDKAppEventsAtePublisher.h */; };
+		F443A2BA25D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = F443A2B725D20A530093AB78 /* FBSDKAppEventsAtePublisher.h */; };
+		F443A2BB25D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = F443A2B725D20A530093AB78 /* FBSDKAppEventsAtePublisher.h */; };
+		F443A2BC25D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = F443A2B725D20A530093AB78 /* FBSDKAppEventsAtePublisher.h */; };
+		F443A2BD25D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = F443A2B825D20A530093AB78 /* FBSDKAppEventsAtePublisher.m */; };
+		F443A2BE25D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = F443A2B825D20A530093AB78 /* FBSDKAppEventsAtePublisher.m */; };
+		F443A2BF25D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = F443A2B825D20A530093AB78 /* FBSDKAppEventsAtePublisher.m */; };
+		F443A2C025D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = F443A2B825D20A530093AB78 /* FBSDKAppEventsAtePublisher.m */; };
+		F443A31C25D231460093AB78 /* FBSDKAppEventsAtePublisherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F443A31B25D231460093AB78 /* FBSDKAppEventsAtePublisherTests.m */; };
 		F44B04B7256442050059A3A6 /* FBSDKBridgeAPIOpenUrlWithSafariTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F44B04A8256442050059A3A6 /* FBSDKBridgeAPIOpenUrlWithSafariTests.m */; };
 		F44B04EE256456140059A3A6 /* FBSDKDynamicFrameworkResolving.h in Headers */ = {isa = PBXBuildFile; fileRef = F44B04EC256456140059A3A6 /* FBSDKDynamicFrameworkResolving.h */; };
 		F44B04EF256456140059A3A6 /* FBSDKDynamicFrameworkResolving.h in Headers */ = {isa = PBXBuildFile; fileRef = F44B04EC256456140059A3A6 /* FBSDKDynamicFrameworkResolving.h */; };
@@ -1604,6 +1614,10 @@
 		F413883D24C76F3B001BC075 /* FBSDKSafeCastTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = FBSDKSafeCastTests.m; path = Internal/Basics/FBSDKSafeCastTests.m; sourceTree = "<group>"; };
 		F41979272475A20E003007CC /* FBSDKTypeUtilityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKTypeUtilityTests.m; sourceTree = "<group>"; };
 		F428430A246B427700CD4393 /* FBSDKServerConfigurationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBSDKServerConfigurationManagerTests.swift; sourceTree = "<group>"; };
+		F443A27C25D1F45E0093AB78 /* FBSDKAppEventsPublishAteTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKAppEventsPublishAteTests.m; sourceTree = "<group>"; };
+		F443A2B725D20A530093AB78 /* FBSDKAppEventsAtePublisher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKAppEventsAtePublisher.h; sourceTree = "<group>"; };
+		F443A2B825D20A530093AB78 /* FBSDKAppEventsAtePublisher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKAppEventsAtePublisher.m; sourceTree = "<group>"; };
+		F443A31B25D231460093AB78 /* FBSDKAppEventsAtePublisherTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKAppEventsAtePublisherTests.m; sourceTree = "<group>"; };
 		F44B04A8256442050059A3A6 /* FBSDKBridgeAPIOpenUrlWithSafariTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKBridgeAPIOpenUrlWithSafariTests.m; sourceTree = "<group>"; };
 		F44B04EC256456140059A3A6 /* FBSDKDynamicFrameworkResolving.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKDynamicFrameworkResolving.h; sourceTree = "<group>"; };
 		F44B051025645DAC0059A3A6 /* FakeDylibResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeDylibResolver.swift; sourceTree = "<group>"; };
@@ -2290,6 +2304,8 @@
 				F98D1D72251297A900276B68 /* FBSDKAppEventsConfigurationManagerTests.swift */,
 				F98D1D63251295E900276B68 /* RawAppEventsConfigurationResponseFixtures.swift */,
 				F40682F425CF6031003ADDDA /* FBSDKAppEventsNumberParserTests.m */,
+				F443A27C25D1F45E0093AB78 /* FBSDKAppEventsPublishAteTests.m */,
+				F443A31B25D231460093AB78 /* FBSDKAppEventsAtePublisherTests.m */,
 			);
 			path = AppEvents;
 			sourceTree = "<group>";
@@ -2549,6 +2565,8 @@
 				5F7064081AF7342600E42ED7 /* FBSDKAppEventsDeviceInfo.m */,
 				C4FC99D7202CD5590038C5ED /* FBSDKHybridAppEventsScriptMessageHandler.h */,
 				C4FC99D8202CD5590038C5ED /* FBSDKHybridAppEventsScriptMessageHandler.m */,
+				F443A2B725D20A530093AB78 /* FBSDKAppEventsAtePublisher.h */,
+				F443A2B825D20A530093AB78 /* FBSDKAppEventsAtePublisher.m */,
 				9D0BC1641A8E892C00BE8BA4 /* FBSDKAppEventsState.h */,
 				9D0BC1651A8E892C00BE8BA4 /* FBSDKAppEventsState.m */,
 				9D0BC15D1A8D428700BE8BA4 /* FBSDKAppEventsStateManager.h */,
@@ -2848,6 +2866,7 @@
 				814AC82D1D1B528900D61E6C /* _FBSDKTemporaryErrorRecoveryAttempter.h in Headers */,
 				814AC82E1D1B528900D61E6C /* FBSDKGraphRequestBody.h in Headers */,
 				033429CA208951E400C94913 /* FBSDKAccessTokenExpirer.h in Headers */,
+				F443A2BC25D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */,
 				814AC8301D1B528900D61E6C /* FBSDKGraphRequestDataAttachment.h in Headers */,
 				F441651E25CAFEB000DAB0A5 /* FBSDKBasicUtility.h in Headers */,
 				C5696FA6209CCEB4009C931F /* FBSDKSwizzler.h in Headers */,
@@ -2929,6 +2948,7 @@
 				C5D25D3721795B790037B13D /* FBSDKCodelessIndexer.h in Headers */,
 				F441659225CAFED900DAB0A5 /* FBSDKTypeUtility.h in Headers */,
 				52963AA4215993C100C7B252 /* FBSDKURL_Internal.h in Headers */,
+				F443A2BA25D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */,
 				5D90CDE72343D4D200AF326A /* FBSDKCrashShield.h in Headers */,
 				81B71D4F1D19C87400933E93 /* FBSDKLogo.h in Headers */,
 				81B71D501D19C87400933E93 /* FBSDKProfilePictureView.h in Headers */,
@@ -3197,6 +3217,7 @@
 				C5D25D3621795B790037B13D /* FBSDKCodelessIndexer.h in Headers */,
 				5D6DF16A2398E2A200AC2D6C /* FBSDKEventDeactivationManager.h in Headers */,
 				52963A88215992F400C7B252 /* FBSDKAppLinkReturnToRefererController.h in Headers */,
+				F443A2B925D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */,
 				C5696F77209BBC35009C931F /* FBSDKCodelessPathComponent.h in Headers */,
 				9DC6589E1A6EE7D800B85AAF /* FBSDKGraphRequestConnection.h in Headers */,
 				9D32A8411A69941A000A936D /* FBSDKKeychainStore.h in Headers */,
@@ -3252,6 +3273,7 @@
 				9D6DEED11BC23A93001A94ED /* _FBSDKTemporaryErrorRecoveryAttempter.h in Headers */,
 				9DB0FAA01BC22CF5005EB8B1 /* FBSDKGraphRequestBody.h in Headers */,
 				033429C9208951E400C94913 /* FBSDKAccessTokenExpirer.h in Headers */,
+				F443A2BB25D20A530093AB78 /* FBSDKAppEventsAtePublisher.h in Headers */,
 				9DB0FAA21BC22D00005EB8B1 /* FBSDKGraphRequestDataAttachment.h in Headers */,
 				F441652C25CAFEB200DAB0A5 /* FBSDKBasicUtility.h in Headers */,
 				C5696FA5209CCEB4009C931F /* FBSDKSwizzler.h in Headers */,
@@ -3920,6 +3942,7 @@
 				C5696FAA209CCEB4009C931F /* FBSDKSwizzler.m in Sources */,
 				814AC8041D1B528900D61E6C /* FBSDKGraphRequest.m in Sources */,
 				52D4F0D21D91A18F0030B7FC /* FBSDKDeviceRequestsHelper.m in Sources */,
+				F443A2C025D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */,
 				814AC8051D1B528900D61E6C /* FBSDKLogo.m in Sources */,
 				F4F98C5624CB820A00F0D6EC /* FBSDKSafeCast.m in Sources */,
 				C57044DA24E26678009637AD /* FBSDKUserDataStore.m in Sources */,
@@ -4029,6 +4052,7 @@
 				C57044D824E26678009637AD /* FBSDKUserDataStore.m in Sources */,
 				F943113224FB25A7002441F1 /* FBSDKSKAdNetworkEvent.m in Sources */,
 				BFC02459237B6B9C00A596EE /* FBSDKFeatureExtractor.m in Sources */,
+				F443A2BE25D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */,
 				52963A77215992F400C7B252 /* FBSDKAppLinkReturnToRefererView.m in Sources */,
 				C5D25D3921795B790037B13D /* FBSDKCodelessIndexer.m in Sources */,
 				81B71D351D19C87400933E93 /* FBSDKButton.m in Sources */,
@@ -4156,6 +4180,7 @@
 				C57044D724E26678009637AD /* FBSDKUserDataStore.m in Sources */,
 				F943112224FB1A54002441F1 /* FBSDKSKAdNetworkEvent.m in Sources */,
 				9DA8303D1A6999EC00770955 /* FBSDKSettings.m in Sources */,
+				F443A2BD25D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */,
 				52963A84215992F400C7B252 /* FBSDKAppLink.m in Sources */,
 				F468B34224C25AB600979F8D /* FBSDKBasicUtility.m in Sources */,
 				52963A76215992F400C7B252 /* FBSDKAppLinkReturnToRefererView.m in Sources */,
@@ -4217,6 +4242,7 @@
 				F48AD348257700B80052C056 /* SampleAuthenticationToken.swift in Sources */,
 				F496E61224E6049A006231A2 /* AppDelegateObserverFake.swift in Sources */,
 				BF5D97C3242EC2D10096D7AA /* FBSDKFeatureExtractorTests.m in Sources */,
+				F443A31C25D231460093AB78 /* FBSDKAppEventsAtePublisherTests.m in Sources */,
 				5DAB023C23A1BA17005495FB /* FBSDKEventDeactivationTests.swift in Sources */,
 				7E253D831A8EB76500CCCFE7 /* FBSDKCoreKitTestUtility.m in Sources */,
 				5D59BFFD23A705010008CA5A /* FBSDKCrashHandlerTests.m in Sources */,
@@ -4244,6 +4270,7 @@
 				45540DB125271A88008E853E /* FBSDKAppLinkResolverRequestBuilderTests.m in Sources */,
 				F408C712256320F300372D61 /* FBSDKBridgeAPIRequestTests.swift in Sources */,
 				5DAB01F123A1831A005495FB /* FBSDKCrashObserverTests.m in Sources */,
+				F443A27D25D1F45E0093AB78 /* FBSDKAppEventsPublishAteTests.m in Sources */,
 				F40B24C224732DD90059351C /* Fuzzer.swift in Sources */,
 				40853B9424C8C43300A7CB16 /* FBSDKJSONValueTests.m in Sources */,
 				F408C6E9256309A500372D61 /* FakeBridgeApiRequest.swift in Sources */,
@@ -4345,6 +4372,7 @@
 				C5696FA9209CCEB4009C931F /* FBSDKSwizzler.m in Sources */,
 				9DB0FA9F1BC22CBB005EB8B1 /* FBSDKGraphRequest.m in Sources */,
 				52D4F0D11D91A18F0030B7FC /* FBSDKDeviceRequestsHelper.m in Sources */,
+				F443A2BF25D20A530093AB78 /* FBSDKAppEventsAtePublisher.m in Sources */,
 				9DDC112A1BEC413900A88306 /* FBSDKLogo.m in Sources */,
 				9D9E16AF1CB46C8E00C8B68F /* FBSDKDeviceButton.m in Sources */,
 				C57044D924E26678009637AD /* FBSDKUserDataStore.m in Sources */,

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsAtePublisher.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsAtePublisher.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol FBSDKAtePublishing <NSObject>
+
+- (void)publishATE;
+
+@end
+
+@interface FBSDKAppEventsAtePublisher : NSObject <FBSDKAtePublishing>
+
+@property (nonatomic, readonly, assign) NSString *appIdentifier;
+
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (nullable instancetype)initWithAppIdentifier:(NSString *)appIdentifier;
+
+- (void)publishATE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsAtePublisher.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsAtePublisher.m
@@ -1,0 +1,86 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "FBSDKAppEventsAtePublisher.h"
+
+#import "FBSDKAppEventsDeviceInfo.h"
+#import "FBSDKInternalUtility.h"
+
+@implementation FBSDKAppEventsAtePublisher
+
+- (nullable instancetype)initWithAppIdentifier:(NSString *)appIdentifier
+{
+  if ((self = [self init])) {
+    NSString *identifier = [FBSDKTypeUtility stringValue:appIdentifier];
+    if (identifier.length == 0) {
+      [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorDeveloperErrors logEntry:@"Missing [FBSDKAppEvents appID] for [FBSDKAppEvents publishATE:]"];
+      return nil;
+    }
+    _appIdentifier = identifier;
+  }
+  return self;
+}
+
+- (void)publishATE
+{
+  NSString *appID = self.appIdentifier;
+  if (appID.length == 0) {
+    [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorDeveloperErrors logEntry:@"Missing [FBSDKAppEvents appID] for [FBSDKAppEvents publishATE:]"];
+    return;
+  }
+  NSString *lastATEPingString = [NSString stringWithFormat:@"com.facebook.sdk:lastATEPing%@", appID];
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  id lastPublishDate = [defaults objectForKey:lastATEPingString];
+  if ([lastPublishDate isKindOfClass:[NSDate class]] && [(NSDate *)lastPublishDate timeIntervalSinceNow] * -1 < 24 * 60 * 60) {
+    return;
+  }
+
+  NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+  [FBSDKTypeUtility dictionary:parameters setObject:@"CUSTOM_APP_EVENTS" forKey:@"event"];
+
+  NSOperatingSystemVersion operatingSystemVersion = [FBSDKInternalUtility operatingSystemVersion];
+  NSString *osVersion = [NSString stringWithFormat:@"%ti.%ti.%ti",
+                         operatingSystemVersion.majorVersion,
+                         operatingSystemVersion.minorVersion,
+                         operatingSystemVersion.patchVersion];
+
+  NSArray *event = @[
+    @{
+      @"_eventName" : @"fb_mobile_ate_status",
+      @"ate_status" : @([FBSDKSettings getAdvertisingTrackingStatus]).stringValue,
+      @"os_version" : osVersion,
+    }
+  ];
+  [FBSDKTypeUtility dictionary:parameters setObject:[FBSDKBasicUtility JSONStringForObject:event error:NULL invalidObjectHandler:NULL] forKey:@"custom_events"];
+
+  [FBSDKAppEventsDeviceInfo extendDictionaryWithDeviceInfo:parameters];
+
+  NSString *path = [NSString stringWithFormat:@"%@/activities", appID];
+  FBSDKGraphRequest *request = [[FBSDKGraphRequest alloc] initWithGraphPath:path
+                                                                 parameters:parameters
+                                                                tokenString:nil
+                                                                 HTTPMethod:FBSDKHTTPMethodPOST
+                                                                      flags:FBSDKGraphRequestFlagDoNotInvalidateTokenOnError | FBSDKGraphRequestFlagDisableErrorRecovery];
+  [request startWithCompletionHandler:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+    if (!error) {
+      [defaults setObject:[NSDate date] forKey:lastATEPingString];
+    }
+  }];
+}
+
+@end

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsAtePublisherTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsAtePublisherTests.m
@@ -1,0 +1,134 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "FBSDKAppEventsAtePublisher.h"
+#import "FBSDKTestCase.h"
+#import "UserDefaultsSpy.h"
+
+@interface FBSDKAppEventsAtePublisherTests : FBSDKTestCase
+
+@end
+
+@implementation FBSDKAppEventsAtePublisherTests
+
+static const int TWELVE_HOURS_AGO_IN_SECONDS = -12 * 60 * 60;
+static const int FORTY_EIGHT_HOURS_AGO_IN_SECONDS = -48 * 60 * 60;
+
+- (void)testCreatingWithEmptyAppIdentifier
+{
+  XCTAssertNil(
+    [[FBSDKAppEventsAtePublisher alloc] initWithAppIdentifier:@""],
+    "Should not create an ATE publisher with an empty app identifier"
+  );
+}
+
+- (void)testCreatingWithValidAppIdentifier
+{
+  FBSDKAppEventsAtePublisher *publisher = [[FBSDKAppEventsAtePublisher alloc] initWithAppIdentifier:self.name];
+  XCTAssertEqualObjects(
+    publisher.appIdentifier,
+    self.name,
+    "Should be able to create a publisher with a non-empty string for the app identifier"
+  );
+}
+
+- (void)testPublishingAteWithoutLastPublishDate
+{
+  [self stubUserDefaultsWith:UserDefaultsSpy.new];
+  [self stubAdvertisingTrackingStatusWith:FBSDKAdvertisingTrackingAllowed];
+
+  id graphRequestMock = OCMClassMock([FBSDKGraphRequest class]);
+  OCMStub([graphRequestMock alloc]).andReturn(graphRequestMock);
+  OCMStub(
+    [graphRequestMock initWithGraphPath:[OCMArg any]
+                             parameters:[OCMArg any]
+                            tokenString:nil
+                             HTTPMethod:FBSDKHTTPMethodPOST
+                                  flags:FBSDKGraphRequestFlagDoNotInvalidateTokenOnError | FBSDKGraphRequestFlagDisableErrorRecovery]
+  ).andReturn(graphRequestMock);
+
+  FBSDKAppEventsAtePublisher *publisher = [[FBSDKAppEventsAtePublisher alloc] initWithAppIdentifier:self.name];
+
+  [publisher publishATE];
+
+  OCMVerify([graphRequestMock startWithCompletionHandler:[OCMArg any]]);
+
+  [graphRequestMock stopMocking];
+  graphRequestMock = nil;
+}
+
+- (void)testPublishingWithNonExpiredLastPublishDate
+{
+  UserDefaultsSpy *userDefault = [UserDefaultsSpy new];
+  [userDefault setObject:[NSDate dateWithTimeIntervalSinceNow:TWELVE_HOURS_AGO_IN_SECONDS]
+                  forKey:[NSString stringWithFormat:@"com.facebook.sdk:lastATEPing%@", @"mockAppID"]];
+  [self stubUserDefaultsWith:userDefault];
+  [self stubAdvertisingTrackingStatusWith:FBSDKAdvertisingTrackingAllowed];
+
+  id graphRequestMock = OCMClassMock([FBSDKGraphRequest class]);
+  OCMStub([graphRequestMock alloc]).andReturn(graphRequestMock);
+  OCMStub(
+    [graphRequestMock initWithGraphPath:[OCMArg any]
+                             parameters:[OCMArg any]
+                            tokenString:nil
+                             HTTPMethod:FBSDKHTTPMethodPOST
+                                  flags:FBSDKGraphRequestFlagDoNotInvalidateTokenOnError | FBSDKGraphRequestFlagDisableErrorRecovery]
+  ).andReturn(graphRequestMock);
+
+  FBSDKAppEventsAtePublisher *publisher = [[FBSDKAppEventsAtePublisher alloc] initWithAppIdentifier:@"mockAppID"];
+
+  OCMReject([graphRequestMock startWithCompletionHandler:[OCMArg any]]);
+
+  [publisher publishATE];
+
+  [graphRequestMock stopMocking];
+  graphRequestMock = nil;
+}
+
+- (void)testPublishingWithExpiredLastPublishDate
+{
+  UserDefaultsSpy *userDefault = [UserDefaultsSpy new];
+  [userDefault setObject:[NSDate dateWithTimeIntervalSinceNow:FORTY_EIGHT_HOURS_AGO_IN_SECONDS]
+                  forKey:[NSString stringWithFormat:@"com.facebook.sdk:lastATEPing%@", @"mockAppID"]];
+  [self stubUserDefaultsWith:userDefault];
+  [self stubAdvertisingTrackingStatusWith:FBSDKAdvertisingTrackingAllowed];
+
+  id graphRequestMock = OCMClassMock([FBSDKGraphRequest class]);
+  OCMStub([graphRequestMock alloc]).andReturn(graphRequestMock);
+  OCMStub(
+    [graphRequestMock initWithGraphPath:[OCMArg any]
+                             parameters:[OCMArg any]
+                            tokenString:nil
+                             HTTPMethod:FBSDKHTTPMethodPOST
+                                  flags:FBSDKGraphRequestFlagDoNotInvalidateTokenOnError | FBSDKGraphRequestFlagDisableErrorRecovery]
+  ).andReturn(graphRequestMock);
+
+  FBSDKAppEventsAtePublisher *publisher = [[FBSDKAppEventsAtePublisher alloc] initWithAppIdentifier:@"mockAppID"];
+
+  [publisher publishATE];
+
+  OCMVerify([graphRequestMock startWithCompletionHandler:[OCMArg any]]);
+
+  [graphRequestMock stopMocking];
+  graphRequestMock = nil;
+}
+
+@end

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsPublishAteTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsPublishAteTests.m
@@ -1,0 +1,107 @@
+//
+// FBSDKAppEventsPublishAteTests.m
+// FBSDKCoreKitTests
+//
+// Created by joesusnick on 2/8/21.
+// Copyright © 2021 Facebook. All rights reserved.
+//
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "FBSDKAppEventsAtePublisher.h"
+#import "FBSDKTestCase.h"
+#import "UserDefaultsSpy.h"
+
+// TODO: move to swift
+@interface FakeAtePublisher : NSObject <FBSDKAtePublishing>
+@property (nonatomic, assign) BOOL publishAteWasCalled;
+@end
+
+@implementation FakeAtePublisher
+
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    _publishAteWasCalled = NO;
+  }
+  return self;
+}
+
+- (void)publishATE
+{
+  self.publishAteWasCalled = YES;
+}
+
+@end
+
+@interface FBSDKAppEvents (Testing)
+@property (nonatomic, strong) id<FBSDKAtePublishing> atePublisher;
+- (instancetype)initWithFlushBehavior:(FBSDKAppEventsFlushBehavior)flushBehavior
+                 flushPeriodInSeconds:(int)flushPeriodInSeconds
+                               userID:(NSString *)userID
+                         atePublisher:(id<FBSDKAtePublishing>)atePublisher;
+- (void)publishATE;
+@end
+
+@interface FBSDKAppEventsPublishAteTests : FBSDKTestCase
+
+@end
+
+@implementation FBSDKAppEventsPublishAteTests
+
+- (void)setUp
+{
+  [super setUp];
+
+  [self stubAllocatingGraphRequestConnection];
+}
+
+- (void)testDefaultAppEventsAtePublisher
+{
+  [self stubAppID:self.name];
+
+  FBSDKAppEvents *appEvents = (FBSDKAppEvents *)[(NSObject *)[FBSDKAppEvents alloc] init];
+
+  FBSDKAppEventsAtePublisher *publisher = appEvents.atePublisher;
+
+  XCTAssertNotNil(publisher, "App events should be provided with an ATE publisher on initialization");
+  XCTAssertEqualObjects(
+    publisher.appIdentifier,
+    self.name,
+    "The ATE publisher should be created with the current app identifier"
+  );
+}
+
+- (void)testPublishingAteWithoutPublisher
+{
+  FBSDKAppEvents *appEvents = [[FBSDKAppEvents alloc] initWithFlushBehavior:FBSDKAppEventsFlushBehaviorExplicitOnly
+                                                       flushPeriodInSeconds:0
+                                                                     userID:@"1"
+                                                               atePublisher:nil];
+  // checking that there is no crash
+  [appEvents publishATE];
+}
+
+- (void)testPublishingAteUsesPublisherOnlyOnce
+{
+  FakeAtePublisher *publisher = [FakeAtePublisher new];
+  FBSDKAppEvents *appEvents = [[FBSDKAppEvents alloc] initWithFlushBehavior:FBSDKAppEventsFlushBehaviorExplicitOnly
+                                                       flushPeriodInSeconds:0
+                                                                     userID:@"1"
+                                                               atePublisher:publisher];
+  [appEvents publishATE];
+
+  XCTAssertTrue(publisher.publishAteWasCalled, "App events should use the provided ATE publisher");
+
+  // Reset the spy
+  publisher.publishAteWasCalled = NO;
+
+  [appEvents publishATE];
+  XCTAssertFalse(
+    publisher.publishAteWasCalled,
+    "Should not invoke the ate publisher more than once"
+  );
+}
+
+@end

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsTests.m
@@ -52,7 +52,6 @@ static NSString *const _mockUserID = @"mockUserID";
 @property (nonatomic, copy) NSString *pushNotificationsDeviceTokenString;
 - (void)checkPersistedEvents;
 - (void)publishInstall;
-- (void)publishATE;
 - (void)flushForReason:(FBSDKAppEventsFlushReason)flushReason;
 - (void)fetchServerConfiguration:(FBSDKCodeBlock)callback;
 - (void)instanceLogEvent:(FBSDKAppEventName)eventName
@@ -557,70 +556,6 @@ static NSString *const _mockUserID = @"mockUserID";
   [self.appEventsMock publishInstall];
 
   OCMVerifyAll(self.appEventsMock);
-}
-
-- (void)testPublishATEWithNoPing
-{
-  [self stubAppID:@"mockAppID"];
-  [self stubUserDefaultsWith:[UserDefaultsSpy new]];
-  [self stubAdvertisingTrackingStatusWith:FBSDKAdvertisingTrackingAllowed];
-
-  id graphRequestMock = OCMClassMock([FBSDKGraphRequest class]);
-  OCMStub([graphRequestMock alloc]).andReturn(graphRequestMock);
-  OCMStub(
-    [graphRequestMock initWithGraphPath:[OCMArg any]
-                             parameters:[OCMArg any]
-                            tokenString:nil
-                             HTTPMethod:FBSDKHTTPMethodPOST
-                                  flags:FBSDKGraphRequestFlagDoNotInvalidateTokenOnError | FBSDKGraphRequestFlagDisableErrorRecovery]
-  ).andReturn(graphRequestMock);
-
-  [self.appEventsMock publishATE];
-
-  OCMVerify([graphRequestMock startWithCompletionHandler:[OCMArg any]]);
-
-  [graphRequestMock stopMocking];
-  graphRequestMock = nil;
-}
-
-- (void)testPublishATEWithPingLessThan24Hours
-{
-  [self stubAppID:@"mockAppID"];
-  UserDefaultsSpy *userDefault = [UserDefaultsSpy new];
-  [userDefault setObject:[NSDate dateWithTimeIntervalSinceNow:-12 * 60 * 60] forKey:[NSString stringWithFormat:@"com.facebook.sdk:lastATEPing%@", @"mockAppID"]];
-  [self stubUserDefaultsWith:userDefault];
-  [self stubAdvertisingTrackingStatusWith:FBSDKAdvertisingTrackingAllowed];
-
-  id graphRequestMock = OCMClassMock([FBSDKGraphRequest class]);
-  OCMStub([graphRequestMock alloc]).andReturn(graphRequestMock);
-  OCMStub(
-    [graphRequestMock initWithGraphPath:[OCMArg any]
-                             parameters:[OCMArg any]
-                            tokenString:nil
-                             HTTPMethod:FBSDKHTTPMethodPOST
-                                  flags:FBSDKGraphRequestFlagDoNotInvalidateTokenOnError | FBSDKGraphRequestFlagDisableErrorRecovery]
-  ).andReturn(graphRequestMock);
-
-  [self.appEventsMock publishATE];
-
-  OCMReject([graphRequestMock startWithCompletionHandler:[OCMArg any]]);
-
-  [graphRequestMock stopMocking];
-  graphRequestMock = nil;
-}
-
-- (void)testPublishATEWithVerifyingParams
-{
-  [self stubAppID:@"mockAppID"];
-  [self stubUserDefaultsWith:[UserDefaultsSpy new]];
-  [self stubAdvertisingTrackingStatusWith:FBSDKAdvertisingTrackingAllowed];
-
-  [self.appEventsMock publishATE];
-
-  OCMReject(
-    [self.appEventsUtilityClassMock activityParametersDictionaryForEvent:[OCMArg any]
-                                               shouldAccessAdvertisingID:[OCMArg any]]
-  );
 }
 
 #pragma mark  Tests for Kill Switch


### PR DESCRIPTION
Summary:
Abstracts the AtePublisher from AppEvents.

Reasons:
AppEvents is nearly a thousand lines long. The publishing of ATE is a unique concern that is related but has no direct dependencies on AppEvents. This simplifies the AppEvents tests because all we care about from the AppEvents side is

a) it has a default publisher of the expected type
b) it invokes that publisher as part of its publishATE method

This allows us to test the publisher in isolation by using an internal initializer that takes the required dependencies which include:

* NSUserDefaults for persisting the last publish date
* NSDate for finding out when the last publish date was
* FBSDKSettings for advertiser tracking status
* FBSDKGraphRequest for creating and starting the graph request
* FBSDKInternalUtility for getting the operating system version

This diff does the following:
1. Moves the body of the publishATE method to be a distinct type (this diff)
1. Tests that the type is used correctly by AppEvents (this diff)
1. Ports the existing tests for the new type (this diff)
1. Adds protocols for the dependencies of the new type so that it can be tested without swizzling. (future diff)
1. Uses fakes to test the new type (future diff)

Reviewed By: Mxiim

Differential Revision: D26341851

