### PR TITLE
Add the necessary dependencies to build gaming services product.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -153,7 +153,7 @@ extension Target {
 
     static let share = target(name: .share, dependencies: [.core, .Prefixed.share])
 
-    static let gaming = target(name: .gaming, dependencies: [.Prefixed.gaming])
+	static let gaming = target(name: .gaming, dependencies: [.core, .share, .Prefixed.gaming])
 
     enum Prefixed {
         static let basics = binaryTarget(
@@ -191,6 +191,7 @@ extension Target {
 extension Target.Dependency {
     static let aem = byName(name: .aem)
     static let core = byName(name: .core)
+	static let share = byName(name: .share)
 
     enum Prefixed {
         static let aem = byName(name: .Prefixed.aem)


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [X] sign [contributor license agreement](https://code.facebook.com/cla)
- [X] I've ensured that all existing tests pass and added tests (when/where necessary)
- [X] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [X] I've added the proper label to this pull request (e.g. `bug` for bug fixes) [I don't seem to have permissions for this]

## Pull Request Details

Building the gaming services product from the Swift package in Xcode results in compilation errors, whether just building from the package or within the context of a package dependency in an application project. These are the result of missing dependencies for the core and sharing targets in the gaming target definition. Adding these dependencies fixes the issue and allows building the gaming services product. 

https://github.com/facebook/facebook-ios-sdk/issues/2194

## Test Plan

Test Plan: I cannot do this, but would make sure all build infrastructure automation continues to function as expected, as the dependency graph for the gaming services product has changed.
