### PR TITLE
Add Nullability annotations to FBSDKButtonImpressionTracking.h

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/include/FBSDKButtonImpressionTracking.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/include/FBSDKButtonImpressionTracking.h
@@ -18,6 +18,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  Internal Type exposed to facilitate transition to Swift.
  API Subject to change or removal without warning. Do not use.
@@ -27,8 +29,10 @@
 NS_SWIFT_NAME(FBButtonImpressionTracking)
 @protocol FBSDKButtonImpressionTracking <NSObject>
 
-@property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *analyticsParameters;
+@property (nullable, nonatomic, readonly, copy) NSDictionary<NSString *, id> *analyticsParameters;
 @property (nonatomic, readonly, copy) NSString *impressionTrackingEventName;
 @property (nonatomic, readonly, copy) NSString *impressionTrackingIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Summary: Added NS_ASSUME_NONNULL_BEGIN / END and set the analyticsParameters property to nullable since it returns nil in one instance.

Reviewed By: joesus

Differential Revision: D30949563

