### PR TITLE
Increase SharePhotoContent photos limit to 10

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/Content/SharePhotoContent.swift
+++ b/FBSDKShareKit/FBSDKShareKit/Content/SharePhotoContent.swift
@@ -116,8 +116,8 @@ extension SharePhotoContent: SharingContent {
 // MARK: - SharingValidatable
 
 extension SharePhotoContent: SharingValidatable {
-  // The number of photos that can be shared at once is restricted
-  private static let photosCountRange = 1 ... 6
+  // The number of photos that can be shared at once is restricted by SLComposeViewController
+  private static let photosCountRange = 1 ... 10
 
   /// Validate that this content contains valid values
   @objc(validateWithOptions:error:)

--- a/FBSDKShareKit/FBSDKShareKitTests/Content/SharePhotoContentTests.swift
+++ b/FBSDKShareKit/FBSDKShareKitTests/Content/SharePhotoContentTests.swift
@@ -81,7 +81,7 @@ final class SharePhotoContentTests: XCTestCase {
     XCTAssertNoThrow(try content.validate(options: []))
     XCTAssertEqual(validator.validateArrayArray as? [SharePhoto], content.photos, .validationValidatesPhotos)
     XCTAssertEqual(validator.validateArrayMinCount, 1, .validationValidatesPhotos)
-    XCTAssertEqual(validator.validateArrayMaxCount, 6, .validationValidatesPhotos)
+    XCTAssertEqual(validator.validateArrayMaxCount, 10, .validationValidatesPhotos)
     XCTAssertEqual(validator.validateArrayName, "photos", .validationValidatesPhotos)
   }
 
@@ -92,7 +92,7 @@ final class SharePhotoContentTests: XCTestCase {
     XCTAssertThrowsError(try content.validate(options: []), .validationValidatesPhotos)
     XCTAssertEqual(validator.validateArrayArray as? [SharePhoto], content.photos, .validationValidatesPhotos)
     XCTAssertEqual(validator.validateArrayMinCount, 1, .validationValidatesPhotos)
-    XCTAssertEqual(validator.validateArrayMaxCount, 6, .validationValidatesPhotos)
+    XCTAssertEqual(validator.validateArrayMaxCount, 10, .validationValidatesPhotos)
     XCTAssertEqual(validator.validateArrayName, "photos", .validationValidatesPhotos)
   }
 


### PR DESCRIPTION
- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

`SLComposeViewController` has a limit of 10 images for sharing to Facebook. This PR increases the limit imposed by `FBSDKShareKit` from 6 to 10 and clarifies the comment.

## Test Plan

Test Plan: Updated the current tests to reflect the change.
