### PR TITLE
Fix SPM Integration

### DIFF
--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |ss|
     ss.dependency 'FBSDKCoreKit/Basics'
     ss.exclude_files = 'Sources/FBSDKCoreKit_Basics/**/*',
+                       'Sources/FacebookCore/Exports.swift',
                        'FBSDKCoreKit/FBSDKCoreKit/include/**/*',
                        'FBSDKCoreKit/FBSDKCoreKit/Swift/Exports.swift'
     ss.source_files = 'FBSDKCoreKit/FBSDKCoreKit/**/*.{h,hpp,m,mm}',

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPI.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPI.h
@@ -22,16 +22,11 @@
 
 #import <UIKit/UIKit.h>
 
-#if SWIFT_PACKAGE
-#import "FBSDKCoreKit.h"
-#else
-#import <FBSDKCoreKit/FBSDKCoreKit.h>
-#endif
-
 #import "FBSDKBridgeAPIProtocol.h"
 #import "FBSDKBridgeAPIProtocolType.h"
 #import "FBSDKBridgeAPIRequest.h"
 #import "FBSDKBridgeAPIResponse.h"
+#import "FBSDKConstants.h"
 #import "FBSDKURLOpening.h"
 
 @protocol FBSDKOperatingSystemVersionComparing;

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPIRequest.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPIRequest.h
@@ -22,12 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
 #import "FBSDKCopying.h"
-#else
-#import <FBSDKCoreKit/FBSDKCopying.h>
-#endif
-
 #import "FBSDKBridgeAPIProtocol.h"
 #import "FBSDKBridgeAPIProtocolType.h"
 

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPIResponse.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPIResponse.h
@@ -22,12 +22,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
 #import "FBSDKCopying.h"
-#else
-#import <FBSDKCoreKit/FBSDKCopying.h>
-#endif
-
 #import "FBSDKBridgeAPIRequest.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,8 @@
 
 import PackageDescription
 
+let conditionalCompilationFlag = "FBSDK_SWIFT_PACKAGE"
+
 let package = Package(
     name: "Facebook",
     platforms: [
@@ -130,10 +132,7 @@ let package = Package(
         */
         .target(
             name: "FacebookCore",
-            dependencies: ["LegacyCoreKit"],
-            swiftSettings: [
-                .define("FBSDK_SWIFT_PACKAGE")
-            ]
+            dependencies: ["LegacyCoreKit"]
         ),
 
         /*
@@ -159,10 +158,11 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("Internal"),
                 .headerSearchPath("../../FBSDKCoreKit/FBSDKCoreKit/Internal"),
-                .define("FBSDK_SWIFT_PACKAGE", to: nil, .when(platforms: [.iOS, .macOS, .tvOS], configuration: nil))
-            ],
-            swiftSettings: [
-                .define("FBSDK_SWIFT_PACKAGE")
+                .define(
+                    conditionalCompilationFlag,
+                    to: nil,
+                    .when(platforms: [.iOS, .macOS, .tvOS], configuration: nil)
+                )
             ]
         ),
 
@@ -187,7 +187,11 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("Internal"),
                 .headerSearchPath("../../FBSDKCoreKit/FBSDKCoreKit/Internal"),
-              .define("FBSDK_SWIFT_PACKAGE", to: nil, .when(platforms: [.iOS, .macOS, .tvOS], configuration: nil))
+                .define(
+                    conditionalCompilationFlag,
+                    to: nil,
+                    .when(platforms: [.iOS, .macOS, .tvOS], configuration: nil)
+                )
             ]
         ),
 
@@ -213,7 +217,11 @@ let package = Package(
                 .headerSearchPath("Internal"),
                 .headerSearchPath("../../FBSDKCoreKit/FBSDKCoreKit/Internal"),
                 .headerSearchPath("../../FBSDKShareKit/FBSDKShareKit/Internal"),
-                .define("FBSDK_SWIFT_PACKAGE", to: nil, .when(platforms: [.iOS, .macOS, .tvOS], configuration: nil))
+                .define(
+                    conditionalCompilationFlag,
+                    to: nil,
+                    .when(platforms: [.iOS, .macOS, .tvOS], configuration: nil)
+                )
             ]
         ),
 

--- a/samples/SmoketestSPM/SmoketestSPM.xcodeproj/project.pbxproj
+++ b/samples/SmoketestSPM/SmoketestSPM.xcodeproj/project.pbxproj
@@ -11,10 +11,12 @@
 		F43C34EA2370F948005145DD /* VerifyFacebookCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43C34E72370F947005145DD /* VerifyFacebookCore.swift */; };
 		F43C34EB2370F948005145DD /* VerifyFacebookShare.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43C34E82370F948005145DD /* VerifyFacebookShare.swift */; };
 		F43C34EC2370F948005145DD /* VerifyFacebookLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43C34E92370F948005145DD /* VerifyFacebookLogin.swift */; };
+		F43FBA9F2649D79300FDCB82 /* VerifyFacebookGamingServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43FBA9E2649D79300FDCB82 /* VerifyFacebookGamingServices.swift */; };
 		F43C34EE2370F957005145DD /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = F43C34ED2370F957005145DD /* README.md */; };
 		F4CEA54023C29C9E0086EB16 /* FacebookShare in Frameworks */ = {isa = PBXBuildFile; productRef = F4CEA53F23C29C9E0086EB16 /* FacebookShare */; };
 		F4CEA54223C29C9E0086EB16 /* FacebookLogin in Frameworks */ = {isa = PBXBuildFile; productRef = F4CEA54123C29C9E0086EB16 /* FacebookLogin */; };
 		F4CEA54423C29C9E0086EB16 /* FacebookCore in Frameworks */ = {isa = PBXBuildFile; productRef = F4CEA54323C29C9E0086EB16 /* FacebookCore */; };
+		F43FBA972649CEA800FDCB82 /* FacebookGamingServices in Frameworks */ = {isa = PBXBuildFile; productRef = F43FBA962649CEA800FDCB82 /* FacebookGamingServices */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +26,7 @@
 		F43C34E72370F947005145DD /* VerifyFacebookCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifyFacebookCore.swift; sourceTree = "<group>"; };
 		F43C34E82370F948005145DD /* VerifyFacebookShare.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifyFacebookShare.swift; sourceTree = "<group>"; };
 		F43C34E92370F948005145DD /* VerifyFacebookLogin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerifyFacebookLogin.swift; sourceTree = "<group>"; };
+		F43FBA9E2649D79300FDCB82 /* VerifyFacebookGamingServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyFacebookGamingServices.swift; sourceTree = "<group>"; };
 		F43C34ED2370F957005145DD /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -35,6 +38,7 @@
 				F4CEA54223C29C9E0086EB16 /* FacebookLogin in Frameworks */,
 				F4CEA54423C29C9E0086EB16 /* FacebookCore in Frameworks */,
 				F4CEA54023C29C9E0086EB16 /* FacebookShare in Frameworks */,
+				F43FBA972649CEA800FDCB82 /* FacebookGamingServices in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,6 +68,7 @@
 				F43C34E72370F947005145DD /* VerifyFacebookCore.swift */,
 				F43C34E92370F948005145DD /* VerifyFacebookLogin.swift */,
 				F43C34E82370F948005145DD /* VerifyFacebookShare.swift */,
+				F43FBA9E2649D79300FDCB82 /* VerifyFacebookGamingServices.swift */,
 				F43C34D72370F8BD005145DD /* SmoketestSPM.h */,
 				F43C34D82370F8BD005145DD /* Info.plist */,
 			);
@@ -102,6 +107,7 @@
 				F4CEA53F23C29C9E0086EB16 /* FacebookShare */,
 				F4CEA54123C29C9E0086EB16 /* FacebookLogin */,
 				F4CEA54323C29C9E0086EB16 /* FacebookCore */,
+				F43FBA962649CEA800FDCB82 /* FacebookGamingServices */,
 			);
 			productName = SmoketestSPM;
 			productReference = F43C34D42370F8BD005145DD /* SmoketestSPM.framework */;
@@ -159,6 +165,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F43FBA9F2649D79300FDCB82 /* VerifyFacebookGamingServices.swift in Sources */,
 				F43C34EB2370F948005145DD /* VerifyFacebookShare.swift in Sources */,
 				F43C34EC2370F948005145DD /* VerifyFacebookLogin.swift in Sources */,
 				F43C34EA2370F948005145DD /* VerifyFacebookCore.swift in Sources */,
@@ -372,6 +379,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		F43FBA962649CEA800FDCB82 /* FacebookGamingServices */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F4CEA53E23C29C9E0086EB16 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;
+			productName = FacebookGamingServices;
+		};
 		F4CEA53F23C29C9E0086EB16 /* FacebookShare */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F4CEA53E23C29C9E0086EB16 /* XCRemoteSwiftPackageReference "facebook-ios-sdk" */;

--- a/samples/SmoketestSPM/SmoketestSPM/VerifyFacebookGamingServices.swift
+++ b/samples/SmoketestSPM/SmoketestSPM/VerifyFacebookGamingServices.swift
@@ -16,11 +16,22 @@
 // IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Need to treat ObjC as separate dependency for SPM because it does not
-// support mixed Swift and ObjC sources. In order to expose the dependent
-// interface we need to pass through the import of the `FBSDKShareKitObjC`
-// target defined in Package.swift.
-// See: https://forums.swift.org/t/16648/2 for more details
-//
+import FacebookGamingServices
 
-@_exported import LegacyCoreKit
+struct VerifyFacebookGamingServices {
+    func verifyTransitiveSymbols() {
+        // Verifies Swift only symbol
+        _ = Permission.email
+
+        // Verifies ObjC symbol
+        Settings.appID = "Foo"
+
+        // Additional Sanity Check
+        AppEvents.logEvent(AppEvents.Name("foo"))
+    }
+
+    func verifyGamingSymbols() {
+        // Verifies ObjC symbol
+        _ = GamingPayload.self
+    }
+}


### PR DESCRIPTION
Summary: Making the BridgeAPI files public broke the SPM integration. This fixes it by getting rid of modular import statements at the top level.

Differential Revision: D28335156

