### PR TITLE
[FBSDKCoreKit] Remove double semicolon causing compilation errors

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/include/FBSDKSettings.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/include/FBSDKSettings.h
@@ -153,7 +153,7 @@ NS_SWIFT_NAME(jpegCompressionQuality);
  A convenient way to toggle error recovery for all FBSDKGraphRequest instances created after this is set.
  */
 @property (class, nonatomic, getter = isGraphErrorRecoveryEnabled) BOOL graphErrorRecoveryEnabled
-  DEPRECATED_MSG_ATTRIBUTE("`Settings.isGraphErrorRecoveryEnabled` is deprecated and will be removed in the next major release, please use `Settings.shared.isGraphErrorRecoveryEnabled` instead");;
+  DEPRECATED_MSG_ATTRIBUTE("`Settings.isGraphErrorRecoveryEnabled` is deprecated and will be removed in the next major release, please use `Settings.shared.isGraphErrorRecoveryEnabled` instead");
 
 /**
  A convenient way to toggle error recovery for all FBSDKGraphRequest instances created after this is set.

--- a/FBSDKCoreKit/FBSDKCoreKit/include/FBSDKURLScheme.h
+++ b/FBSDKCoreKit/FBSDKCoreKit/include/FBSDKURLScheme.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef NSString *FBSDKURLScheme NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(URLScheme);;
+typedef NSString *FBSDKURLScheme NS_TYPED_EXTENSIBLE_ENUM NS_SWIFT_NAME(URLScheme);
 
 FOUNDATION_EXPORT FBSDKURLScheme const FBSDKURLSchemeFacebookApp;
 FOUNDATION_EXPORT FBSDKURLScheme const FBSDKURLSchemeFacebookAPI;


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes) (no rights to do it in this repo)

## Pull Request Details

This PR is an attempt fix for https://github.com/facebook/facebook-ios-sdk/issues/1939.

There are other instances of double semicolon in internal code, but those don't create issues when integrating pre-compiled artifacts.