### PR TITLE
Fix missing token bug for App Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- App Events use the correct token if none have been provided manually
+
 ### Important
 
 [Full Changelog](https://github.com/facebook/facebook-ios-sdk/compare/v9.1.0...HEAD)

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsUtility.m
@@ -319,7 +319,7 @@ static NSArray<NSString *> *standardEvents;
     // If there's an logging override app id present, then we don't want to use the client token since the client token
     // is intended to match up with the primary app id (and AppEvents doesn't require a client token).
     NSString *clientTokenString = [FBSDKSettings clientToken];
-    if (clientTokenString && appID && [appID isEqualToString:token.appID]) {
+    if (clientTokenString && appID && ([appID isEqualToString:token.appID] || token == nil)) {
       tokenString = [NSString stringWithFormat:@"%@|%@", appID, clientTokenString];
     } else if (appID) {
       tokenString = nil;

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsUtilityTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsUtilityTests.m
@@ -317,4 +317,13 @@ static NSString *const FBSDKSettingsAdvertisingTrackingStatus = @"com.facebook.s
   }
 }
 
+- (void)testProvideTokenForAppAndClient
+{
+  [FBSDKAppEvents setLoggingOverrideAppID:nil];
+  [FBSDKSettings setAppID:@"123"];
+  [FBSDKSettings setClientToken:@"toktok"];
+  NSString *token = [FBSDKAppEventsUtility tokenStringToUseFor:nil];
+  XCTAssertEqualObjects(@"123|toktok", token);
+}
+
 @end


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)

## Pull Request Details

App Events utils had bug where it wouldn't provide the `app|client` token unless a token was partially specified either as input or in the settings.

## Test Plan

I've added a test to verify that `tokenStringToUseFor` returns the correct token