### PR TITLE
Fix Circle build error caused by D27607137

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("AppEvents"),
                 .headerSearchPath("AppEvents/Internal"),
+                .headerSearchPath("AppEvents/Internal/AAM"),
                 .headerSearchPath("AppEvents/Internal/Codeless"),
                 .headerSearchPath("AppEvents/Internal/ViewHierarchy/"),
                 .headerSearchPath("AppEvents/Internal/ML"),


### PR DESCRIPTION
Summary: Fix build error caused by D27607137 (https://github.com/facebook/facebook-ios-sdk/commit/35dffd4d8533fcd2fa3ec97e8c41410e335bb956).

Reviewed By: joesus

Differential Revision: D27664125

