### PR TITLE
Have cocoapods rebuild FacebookSDKStrings.bundle so xcode processes strings files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Important
 
+**Performance Improvements**
+
+- Cocoapods: FBSDKCoreKit rebuilds FacebookSDKStrings.bundle so xcode processes the strings files into binary plist format. This strips comments and saves ~181KB in disk space for apps. [#1713](https://github.com/facebook/facebook-ios-sdk/pull/1713)
+
 [Full Changelog](https://github.com/facebook/facebook-ios-sdk/compare/v9.2.0...HEAD)
 
 ## 9.2.0

--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
                              'FBSDKCoreKit/FBSDKCoreKit/GraphAPI/*.h'
     ss.private_header_files = 'FBSDKCoreKit/FBSDKCoreKit/Internal/**/*.h',
                               'FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/**/*.h'
-    ss.resources = 'FacebookSDKStrings.bundle'
+    ss.resource_bundles = { 'FacebookSDKStrings' => ['FacebookSDKStrings.bundle/**/*.strings'] }
     ss.library = 'c++', 'stdc++'
   end
 end


### PR DESCRIPTION
The end result is the final product ends up converting the strings files from the current text format to a minified binary plist format.

Size change:
Before
246,293 bytes (365 KB on disk)

After
133,039 bytes (184 KB on disk)

Nice ~100KB win for installed app size.

I decided to leave the bundle alone instead of breaking out the strings into their own folder because I didn't know if anything else was using the bundle currently. It doesn't look like spm is using it, which is probably a bug.

Also I'm not sure if these strings have test coverage or not, but if not I can help make sure various translations are still working correctly. Not sure where exactly these strings are used.


To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary) Wasn't sure how to run them all, I assume PR process has CI that will run them.
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes) I can't add labels.
