### PR TITLE
iOS GamingServicesKit Gaming PayLoad

### DIFF
--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/project.pbxproj
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit.xcodeproj/project.pbxproj
@@ -22,6 +22,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		9FB2855526014BF300DB99CB /* FBSDKGamingPayloadObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB2854126014BF300DB99CB /* FBSDKGamingPayloadObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FB2855626014BF300DB99CB /* FBSDKGamingPayloadObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB2854126014BF300DB99CB /* FBSDKGamingPayloadObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FB2855726014BF300DB99CB /* FBSDKGamingPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB2855226014BF300DB99CB /* FBSDKGamingPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FB2855826014BF300DB99CB /* FBSDKGamingPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB2855226014BF300DB99CB /* FBSDKGamingPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9FB2855926014BF300DB99CB /* FBSDKGamingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2855326014BF300DB99CB /* FBSDKGamingPayload.m */; };
+		9FB2855A26014BF300DB99CB /* FBSDKGamingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2855326014BF300DB99CB /* FBSDKGamingPayload.m */; };
+		9FB2855B26014BF300DB99CB /* FBSDKGamingPayloadObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2855426014BF300DB99CB /* FBSDKGamingPayloadObserver.m */; };
+		9FB2855C26014BF300DB99CB /* FBSDKGamingPayloadObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FB2855426014BF300DB99CB /* FBSDKGamingPayloadObserver.m */; };
 		9FB51BA024B8BD4700059B77 /* FBSDKGamingGroupIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FB51B8E24B8BD4700059B77 /* FBSDKGamingGroupIntegration.m */; };
 		9FB51BA124B8BD4700059B77 /* FBSDKGamingGroupIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB51B9F24B8BD4700059B77 /* FBSDKGamingGroupIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9FB51BA224B8BD5400059B77 /* FBSDKGamingGroupIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 9FB51B9F24B8BD4700059B77 /* FBSDKGamingGroupIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -232,6 +240,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9FB2854126014BF300DB99CB /* FBSDKGamingPayloadObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKGamingPayloadObserver.h; sourceTree = "<group>"; };
+		9FB2855226014BF300DB99CB /* FBSDKGamingPayload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKGamingPayload.h; sourceTree = "<group>"; };
+		9FB2855326014BF300DB99CB /* FBSDKGamingPayload.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKGamingPayload.m; sourceTree = "<group>"; };
+		9FB2855426014BF300DB99CB /* FBSDKGamingPayloadObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKGamingPayloadObserver.m; sourceTree = "<group>"; };
 		9FB51B8E24B8BD4700059B77 /* FBSDKGamingGroupIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKGamingGroupIntegration.m; sourceTree = "<group>"; };
 		9FB51B9F24B8BD4700059B77 /* FBSDKGamingGroupIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBSDKGamingGroupIntegration.h; sourceTree = "<group>"; };
 		9FC2000A247D82A00016A053 /* FBSDKGamingVideoUploaderConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBSDKGamingVideoUploaderConfiguration.m; sourceTree = "<group>"; };
@@ -368,6 +380,10 @@
 		F4F7C9B523F48F2C0030A346 /* FBSDKGamingServicesKit */ = {
 			isa = PBXGroup;
 			children = (
+				9FB2855226014BF300DB99CB /* FBSDKGamingPayload.h */,
+				9FB2855326014BF300DB99CB /* FBSDKGamingPayload.m */,
+				9FB2854126014BF300DB99CB /* FBSDKGamingPayloadObserver.h */,
+				9FB2855426014BF300DB99CB /* FBSDKGamingPayloadObserver.m */,
 				9FC2000C247D82A00016A053 /* FBSDKGamingVideoUploader.h */,
 				9FC2000B247D82A00016A053 /* FBSDKGamingVideoUploader.m */,
 				9FC2000D247D82A00016A053 /* FBSDKGamingVideoUploaderConfiguration.h */,
@@ -511,9 +527,11 @@
 				F4F7C9EA23F48F2C0030A346 /* FBSDKFriendFinderDialog.h in Headers */,
 				F4F7C9E423F48F2C0030A346 /* FBSDKGamingServiceCompletionHandler.h in Headers */,
 				F4F7C9E823F48F2C0030A346 /* FBSDKGamingImageUploader.h in Headers */,
+				9FB2855726014BF300DB99CB /* FBSDKGamingPayload.h in Headers */,
 				F4DC057F2519499A0073B380 /* FBSDKCoreKitInternalImport.h in Headers */,
 				F4F7C9EB23F48F2C0030A346 /* FBSDKGamingServicesKit.h in Headers */,
 				F4F7CA3623F499600030A346 /* FBSDKCoreKit+Internal.h in Headers */,
+				9FB2855526014BF300DB99CB /* FBSDKGamingPayloadObserver.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -530,9 +548,11 @@
 				F4F7CA7123F49D6F0030A346 /* FBSDKGamingServiceCompletionHandler.h in Headers */,
 				F4F7CA7223F49D6F0030A346 /* FBSDKGamingImageUploader.h in Headers */,
 				F4F7CA7323F49D6F0030A346 /* FBSDKGamingServicesKit.h in Headers */,
+				9FB2855826014BF300DB99CB /* FBSDKGamingPayload.h in Headers */,
 				F4DC05832519499B0073B380 /* FBSDKCoreKitInternalImport.h in Headers */,
 				F4F7CA7423F49D6F0030A346 /* FBSDKCoreKit+Internal.h in Headers */,
 				9FC2002E247D8ACF0016A053 /* FBSDKVideoUploader.h in Headers */,
+				9FB2855626014BF300DB99CB /* FBSDKGamingPayloadObserver.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -840,6 +860,8 @@
 				9FB51BA024B8BD4700059B77 /* FBSDKGamingGroupIntegration.m in Sources */,
 				F4F7C9E623F48F2C0030A346 /* FBSDKGamingServiceController.m in Sources */,
 				9FC2000F247D82A00016A053 /* FBSDKGamingVideoUploader.m in Sources */,
+				9FB2855B26014BF300DB99CB /* FBSDKGamingPayloadObserver.m in Sources */,
+				9FB2855926014BF300DB99CB /* FBSDKGamingPayload.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -855,6 +877,8 @@
 				9FB51BA324B8BD6100059B77 /* FBSDKGamingGroupIntegration.m in Sources */,
 				F4F7CA7823F49D6F0030A346 /* FBSDKGamingImageUploaderConfiguration.m in Sources */,
 				F4F7CA7923F49D6F0030A346 /* FBSDKGamingServiceController.m in Sources */,
+				9FB2855C26014BF300DB99CB /* FBSDKGamingPayloadObserver.m in Sources */,
+				9FB2855A26014BF300DB99CB /* FBSDKGamingPayload.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayload.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayload.h
@@ -15,29 +15,24 @@
 // COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#import <Foundation/Foundation.h>
 
-#if defined FBSDKCOCOAPODS || defined BUCK
+@class FBSDKURL;
 
- #import <FBSDKGamingServicesKit/FBSDKFriendFinderDialog.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingGroupIntegration.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingImageUploader.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingPayload.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingPayloadObserver.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h>
+NS_ASSUME_NONNULL_BEGIN
 
-#else
+extern NSString *const kGamingPayload;
+extern NSString *const kGamingPayloadGameRequestID;
 
- #import "FBSDKFriendFinderDialog.h"
- #import "FBSDKGamingGroupIntegration.h"
- #import "FBSDKGamingImageUploader.h"
- #import "FBSDKGamingImageUploaderConfiguration.h"
- #import "FBSDKGamingPayload.h"
- #import "FBSDKGamingPayloadObserver.h"
- #import "FBSDKGamingServiceCompletionHandler.h"
- #import "FBSDKGamingVideoUploader.h"
- #import "FBSDKGamingVideoUploaderConfiguration.h"
+NS_SWIFT_NAME(GamingPayload)
+@interface FBSDKGamingPayload : NSObject
 
-#endif
+@property (nonatomic, strong, nonnull) FBSDKURL *URL;
+@property (nonatomic, strong, readonly) NSString *payload;
+@property (nonatomic, strong, readonly) NSString *gameRequestID;
+
+- (instancetype)initWithUrl:(FBSDKURL * _Nonnull)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayload.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayload.m
@@ -1,0 +1,36 @@
+// (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+#import "FBSDKGamingPayload.h"
+
+#import "FBSDKCoreKitInternalImport.h"
+
+NSString *const kGamingPayload = @"payload";
+NSString *const kGamingPayloadGameRequestID = @"game_request_id";
+
+@implementation FBSDKGamingPayload : NSObject
+
+- (instancetype)initWithUrl:(FBSDKURL *_Nonnull)url
+{
+  if (self = [super init]) {
+    _URL = url;
+  }
+  return self;
+}
+
+- (NSString *)gameRequestID
+{
+  if (self.URL) {
+    return self.URL.appLinkExtras[kGamingPayloadGameRequestID];
+  }
+  return @"";
+}
+
+- (NSString *)payload
+{
+  if (self.URL) {
+    return self.URL.appLinkExtras[kGamingPayload];
+  }
+  return @"";
+}
+
+@end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayloadObserver.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayloadObserver.h
@@ -16,28 +16,22 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#if defined FBSDKCOCOAPODS || defined BUCK
+#import <Foundation/Foundation.h>
 
- #import <FBSDKGamingServicesKit/FBSDKFriendFinderDialog.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingGroupIntegration.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingImageUploader.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingImageUploaderConfiguration.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingPayload.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingPayloadObserver.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingServiceCompletionHandler.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingVideoUploader.h>
- #import <FBSDKGamingServicesKit/FBSDKGamingVideoUploaderConfiguration.h>
+@class FBSDKGamingPayload;
 
-#else
+@protocol FBSDKGamingPayloadDelegate <NSObject>
+- (void)updatedURLContaining:(FBSDKGamingPayload* _Nonnull)payload;
+@end
 
- #import "FBSDKFriendFinderDialog.h"
- #import "FBSDKGamingGroupIntegration.h"
- #import "FBSDKGamingImageUploader.h"
- #import "FBSDKGamingImageUploaderConfiguration.h"
- #import "FBSDKGamingPayload.h"
- #import "FBSDKGamingPayloadObserver.h"
- #import "FBSDKGamingServiceCompletionHandler.h"
- #import "FBSDKGamingVideoUploader.h"
- #import "FBSDKGamingVideoUploaderConfiguration.h"
+NS_ASSUME_NONNULL_BEGIN
 
-#endif
+NS_SWIFT_NAME(GamingPayload)
+@interface FBSDKGamingPayloadObserver : NSObject
+
+@property (nonatomic, weak) id<FBSDKGamingPayloadDelegate> delegate;
+
++ (instancetype)shared;
+
+@end
+NS_ASSUME_NONNULL_END

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayloadObserver.m
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/FBSDKGamingPayloadObserver.m
@@ -1,0 +1,73 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "FBSDKGamingPayloadObserver.h"
+
+#import "FBSDKCoreKitInternalImport.h"
+#import "FBSDKGamingPayload.h"
+
+@interface FBSDKGamingPayloadObserver () <FBSDKApplicationObserving>
+@end
+
+@implementation FBSDKGamingPayloadObserver
+
+static FBSDKGamingPayloadObserver *shared = nil;
+
++ (instancetype)shared
+{
+  if (!shared) {
+    shared = [FBSDKGamingPayloadObserver new];
+  }
+  return shared;
+}
+
+- (void)setDelegate:(id<FBSDKGamingPayloadDelegate>)delegate
+{
+  if (!delegate) {
+    [[FBSDKApplicationDelegate sharedInstance] removeObserver:shared];
+    shared = nil;
+  }
+
+  if (!_delegate) {
+    [[FBSDKApplicationDelegate sharedInstance] addObserver:[FBSDKGamingPayloadObserver shared]];
+  }
+  _delegate = delegate;
+}
+
+#pragma mark -- FBSDKApplicationObserving
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication
+         annotation:(id)annotation
+{
+  FBSDKURL *sdkURL = [FBSDKURL URLWithURL:url];
+  if (!sdkURL.appLinkExtras[kGamingPayload] && !sdkURL.appLinkExtras[kGamingPayloadGameRequestID]) {
+    return false;
+  }
+
+  if ([_delegate respondsToSelector:@selector(updatedURLContaining:)]) {
+    FBSDKGamingPayload *payload = [[FBSDKGamingPayload alloc] initWithUrl:sdkURL];
+    [_delegate updatedURLContaining:payload];
+    return true;
+  }
+
+  return false;
+}
+
+@end

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/include/FBSDKGamingPayload.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/include/FBSDKGamingPayload.h
@@ -1,0 +1,1 @@
+../FBSDKGamingPayload.h

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/include/FBSDKGamingPayloadObserver.h
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/include/FBSDKGamingPayloadObserver.h
@@ -1,0 +1,1 @@
+../FBSDKGamingPayloadObserver.h


### PR DESCRIPTION
Summary: Created an observer class where if developers set the delegate we will trigger the delegate method with a GamingPayload object if any urls contain gaming payload data.

Reviewed By: dloomb

Differential Revision: D26917678

