### PR TITLE
Perform heavy operations with timeout to prevent app hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Update the implementation for SKAdNetwork to use the latest Apple API
 
+### Fixed
+
+- Fix an issue when the SDK may hang the app for devices with low memory.
+
 [2023-09-21](https://github.com/facebook/facebook-ios-sdk/releases/tag/v16.2.0) |
 [Full Changelog](https://github.com/facebook/facebook-ios-sdk/compare/v16.1.3...v16.2.0)
 

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsStateManager.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsStateManager.m
@@ -7,6 +7,7 @@
  */
 
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h>
 #import <FBSDKCoreKit_Basics/FBSDKCoreKit_Basics.h>
 #import <Foundation/Foundation.h>
 
@@ -61,7 +62,9 @@
   [FBSDKTypeUtility array:existingEvents addObject:appEventsState];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [NSKeyedArchiver archiveRootObject:existingEvents toFile:[self filePath]];
+  [FBSDKDispatchTools performSyncOnBackgroundWithTimeout:2 block:^{
+    [NSKeyedArchiver archiveRootObject:existingEvents toFile:[self filePath]];
+  }];
 #pragma clang diagnostic pop
   self.canSkipDiskCheck = NO;
 }

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsUtility.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKAppEventsUtility.m
@@ -153,7 +153,11 @@ static FBSDKAppEventsUtility *_shared;
 
   ASIdentifierManager *manager = [self _asIdentifierManagerWithShouldUseCachedManager:shouldUseCachedManager
                                                              dynamicFrameworkResolver:dynamicFrameworkResolver];
-  return manager.advertisingIdentifier.UUIDString;
+  __block NSString* adid = nil;
+  [FBSDKDispatchTools performSyncOnBackgroundWithTimeout:2 block:^{
+    adid = manager.advertisingIdentifier.UUIDString;
+  }];
+  return adid;
 }
 
 - (ASIdentifierManager *)_asIdentifierManagerWithShouldUseCachedManager:(BOOL)shouldUseCachedManager

--- a/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKTimeSpentData.m
+++ b/FBSDKCoreKit/FBSDKCoreKit/AppEvents/Internal/FBSDKTimeSpentData.m
@@ -7,6 +7,7 @@
  */
 
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <FBSDKCoreKit/FBSDKCoreKit-Swift.h>
 #import <FBSDKCoreKit_Basics/FBSDKCoreKit_Basics.h>
 
 #import "FBSDKAppEventName+Internal.h"
@@ -130,10 +131,12 @@ static const long INACTIVE_SECONDS_QUANTA[] =
 
   NSString *content = [FBSDKBasicUtility JSONStringForObject:timeSpentData error:NULL invalidObjectHandler:NULL];
 
-  [content writeToFile:[FBSDKBasicUtility persistenceFilePath:FBSDKTimeSpentFilename]
-            atomically:YES
-              encoding:NSASCIIStringEncoding
-                 error:nil];
+  [FBSDKDispatchTools performSyncOnBackgroundWithTimeout:2 block:^{
+    [content writeToFile:[FBSDKBasicUtility persistenceFilePath:FBSDKTimeSpentFilename]
+              atomically:YES
+                encoding:NSASCIIStringEncoding
+                   error:nil];
+  }];
 
   NSString *msg = [NSString stringWithFormat:@"FBSDKTimeSpentData Persist: %@", content];
   [FBSDKLogger singleShotLogEntry:FBSDKLoggingBehaviorAppEvents

--- a/FBSDKCoreKit/FBSDKCoreKit/DispatchTools.swift
+++ b/FBSDKCoreKit/FBSDKCoreKit/DispatchTools.swift
@@ -1,0 +1,29 @@
+//
+//  DispatchTools.swift
+//  FBSDKCoreKit
+//
+//  Created by Narek Sahakyan on 11.10.23.
+//  Copyright © 2023 Facebook. All rights reserved.
+//
+
+import Foundation
+
+@objcMembers
+@objc(FBSDKDispatchTools)
+public final class DispatchTools: NSObject {
+  /// Perform synchronous task on background thread.
+  /// - Parameters:
+  ///   - timeout: The latest time to wait for a task.
+  ///   - block: The block to be invoked on the global queue with userInteractive priority.
+  /// - Returns: A value of returned task or nil if timeout with pass.
+  public static func performSyncOnBackground(timeout: TimeInterval, block: @escaping () -> ()) {
+    let semaphore = DispatchSemaphore(value: 0)
+
+    DispatchQueue.global(qos: .userInteractive).async {
+      block()
+      semaphore.signal()
+    }
+
+    _ = semaphore.wait(timeout: .now() + timeout)
+  }
+}


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

In our application we got lot's of app hangs and crashes (mainly on devices with low storage) because the SDK performs heavy operations on main thread (~5000 crashes per month). There is even an open [issue](https://github.com/facebook/facebook-ios-sdk/issues/2247), please take a look. 

The purpose of this PR is to put timeouts on those operations.

## Test Plan

Test Plan: **Add your test plan here**
