### PR TITLE
Convert logger properties from global variables to instance variables

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKLogger.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKLogger.m
@@ -30,14 +30,13 @@ static NSMutableDictionary<NSNumber *, id> *g_startTimesWithTags = nil;
 
 @interface FBSDKLogger ()
 
+@property (nonatomic) NSUInteger loggerSerialNumber;
+@property (nonatomic, copy) FBSDKLoggingBehavior loggingBehavior;
+@property (nonatomic, getter = isActive) BOOL active;
 @property (nonatomic, readonly, strong) NSMutableString *internalContents;
 @end
 
-@implementation FBSDKLogger {
-    NSUInteger _loggerSerialNumber;
-    FBSDKLoggingBehavior _loggingBehavior;
-    BOOL _active;
-}
+@implementation FBSDKLogger
 
 // Lifetime
 
@@ -67,21 +66,6 @@ static NSMutableDictionary<NSNumber *, id> *g_startTimesWithTags = nil;
   if (_active) {
     _internalContents = [NSMutableString stringWithString:contents];
   }
-}
-
-- (NSUInteger)loggerSerialNumber
-{
-  return _loggerSerialNumber;
-}
-
-- (FBSDKLoggingBehavior)loggingBehavior
-{
-  return _loggingBehavior;
-}
-
-- (BOOL)isActive
-{
-  return _active;
 }
 
 // Public instance methods

--- a/FBSDKCoreKit/FBSDKCoreKit/FBSDKLogger.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/FBSDKLogger.m
@@ -33,10 +33,11 @@ static NSMutableDictionary<NSNumber *, id> *g_startTimesWithTags = nil;
 @property (nonatomic, readonly, strong) NSMutableString *internalContents;
 @end
 
-@implementation FBSDKLogger
-NSUInteger _loggerSerialNumber;
-FBSDKLoggingBehavior _loggingBehavior;
-BOOL _active;
+@implementation FBSDKLogger {
+    NSUInteger _loggerSerialNumber;
+    FBSDKLoggingBehavior _loggingBehavior;
+    BOOL _active;
+}
 
 // Lifetime
 

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Codeless/CodelessIndexerTests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/Codeless/CodelessIndexerTests.swift
@@ -40,7 +40,7 @@ class CodelessIndexerTests: XCTestCase { // swiftlint:disable:this type_body_len
     size: CGSize(width: 36, height: 36)
   )
   lazy var view = {
-    return UIView(frame: frame)
+    UIView(frame: frame)
   }()
   let autoEventSetupEnabled = "auto_event_setup_enabled"
 

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/PaymentProductRequestorTests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/PaymentProductRequestorTests.swift
@@ -538,7 +538,7 @@ class PaymentProductRequestorTests: XCTestCase { // swiftlint:disable:this type_
     )
     XCTAssertFalse(
       store.capturedValues.contains {
-        return $0.value as? String == identifier
+        $0.value as? String == identifier
       },
       "Logging a trial start should clear the original transaction"
     )


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Converts ObjC global variables to instance variables. I think they were mistakenly made global since they are only set in the initializer of the logger. Found with thread sanitizer:
```
WARNING: ThreadSanitizer: data race (pid=38749)
  Write of size 1 at 0x00011b5b0168 by thread T16:
    #0 -[FBSDKLogger initWithLoggingBehavior:]
    
  Previous write of size 1 at 0x00011b5b0168 by main thread (mutexes: write M554359606512535976, write M201389934177928688, write M99642146494846552):
    #0 -[FBSDKLogger initWithLoggingBehavior:]
    
  Location is global '_active' at 0x00011b5b0168 (TripAdvisor+0x00010e3a7168)
```

## Test Plan

Test Plan: CI
