### PR TITLE
make ViewController nullable param in reauthorizeDataAccess

### DIFF
--- a/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift
+++ b/FBSDKLoginKit/FBSDKLoginKit/LoginManager.swift
@@ -303,7 +303,7 @@ public final class LoginManager: NSObject {
    */
   @objc(reauthorizeDataAccess:handler:)
   public func reauthorizeDataAccess(
-    from viewController: UIViewController,
+    from viewController: UIViewController?,
     handler: @escaping LoginManagerLoginResultBlock
   ) {
     guard


### PR DESCRIPTION
To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

👋  hello from the [react-native-fbsdk-next](https://github.com/thebergamo/react-native-fbsdk-next) maintainer 😄 

I would like the `reauthorizeDataAccess` ViewController param to conform to the nullability documented for it, and acceptable to the methods it passes the param to

## Test Plan

Untested (not entirely true, we've been [actively sending nil through this API](https://github.com/thebergamo/react-native-fbsdk-next/pull/204/files#diff-17f183fc0de77f22952fc0fddd688c62adde2533c3dc32798d9f836390f08454R110) since [our first implementation using the API](https://github.com/thebergamo/react-native-fbsdk-next/pull/204), and it's worked fine)

Fixes #2476