### PR TITLE
Fix log in grammar

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorConfiguration.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/Internal/ServerConfiguration/FBSDKErrorConfiguration.m
@@ -62,7 +62,7 @@ static NSString *const kErrorCategoryLogin = @"login";
         @"ErrorRecovery.Login.Suggestion",
         @"FacebookSDK",
         [FBSDKInternalUtility.sharedUtility bundleForStrings],
-        @"Please log into this app again to reconnect your Facebook account.",
+        @"Please log in to this app again to reconnect your Facebook account.",
         @"The fallback message to display to recover invalidated tokens"
       );
       NSArray<NSDictionary<NSString *, id> *> *fallbackArray = @[


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details
This pull request replaces "into" with "in to" as "log in" is a phrasal verb. The Facebook website used to show [Log Into Facebook](https://webcache.googleusercontent.com/search?q=cache%3Aj0A5ZsypiDgJ%3Ahttps%3A%2F%2Fwww.facebook.com%2Flogin.php%2F%20&cd=1&hl=en&ct=clnk&gl=de) but now displays [Log in to Facebook](https://www.facebook.com/login.php/).