### PR TITLE
Fix images being out of order in ShareDialog

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/UserInterface/ShareDialog.swift
+++ b/FBSDKShareKit/FBSDKShareKit/UserInterface/ShareDialog.swift
@@ -344,8 +344,8 @@ extension ShareDialog {
 
   private var contentImages: [UIImage] {
     if let photoContent = shareContent as? SharePhotoContent {
-      let uniqueImages = Set(photoContent.photos.compactMap(\.image))
-      return Array(uniqueImages)
+      var seen = Set<UIImage>()
+      return photoContent.photos.compactMap(\.image).filter { seen.insert($0).inserted }
     } else if let mediaContent = shareContent as? ShareMediaContent {
       return mediaContent.media.compactMap { ($0 as? SharePhoto)?.image }
     } else {


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://code.facebook.com/cla) (signed by company)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

When sharing multiple images their order is not stable:

```Swift
let content = SharePhotoContent()
content.photos = imagePaths
let dialog = ShareDialog(viewController: presenter, content: content, delegate: delegate)
try dialog.validate()
dialog.show()
```

This is because they are uniqued by converting into a `Set` and back to an `Array`:

```
let uniqueImages = Set(photoContent.photos.compactMap(\.image))
return Array(uniqueImages)
```

This PR ensures that the original order is preserved by using an `Array.filter` with an auxiliary `Set` to keep the performance `O(n)`.


## Test Plan

Uniquing is done in a private property and is currently not covered by tests.
