### PR TITLE
Add BITCODE_GENERATION_MODE = bitcode for iOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Static library binaries are built with `BITCODE_GENERATION_MODE = bitcode` to fix errors where Xcode is unable to build apps with bitcode enabled. [#1698](https://github.com/facebook/facebook-ios-sdk/pull/1698)
+
 ### Important
 
 [Full Changelog](https://github.com/facebook/facebook-ios-sdk/compare/v9.1.0...HEAD)

--- a/Configurations/Platform/iOS.xcconfig
+++ b/Configurations/Platform/iOS.xcconfig
@@ -27,6 +27,7 @@ LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/
 
 // Bitcode Support
 ENABLE_BITCODE = YES
+BITCODE_GENERATION_MODE = bitcode
 
 FB_BITCODE_FLAG = -fembed-bitcode
 OTHER_CFLAGS = $(inherited) $(FB_BITCODE_FLAG)


### PR DESCRIPTION
## Pull Request Details

Even though `-fembed-bitcode` is specified and the binaries have `__LLVM` segments for bitcode, Xcode fails when building an app with bitcode enabled.

Adding this option to iOS builds alongside the `-fembed-bitcode` flags eliminates this error and Xcode does not fail upon not finding bitcode in FBSDKLoginKit.framework.

See https://github.com/facebook/facebook-ios-sdk/issues/1679.

## Test Plan

Test Plan: Ran `scripts/run.sh release github static`, unzipped the built FBSDKLoginKit framework, manually copied the FBSDKLoginKit binary into the Pods folder of an app that depends on the FacebookSDK pod, built an app archive. Previously got an error saying, 

> ld: bitcode bundle could not be generated because '/Pods/FacebookSDK/FBSDKLoginKit.framework/FBSDKLoginKit(LoginManager.o)' was built without full bitcode.

After copying the newly built library binary in, this error went away (ran into other build errors but I believe they are not caused by this commit).
