### PR TITLE
Fix compilation on Xcode 13b3

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/FBSDKAppEvents.m
@@ -310,6 +310,7 @@ static id<FBSDKAppEventsParameterProcessing, FBSDKEventsProcessing> g_restrictiv
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKAppEvents
 {
   FBSDKServerConfiguration *_serverConfiguration;

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/FBSDKCodelessIndexer.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/FBSDKCodelessIndexer.m
@@ -62,6 +62,7 @@
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKCodelessIndexer
 
 static BOOL _isCodelessIndexing;

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/FBSDKEventBindingManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/Codeless/FBSDKEventBindingManager.m
@@ -54,6 +54,7 @@
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKEventBindingManager
 
 - (instancetype)initWithSwizzler:(Class<FBSDKSwizzling>)swizzling

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKSuggestedEventsIndexer.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/SuggestedEvents/FBSDKSuggestedEventsIndexer.m
@@ -65,6 +65,7 @@ NSString *const UnconfirmedEvents = @"eligible_for_prediction_events";
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKSuggestedEventsIndexer
 
 - (instancetype)init

--- a/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKWebViewAppLinkResolver.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppLink/FBSDKWebViewAppLinkResolver.m
@@ -77,6 +77,7 @@ static NSString *const FBSDKWebViewAppLinkResolverShouldFallbackKey = @"should_f
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKWebViewAppLinkResolverWebViewDelegate
 
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
@@ -112,6 +113,7 @@ static NSString *const FBSDKWebViewAppLinkResolverShouldFallbackKey = @"should_f
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKWebViewAppLinkResolver
 
 - (instancetype)init

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKApplicationDelegate.m
@@ -125,6 +125,7 @@ static UIApplicationState _applicationState;
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKApplicationDelegate
 
 #pragma mark - Class Methods

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPI.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPI.m
@@ -74,6 +74,7 @@ typedef NS_ENUM(NSUInteger, FBSDKAuthenticationSession) {
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKBridgeAPI
 {
   NSObject<FBSDKBridgeAPIRequestProtocol> *_pendingRequest;

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPIRequest.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKBridgeAPIRequest.m
@@ -34,6 +34,7 @@ NSString *const FBSDKBridgeAPIAppIDKey = @"app_id";
 NSString *const FBSDKBridgeAPISchemeSuffixKey = @"scheme_suffix";
 NSString *const FBSDKBridgeAPIVersionKey = @"version";
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKBridgeAPIRequest
 
  #pragma mark - Class Methods

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKInternalUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKInternalUtility.m
@@ -48,6 +48,7 @@ typedef NS_ENUM(NSUInteger, FBSDKInternalUtilityVersionShift) {
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKInternalUtility
 
 static Class<FBSDKLogging> _loggerType;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKViewImpressionTracker.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/UI/FBSDKViewImpressionTracker.m
@@ -36,6 +36,7 @@
 
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKViewImpressionTracker
 {
   NSMutableSet *_trackedImpressions;

--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/WebDialog/FBSDKWebDialog.m
@@ -43,6 +43,7 @@ static FBSDKWebDialog *g_currentDialog = nil;
 @interface FBSDKWebDialog () <FBSDKWebDialogViewDelegate>
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKWebDialog
 {
   UIView *_backgroundView;

--- a/FBSDKLoginKit/FBSDKLoginKit/FBSDKTooltipView.m
+++ b/FBSDKLoginKit/FBSDKLoginKit/FBSDKTooltipView.m
@@ -49,6 +49,7 @@ static CGMutablePathRef _fbsdkCreateDownPointingBubbleWithRect(CGRect rect, CGFl
 
  #pragma mark -
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKTooltipView
 {
   CGPoint _positionInView;

--- a/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m
+++ b/FBSDKShareKit/FBSDKShareKit/FBSDKShareDialog.m
@@ -75,6 +75,7 @@ static inline void FBSDKShareDialogValidateShareExtensionSchemeRegisteredForCanO
 @interface FBSDKShareDialog () <FBSDKWebDialogDelegate>
 @end
 
+NS_EXTENSION_UNAVAILABLE("")
 @implementation FBSDKShareDialog
 {
   FBSDKWebDialog *_webDialog;


### PR DESCRIPTION
While this is not a proper fix, it allows you to compile Facebook SDK with Xcode 13b3 and up. 

Kind of a fix for #1799
