### PR TITLE
Error Recovery Bugfix

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
+++ b/FBSDKCoreKit/FBSDKCoreKit.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		06876ABAFFFDDE48FCEBEE39 /* FBSDKEventsProcessing.h in Headers */ = {isa = PBXBuildFile; fileRef = E79CF5653BD9B3E85FEF28AB /* FBSDKEventsProcessing.h */; };
 		068C0C95366587283D8ECB91 /* FBSDKGraphRequestDataAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = EFB677C5F1DA6F65D65BF14E /* FBSDKGraphRequestDataAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		06903E664BBE79F8CCBB9DA0 /* FBSDKRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = B98D8DE921807B1F4DE80551 /* FBSDKRandom.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		06A36C2C37D36679BA3A7CE2 /* FBSDKGraphErrorRecoveryProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8C7306E39BA9E16A7DC62A /* FBSDKGraphErrorRecoveryProcessorTests.swift */; };
 		070DEBC4477DCFBB75AA359A /* FBSDKInternalUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F5933A257F89151D2A34CA0E /* FBSDKInternalUtilityTests.m */; };
 		07420D3992BDBDB976E57767 /* FBSDKIcon+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 414D4781F737390D48889F8E /* FBSDKIcon+Internal.h */; };
 		074DBADB02BA82927F735D95 /* FBSDKLogger+Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = D56BA2ADE5B4022C41CDA742 /* FBSDKLogger+Logging.h */; };
@@ -2080,6 +2081,7 @@
 		4EB64775CF7B2AA4603B267E /* FBSDKSettings+ClientTokenProviding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSDKSettings+ClientTokenProviding.h"; sourceTree = "<group>"; };
 		4EC59417920E489639BB5AA2 /* ModelUtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelUtilityTests.swift; sourceTree = "<group>"; };
 		4F08003CB0ED6C205E537A7A /* FBSDKTokenStringProviding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBSDKTokenStringProviding.h; sourceTree = "<group>"; };
+		4F8C7306E39BA9E16A7DC62A /* FBSDKGraphErrorRecoveryProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FBSDKGraphErrorRecoveryProcessorTests.swift; sourceTree = "<group>"; };
 		4FB16DC816E29889A83DD78D /* EventBindingManagerEventHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventBindingManagerEventHandlingTests.swift; sourceTree = "<group>"; };
 		5004CC150760BD4095447B1B /* FBSDKShareDialogConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKShareDialogConfiguration.m; sourceTree = "<group>"; };
 		5059C4D51B64B337477F2B5C /* FBSDKModelManager+RulesFromKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FBSDKModelManager+RulesFromKeyProvider.h"; sourceTree = "<group>"; };
@@ -3175,6 +3177,7 @@
 		7E02955443925C321F3DF794 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				4F8C7306E39BA9E16A7DC62A /* FBSDKGraphErrorRecoveryProcessorTests.swift */,
 				207E6603923B41D60D8A988C /* FBSDKGraphRequestPiggybackManagerTests.m */,
 				23DD5B690744C342AA1033EC /* GraphRequestBodyTests.swift */,
 				A21CDAC0F8F00FFED249ABC2 /* GraphRequestConnectionFactoryTests.swift */,
@@ -5679,6 +5682,7 @@
 				B7BB2B59115E0314CCB843A3 /* FBSDKEventBindingTests.swift in Sources */,
 				5FC8C1F47B093476FD2650F6 /* FBSDKEventDeactivationTests.swift in Sources */,
 				F46BA3C1AAC1E277F68F9FE6 /* FBSDKFeatureExtractorTests.m in Sources */,
+				06A36C2C37D36679BA3A7CE2 /* FBSDKGraphErrorRecoveryProcessorTests.swift in Sources */,
 				55B108DC31F9C2FA1E042BD7 /* FBSDKGraphRequestConnectionTests.m in Sources */,
 				556B6A03E46040A4645E2B54 /* FBSDKGraphRequestPiggybackManagerTests.m in Sources */,
 				1A4903C2980F615BAD99986B /* FBSDKIntegrityManagerTests.swift in Sources */,

--- a/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphErrorRecoveryProcessor.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphErrorRecoveryProcessor.h
@@ -88,8 +88,16 @@ NS_ASSUME_NONNULL_BEGIN
  the `[FBSDKAccessToken currentAccessToken]` might still have been updated.
  .
  */
-NS_SWIFT_UNAVAILABLE("")
+NS_SWIFT_NAME(GraphErrorRecoveryProcessor)
 @interface FBSDKGraphErrorRecoveryProcessor : NSObject
+
++ (instancetype)new DEPRECATED_MSG_ATTRIBUTE("Creating instances of FBSDKGraphErrorRecoveryProcessor using `new` is deprecated and will be removed in the next major release");
+- (instancetype)init DEPRECATED_MSG_ATTRIBUTE("Creating instances of FBSDKGraphErrorRecoveryProcessor using `init` is deprecated and will be removed in the next major release");
+
+/**
+ Initializes a GraphErrorRecoveryProcessor with an access token string.
+ */
+- (instancetype)initWithAccessTokenString:(NSString *)accessTokenString;
 
 /**
   Attempts to process the error, return YES if the error can be processed.

--- a/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphErrorRecoveryProcessor.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphErrorRecoveryProcessor.m
@@ -22,15 +22,39 @@
 
  #import "FBSDKGraphErrorRecoveryProcessor.h"
 
+ #import "FBSDKAccessToken+AccessTokenProtocols.h"
+ #import "FBSDKErrorRecoveryAttempter.h"
  #import "FBSDKGraphRequestProtocol.h"
 
 @interface FBSDKGraphErrorRecoveryProcessor ()
 
+@property (nonatomic, readonly) NSString *accessToken;
 @property (nullable, nonatomic, readonly, weak) id<FBSDKGraphErrorRecoveryProcessorDelegate> delegate;
+@property (nullable, nonatomic) FBSDKErrorRecoveryAttempter *recoveryAttempter;
+@property (nullable, nonatomic) NSError *_error;
 
 @end
 
 @implementation FBSDKGraphErrorRecoveryProcessor
+
++ (instancetype)new
+{
+  return [[FBSDKGraphErrorRecoveryProcessor alloc] init];
+}
+
+- (instancetype)init
+{
+  return [self initWithAccessTokenString:FBSDKAccessToken.currentAccessToken.tokenString];
+}
+
+- (instancetype)initWithAccessTokenString:(NSString *)accessTokenString
+{
+  if ((self = [super init])) {
+    _accessToken = accessTokenString;
+  }
+
+  return self;
+}
 
 - (BOOL)processError:(NSError *)error
              request:(id<FBSDKGraphRequest>)request
@@ -42,12 +66,30 @@
     }
   }
 
-  FBSDKGraphRequestError errorCategory = [error.userInfo[FBSDKGraphRequestErrorKey] unsignedIntegerValue];
+  FBSDKGraphRequestError errorCategory;
+  id rawErrorCategory = error.userInfo[FBSDKGraphRequestErrorKey];
+  if (rawErrorCategory && [rawErrorCategory respondsToSelector:@selector(unsignedIntegerValue)]) {
+    errorCategory = [rawErrorCategory unsignedIntegerValue];
+  } else {
+    return NO;
+  }
+
   switch (errorCategory) {
     case FBSDKGraphRequestErrorTransient:
       [delegate processorDidAttemptRecovery:self didRecover:YES error:nil];
       return YES;
     case FBSDKGraphRequestErrorRecoverable:
+      if (request.tokenString && [request.tokenString isEqualToString:self.accessToken]) {
+        self.recoveryAttempter = error.recoveryAttempter;
+        [self.recoveryAttempter attemptRecoveryFromError:error
+                                             optionIndex:0
+                                       completionHandler:^(BOOL didRecover) {
+                                         [delegate processorDidAttemptRecovery:self didRecover:didRecover error:error];
+                                         self->_delegate = nil;
+                                       }];
+        return YES;
+      }
+      break;
     case FBSDKGraphRequestErrorOther:
       return NO;
   }

--- a/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphRequestConnection.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/GraphAPI/FBSDKGraphRequestConnection.m
@@ -887,7 +887,8 @@ static BOOL _canMakeRequests = NO;
     BOOL isRecoveryDisabled = [metadata.request isGraphErrorRecoveryDisabled];
     if (resultError && !isRecoveryDisabled && isSingleRequestToRecover) {
       self->_recoveringRequestMetadata = metadata;
-      self->_errorRecoveryProcessor = [FBSDKGraphErrorRecoveryProcessor new];
+      self->_errorRecoveryProcessor = [[FBSDKGraphErrorRecoveryProcessor alloc]
+                                       initWithAccessTokenString:FBSDKAccessToken.currentAccessToken.tokenString];
       if ([self->_errorRecoveryProcessor processError:resultError request:metadata.request delegate:self]) {
         return;
       }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKCoreKitTests-Bridging-Header.h
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/FBSDKCoreKitTests-Bridging-Header.h
@@ -107,6 +107,7 @@
 #import "FBSDKFeatureExtracting.h"
 #import "FBSDKFeatureManager.h"
 #import "FBSDKGateKeeperManager+Testing.h"
+#import "FBSDKGraphErrorRecoveryProcessor.h"
 #import "FBSDKGraphRequestConnecting+Internal.h"
 #import "FBSDKGraphRequestConnecting.h"
 #import "FBSDKGraphRequestConnectionFactory.h"

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Network/FBSDKGraphErrorRecoveryProcessorTests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/Network/FBSDKGraphErrorRecoveryProcessorTests.swift
@@ -1,0 +1,174 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+//
+// You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+// copy, modify, and distribute this software in source code or binary form for use
+// in connection with the web services and APIs provided by Facebook.
+//
+// As with any software that integrates with the Facebook platform, your use of
+// this software is subject to the Facebook Developer Principles and Policies
+// [http://developers.facebook.com/policy/]. This copyright notice shall be
+// included in all copies or substantial portions of the software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import TestTools
+import XCTest
+
+private class TestGraphErrorRecoveryProcessorDelegate: NSObject, GraphErrorRecoveryProcessorDelegate {
+
+  var wasRecoveryAttempted = false
+  var capturedProcessor: GraphErrorRecoveryProcessor?
+  var capturedDidRecover = false
+  var capturedError: NSError?
+
+  func processorDidAttemptRecovery(
+    _ processor: GraphErrorRecoveryProcessor,
+    didRecover: Bool,
+    error: Error?
+  ) {
+    wasRecoveryAttempted = true
+    capturedProcessor = processor
+    capturedDidRecover = didRecover
+    capturedError = error as NSError?
+  }
+}
+
+private class TestErrorRecoveryAttempter: ErrorRecoveryAttempter {
+
+  var capturedError: Error?
+  var capturedOptionIndex: UInt?
+  var capturedCompletion: ((Bool) -> Void)?
+
+  override func attemptRecovery(
+    fromError error: Error,
+    optionIndex recoveryOptionIndex: UInt,
+    completionHandler: @escaping (Bool) -> Void
+  ) {
+    capturedError = error
+    capturedOptionIndex = recoveryOptionIndex
+    capturedCompletion = completionHandler
+  }
+}
+
+class FBSDKGraphErrorRecoveryProcessorTests: XCTestCase {
+
+  private enum Keys {
+    static let errorKey = "com.facebook.sdk:FBSDKGraphRequestErrorKey"
+  }
+
+  private enum SampleErrors {
+
+    static let recoverableCode = Int(GraphRequestError.recoverable.rawValue)
+    static let transientCode = Int(GraphRequestError.transient.rawValue)
+    static let transient = NSError(
+      domain: "test",
+      code: transientCode,
+      userInfo: [Keys.errorKey: transientCode]
+    )
+
+    static func createRecoverable(attempter: ErrorRecoveryAttempter) -> NSError {
+      NSError(
+        domain: "test",
+        code: recoverableCode,
+        userInfo: [
+          Keys.errorKey: recoverableCode,
+          NSRecoveryAttempterErrorKey: attempter
+        ]
+      )
+    }
+
+  }
+
+  let processor = GraphErrorRecoveryProcessor(accessTokenString: "Foo")
+  private let delegate = TestGraphErrorRecoveryProcessorDelegate()
+  private let attempter = TestErrorRecoveryAttempter()
+
+  func testProcessingRandomErrorCategories() {
+    (1..<100).forEach { _ in
+      let error = NSError(domain: "test", code: 0, userInfo: [Keys.errorKey: Fuzzer.random])
+      processor.processError(error, request: TestGraphRequest(), delegate: delegate)
+    }
+  }
+
+  func testProcessingTransientError() {
+    XCTAssertTrue(
+      processor.processError(SampleErrors.transient, request: TestGraphRequest(), delegate: delegate),
+      "Should successfully process a transient graph request error"
+    )
+    XCTAssertEqual(
+      delegate.capturedProcessor,
+      processor,
+      "Should invoke the delegate with the expected recovery processor"
+    )
+    XCTAssertTrue(
+      delegate.capturedDidRecover,
+      "Should inform the delegate about the successful recovery"
+    )
+    XCTAssertNil(
+      delegate.capturedError
+    )
+  }
+
+  func testProcessingRecoverableErrorWithIdenticalAccessTokenString() throws {
+    let processor = GraphErrorRecoveryProcessor(accessTokenString: name)
+    let error = SampleErrors.createRecoverable(attempter: attempter)
+
+    XCTAssertTrue(
+      processor.processError(
+        error,
+        request: createGraphRequest(tokenString: name),
+        delegate: delegate
+      ),
+      "Should successfully process a recoverable graph request error"
+    )
+
+    let completion = try XCTUnwrap(attempter.capturedCompletion)
+    let wasRecoverySuccessful = Bool.random()
+    completion(wasRecoverySuccessful)
+
+    XCTAssertEqual(
+      delegate.capturedProcessor,
+      processor,
+      "Should invoke the delegate with the expected recovery processor"
+    )
+    XCTAssertEqual(
+      delegate.capturedDidRecover,
+      wasRecoverySuccessful,
+      "Should inform the delegate about the status of the recovery"
+    )
+    XCTAssertTrue(
+      delegate.capturedError === error,
+      "Should invoke the delegate with the expected error"
+    )
+  }
+
+  func testProcessingRecoverableErrorWithDifferentAccessTokenStrings() throws {
+    XCTAssertFalse(
+      processor.processError(
+        SampleErrors.createRecoverable(attempter: attempter),
+        request: createGraphRequest(tokenString: name),
+        delegate: delegate
+      ),
+      "Should not attempt to recover a graph request error if the access token strings do not match"
+    )
+    XCTAssertFalse(
+      delegate.wasRecoveryAttempted,
+      "Should not invoke the delegate when recovery is not attempted"
+    )
+  }
+
+// MARK: - Helpers
+
+  func createGraphRequest(tokenString: String) -> GraphRequestProtocol {
+    TestGraphRequest(
+      graphPath: "me",
+      parameters: [:],
+      tokenString: tokenString
+    )
+  }
+}


### PR DESCRIPTION
Summary: Fixes issue where errors due to an expired login token were not automatically handled by `_FBSDKLoginRecoveryAttempter`

Reviewed By: jawwad

Differential Revision: D30256570

