### PR TITLE
Update generate-projects.sh to re-open Xcode if it was open when running it

### DIFF
--- a/generate-projects.sh
+++ b/generate-projects.sh
@@ -19,7 +19,16 @@
 
 EXPECTED_XCODEGEN_VERSION="2.24.0"
 
-killall Xcode || true
+RESET='\033[0m'
+YELLOW='\033[1;33m'
+
+pgrep -f '/Applications/Xcode.*\.app/Contents/MacOS/Xcode' > /dev/null
+if [ $? -eq 0 ]; then
+    XCODE_WAS_OPEN="true"
+    echo "⚠️  ${YELLOW}Closing Xcode!${RESET}"
+    killall Xcode || true
+fi
+
 
 if [ ! -d "Carthage/checkouts/ocmock" ]; then
     echo "OCMock is required to run some tests. Run the command 'carthage bootstrap --no-build' and try again."
@@ -70,3 +79,10 @@ cd ..
 
 cd FBSDKGamingServicesKit || exit
 xcodegen generate
+
+cd ..
+
+if [ $XCODE_WAS_OPEN ]; then
+    echo "${YELLOW}Reopening FacebookSDK.xcworkspace${RESET}"
+    open FacebookSDK.xcworkspace
+fi


### PR DESCRIPTION
Summary:
If Xcode is running when the script is run, it will reopen FacebookSDK.xcodeproj

Not sure if there is a better way to detect if Xcode is running but this seems to work:
ps -ef | grep -v "grep" | grep '/Applications/Xcode.*\.app/Contents/MacOS/Xcode'

Also I'm assuming that if you are working in this directory then you have FacebookSDK.xcworkspace which I believe is a safe assumption unless someone tells me otherwise.

Reviewed By: joesus, jamestouri

Differential Revision: D30229076

