### PR TITLE
AppLinkUtility.fetchDeferredAppLink never calling completion on error and blocks main thread

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
@@ -160,6 +160,10 @@ static dispatch_once_t sharedConfigurationManagerNonce;
     self.isLoadingConfiguration = NO;
     self.hasRequeryFinishedForAppStart = YES;
     if (error) {
+        for (FBSDKAppEventsConfigurationManagerBlock completionBlock in g_completionBlocks) {
+          completionBlock();
+        }
+        [g_completionBlocks removeAllObjects];
       return;
     }
     self.configuration = [[FBSDKAppEventsConfiguration alloc] initWithJSON:response];

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
@@ -163,7 +163,7 @@ static dispatch_once_t sharedConfigurationManagerNonce;
       for (FBSDKAppEventsConfigurationManagerBlock completionBlock in self.completionBlocks) {
         completionBlock();
       }
-      [g_completionBlocks removeAllObjects];
+      [self.completionBlocks removeAllObjects];
       return;
     }
     self.configuration = [[FBSDKAppEventsConfiguration alloc] initWithJSON:response];

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsConfigurationManager.m
@@ -160,10 +160,10 @@ static dispatch_once_t sharedConfigurationManagerNonce;
     self.isLoadingConfiguration = NO;
     self.hasRequeryFinishedForAppStart = YES;
     if (error) {
-        for (FBSDKAppEventsConfigurationManagerBlock completionBlock in g_completionBlocks) {
-          completionBlock();
-        }
-        [g_completionBlocks removeAllObjects];
+      for (FBSDKAppEventsConfigurationManagerBlock completionBlock in self.completionBlocks) {
+        completionBlock();
+      }
+      [g_completionBlocks removeAllObjects];
       return;
     }
     self.configuration = [[FBSDKAppEventsConfiguration alloc] initWithJSON:response];

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsConfigurationManagerTests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/FBSDKAppEventsConfigurationManagerTests.swift
@@ -284,8 +284,10 @@ class FBSDKAppEventsConfigurationManagerTests: XCTestCase {
   }
 
   func testCompleteLoadingWithError() {
+    var firstCompletionCallCount = 0
     AppEventsConfigurationManager.loadAppEventsConfiguration {
-      XCTFail("Completing with an error should probably invoke the completions but it wont")
+      // Completions now correctly calaled with error. As to not block the main thread.
+      firstCompletionCallCount += 1
     }
     connection.capturedCompletion?(nil, nil, SampleError())
 
@@ -297,6 +299,7 @@ class FBSDKAppEventsConfigurationManagerTests: XCTestCase {
       AppEventsConfigurationManager.shared.timestamp,
       "Completing with an error should not set a timestamp"
     )
+    XCTAssertEqual(firstCompletionCallCount, 1)
   }
 
   func testCompleteLoadingWithErrorDoesNotClearPendingCompletions() {
@@ -316,8 +319,8 @@ class FBSDKAppEventsConfigurationManagerTests: XCTestCase {
     settings.appID = nil
     AppEventsConfigurationManager.loadAppEventsConfiguration {}
 
-    XCTAssertEqual(firstCompletionCallCount, 1)
-    XCTAssertEqual(secondCompletionCallCount, 1)
+    XCTAssertEqual(firstCompletionCallCount, 2)
+    XCTAssertEqual(secondCompletionCallCount, 2)
   }
 
   func testUnarchivesStoredCaptureEvents() {


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Completion handles are called now even when an error occurs. Due to issue where the following code has to be executed on the main thread. When Facebook down as it was last night the SDK stops working and as a result the main thread was blocked. This ensures that the completion is still called regardless.

`AppLinkUtility.fetchDeferredAppLink { url, _ in
            completion(url)
}`

## Test Plan

Test Plan:
* Updated two unit tests regarding these completions
* Tested manually by launching application with the above last night when Facebook was down and worked as expected. This can also be tested if you launch the application with above code with aeroplane mode turned on.

