### PR TITLE
Prioritize user consent over server configuration for auto log app events

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKit/Settings+AutoLogAppEvents.swift
+++ b/FBSDKCoreKit/FBSDKCoreKit/Settings+AutoLogAppEvents.swift
@@ -16,16 +16,20 @@ extension Settings {
     guard let dependencies = try? getDependencies() else {
       return true
     }
+
+    if let locallyEnabled = checkClientSideConfiguration(dependencies) {
+      return locallyEnabled
+    }
+
     guard let migratedAutoLogValues = dependencies
       .serverConfigurationProvider.cachedServerConfiguration().migratedAutoLogValues else {
       return isAutoLogAppEventsEnabledLocally
     }
+
     if let migratedAutoLogEnabled = migratedAutoLogValues[AutoLogAppEventServerFlags.ENABLE.rawValue] as? NSNumber {
       return migratedAutoLogEnabled.boolValue
     }
-    if let locallyEnabled = checkClientSideConfiguration(dependencies) {
-      return locallyEnabled
-    }
+
     if let migratedDefault = migratedAutoLogValues[AutoLogAppEventServerFlags.DEFAUT.rawValue] as? NSNumber {
       return migratedDefault.boolValue
     }


### PR DESCRIPTION
Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [✅] sign [contributor license agreement](https://code.facebook.com/cla)
- [✅] I've ensured that all existing tests pass and added tests (when/where necessary)
- [❌] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [❌] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details
This PR intends to fix the order of prioritisation of the isAutoLogAppEventsEnabled bool. First, it checks if the user gave its consent on the client side, before checking the server configuration of it.
