### PR TITLE
Align `LoginManager`'s  `login` method's access control level

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift
+++ b/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift
@@ -245,7 +245,7 @@ public final class LoginManager: NSObject {
    - parameter viewController: Optional view controller to present from. Default: topmost view controller.
    - parameter completion: Optional callback.
    */
-  func logIn(
+  public func logIn(
     permissions: [Permission] = [.publicProfile],
     viewController: UIViewController? = nil,
     completion: LoginResultBlock? = nil


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Hello, I have noticed `LoginManager`'s `login(permissions:viewController:completion)` isn't available when integrating `FBSDKLoginKit`. Here are some details:

* Until `14.0.0`, this method used to be defined as part of `public extension` of `LoginManager`.
  * e.g. On `14.0.0`
    * `public extension`: https://github.com/facebook/facebook-ios-sdk/blob/84107793d352dbf698e3df4bf158d0af3633e3df/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift#L25
    * Method: https://github.com/facebook/facebook-ios-sdk/blob/84107793d352dbf698e3df4bf158d0af3633e3df/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift#L54-L58
    * Since this is part of the `public extension`, it's access level was public.
* On `14.1.0` or later, `LoginManager` is defined as an independent class.
  * `public final class`: https://github.com/facebook/facebook-ios-sdk/blob/fac1b605fcbaba06de15193a0928281ab3ffe7f4/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift#L27
  * Method: https://github.com/facebook/facebook-ios-sdk/blob/fac1b605fcbaba06de15193a0928281ab3ffe7f4/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift#L248-L252
  * Different from other `login` methods, access control level is not specified, and thus this is internal.
* Commit for this change: [link](https://github.com/facebook/facebook-ios-sdk/commit/8c733434c953528c2500bfe6008fa78911648fd7#diff-36f62e7998a14e6cb1b674e60a27ddc39d69263bd519c71c9e7af0c33f0f09de).
  * I am unsure if this change was intentional, but because other `login` methods were marked as public in this commit, guessing this was simply missed.

To use this `login` method from `FBSDKLoginKit`'s user (app), I'd like to make it public.
Let me know if I'm misunderstanding something.

## Test Plan

Test Plan: **Add your test plan here**
