### PR TITLE
Bugfix - Cocoapods with generate_multiple_pod_projects

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKCoreKit.h
@@ -24,6 +24,7 @@
  #import <FBSDKCoreKit/FBSDKAppEvents.h>
  #import <FBSDKCoreKit/FBSDKApplicationDelegate.h>
  #import <FBSDKCoreKit/FBSDKAuthenticationToken.h>
+ #import <FBSDKCoreKit/FBSDKAuthenticationTokenClaims.h>
  #import <FBSDKCoreKit/FBSDKButton.h>
  #import <FBSDKCoreKit/FBSDKConstants.h>
  #import <FBSDKCoreKit/FBSDKCopying.h>

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKCoreKit+Internal.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/FBSDKCoreKit+Internal.h
@@ -28,8 +28,6 @@
 
 #if defined FBSDKCOCOAPODS || defined BUCK
 
- #import "FBSDKCoreKit+Internal.h"
-
  #if !TARGET_OS_TV
   #import "FBSDKAuthenticationStatusUtility.h"
   #import "FBSDKBridgeAPI.h"
@@ -71,7 +69,6 @@
  #import "FBSDKApplicationObserving.h"
  #import "FBSDKAuthenticationStatusUtility.h"
  #import "FBSDKAuthenticationToken+Internal.h"
- #import "FBSDKAuthenticationTokenClaims.h"
  #import "FBSDKAuthenticationTokenFactory.h"
  #import "FBSDKAuthenticationTokenHeader.h"
  #import "FBSDKBase64.h"


### PR DESCRIPTION
Summary:
We moved auth token claims to the public headers of corekit but didn't remove it from the internal umbrella header. We also didn't add it to the public header for BUCK builds. This fixes both of those oversights.

There was also a weird import of the CoreKit+Internal header in the CoreKit+Internal header. This made no sense so removing.

Differential Revision: D27620983

