### PR TITLE
fix #1618 remove deprecated unarchiveObjectWith- methods

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
@@ -84,7 +84,11 @@ static dispatch_once_t sharedConfigurationManagerNonce;
   self.connectionFactory = graphRequestConnectionFactory;
   id data = [self.store objectForKey:FBSDKAppEventsConfigurationKey];
   if ([data isKindOfClass:NSData.class]) {
-    self.configuration = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    if (@available(iOS 11.0, tvOS 11.0, *)) {
+      self.configuration = [NSKeyedUnarchiver unarchivedObjectOfClass:FBSDKAppEventsConfiguration.class fromData:data error:nil];
+    } else {
+      self.configuration = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
   }
   if (!self.configuration) {
     self.configuration = [FBSDKAppEventsConfiguration defaultConfiguration];

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SKAdNetwork/FBSDKSKAdNetworkReporter.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SKAdNetwork/FBSDKSKAdNetworkReporter.m
@@ -278,7 +278,20 @@ static Class<FBSDKConversionValueUpdating> _conversionValueUpdatable;
   g_recordedEvents = [NSMutableSet new];
   g_recordedValues = [NSMutableDictionary new];
   if ([cachedReportData isKindOfClass:[NSData class]]) {
-    NSDictionary<NSString *, id> *data = [FBSDKTypeUtility dictionaryValue:[NSKeyedUnarchiver unarchiveObjectWithData:cachedReportData]];
+    NSDictionary<NSString *, id> *data;
+    if (@available(iOS 11.0, *)) {
+      data = [FBSDKTypeUtility dictionaryValue:[NSKeyedUnarchiver
+                                                unarchivedObjectOfClasses:[NSSet setWithArray:
+                                                                           @[NSString.class,
+                                                                             NSNumber.class,
+                                                                             NSArray.class,
+                                                                             NSDictionary.class,
+                                                                             NSSet.class]]
+                                                fromData:cachedReportData
+                                                error:nil]];
+    } else {
+      data = [FBSDKTypeUtility dictionaryValue:[NSKeyedUnarchiver unarchiveObjectWithData:cachedReportData]];
+    }
     if (data) {
       g_conversionValue = [FBSDKTypeUtility integerValue:data[@"conversion_value"]];
       g_timestamp = [FBSDKTypeUtility dictionary:data objectForKey:@"timestamp" ofType:NSDate.class];

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKSettings.m
@@ -560,9 +560,17 @@ FBSDKSETTINGS_PLIST_CONFIGURATION_SETTING_IMPL(
   if (!g_dataProcessingOptions) {
     NSData *data = [self.store objectForKey:FBSDKSettingsDataProcessingOptions];
     if ([data isKindOfClass:[NSData class]]) {
-      NSDictionary<NSString *, id> *dataProcessingOptions = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-      if (dataProcessingOptions && [dataProcessingOptions isKindOfClass:[NSDictionary class]]) {
-        g_dataProcessingOptions = dataProcessingOptions;
+      if (@available(iOS 11.0, tvOS 11.0, *)) {
+        if (@available(tvOS 11.0, *)) {
+          g_dataProcessingOptions = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithArray:@[NSString.class, NSNumber.class, NSArray.class, NSDictionary.class, NSSet.class]] fromData:data error:nil];
+        } else {
+          // Fallback on earlier versions
+        }
+      } else {
+        NSDictionary<NSString*, id> *dataProcessingOptions = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        if (dataProcessingOptions && [dataProcessingOptions isKindOfClass:[NSDictionary class]]) {
+          g_dataProcessingOptions = dataProcessingOptions;
+        }
       }
     }
   }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/SKAdNetwork/FBSDKSKAdNetworkReporterTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/SKAdNetwork/FBSDKSKAdNetworkReporterTests.m
@@ -221,7 +221,16 @@ typedef void (^FBSDKSKAdNetworkReporterBlock)(void);
     [FBSDKSKAdNetworkReporter _recordAndUpdateEvent:@"test" currency:nil value:nil];
     NSData *cache = [userDefaultsSpy objectForKey:FBSDKSKAdNetworkReporterKey];
     XCTAssertNotNil(cache);
-    NSDictionary<NSString *, id> *data = [FBSDKTypeUtility dictionaryValue:[NSKeyedUnarchiver unarchiveObjectWithData:cache]];
+    // cannot adopt NSKeyedUnarchiver.unarchivedDictionaryWithKeysOfClasses::: due to nested collections
+    NSDictionary<NSString *, id> *data = [FBSDKTypeUtility dictionaryValue: [NSKeyedUnarchiver
+                                                                             unarchivedObjectOfClasses:[NSSet setWithArray:
+                                                                                                        @[NSDictionary.class,
+                                                                                                          NSString.class,
+                                                                                                          NSNumber.class,
+                                                                                                          NSDate.class,
+                                                                                                          NSSet.class]]
+                                                                             fromData:cache
+                                                                             error:nil]];
     NSMutableSet<NSString *> *recordedEvents = [FBSDKTypeUtility dictionary:data objectForKey:@"recorded_events" ofType:NSMutableSet.class];
     NSSet<NSString *> *expectedEvents = [NSSet setWithArray:@[@"fb_test", @"fb_mobile_purchase"]];
     XCTAssertTrue([expectedEvents isEqualToSet:recordedEvents]);

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/FBSDKErrorConfigurationTests.m
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/FBSDKErrorConfigurationTests.m
@@ -65,8 +65,13 @@
   [intermediaryConfiguration updateWithArray:rawErrorCodeConfiguration];
 
   NSData *data = [NSKeyedArchiver archivedDataWithRootObject:intermediaryConfiguration];
-  FBSDKErrorConfiguration *configuration = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-
+  FBSDKErrorConfiguration *configuration;
+  if (@available(iOS 11.0, *)) {
+    configuration = [NSKeyedUnarchiver unarchivedObjectOfClass:FBSDKErrorConfiguration.class fromData:data error:nil];
+  } else {
+    configuration = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  }
+  XCTAssertNotNil(configuration);
   XCTAssertEqual(FBSDKGraphRequestErrorTransient, [configuration recoveryConfigurationForCode:@"1" subcode:nil request:nil].errorCategory);
   XCTAssertEqual(FBSDKGraphRequestErrorRecoverable, [configuration recoveryConfigurationForCode:@"1" subcode:@"12312" request:nil].errorCategory);
   XCTAssertEqual(FBSDKGraphRequestErrorTransient, [configuration recoveryConfigurationForCode:@"2" subcode:@"*" request:nil].errorCategory);


### PR DESCRIPTION
I replaced instances of the deprecated `NSKeyedUnarchiver.unarchiveObjectWithData` to the recommended secure implementation `NSKeyedUnarchiver.unarchivedObjectOfClass(es)`.  

 - For backwards compatibility, the legacy references remain for iOS<11.0
 - An additional test was added to `FBSDKAppEventsConfigurationManagerTests` to validate unarchive code path

Note: The original issue references a number of locations of the deprecated method; many of these had already been modernized, so no additional action was needed here.
