### PR TITLE
Fix missing dependency for FacebookAEM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,7 +148,7 @@ extension Target {
 
     static let aem = target(
         name: .aem,
-        dependencies: [.Prefixed.aem],
+        dependencies: [.Prefixed.aem, .Prefixed.basics],
         resources: [
            .copy("Resources/PrivacyInfo.xcprivacy"),
         ]


### PR DESCRIPTION
When building an iOS application with the latest facebook-ios-sdk, I get this error:
```
/private/var/tmp/_bazel_shukantpal/efbe2e79ba1c0bdcd3165017ca0cd2cb/execroot/_main/external/rules_swift_package_manager++swift_deps+swiftpkg_facebook_ios_sdk/remote/archive/FBAEMKit-Dynamic_XCFramework.zip/FBAEMKit.xcframework/ios-arm64/FBAEMKit.framework/Modules/FBAEMKit.swiftmodule/arm64-apple-ios.private.swiftinterface: 0:/private/var/tmp/_bazel_shukantpal/efbe2e79ba1c0bdcd3165017ca0cd2cb/execroot/_main/external/rules_swift_package_manager++swift_deps+swiftpkg_facebook_ios_sdk/remote/archive/FBAEMKit-Dynamic_XCFramework.zip/FBAEMKit.xcframework/ios-arm64/FBAEMKit.framework/Modules/FBAEMKit.swiftmodule/arm64-apple-ios.private.swiftinterface:7:8: error: no such module 'FBSDKCoreKit_Basics'
 5 | import CommonCrypto
 6 | import CommonCrypto.CommonHMAC
 7 | import FBSDKCoreKit_Basics
   |        `- error: no such module 'FBSDKCoreKit_Basics'
 8 | import Foundation
 9 | import Swift
external/rules_swift_package_manager++swift_deps+swiftpkg_facebook_ios_sdk/Sources/FacebookAEM/Exports.swift:10:19: error: missing required module 'FBSDKCoreKit_Basics'
 8 |
 9 | #if canImport(FBAEMKit)
10 | @_exported import FBAEMKit
   |                   `- error: missing required module 'FBSDKCoreKit_Basics'
11 | #endif
12 |
```

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

This is to be due to the fact that `FBAEMKit` depends on `FBSDKCoreKit_Basics` internally. By declaring this dependency explicitly, Bazel is able to compile the AEM component successfully.

## Test Plan

We were able to integrate the FB SDK into the app successfully with Bazel.