### PR TITLE
Add support for building for arm64e

### DIFF
--- a/Configurations/Common.xcconfig
+++ b/Configurations/Common.xcconfig
@@ -11,7 +11,7 @@
 ALWAYS_SEARCH_USER_PATHS = NO
 
 // Architectures to build
-ARCHS = $(ARCHS_STANDARD)
+ARCHS = $(ARCHS_STANDARD) arm64e
 
 // Whether to enable module imports
 CLANG_ENABLE_MODULES = YES

--- a/Configurations/FacebookSDK-Project.xcconfig
+++ b/Configurations/FacebookSDK-Project.xcconfig
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 
 // Architectures
-ARCHS = i386 armv7 x86_64 arm64
+ARCHS = i386 armv7 x86_64 arm64 arm64e
 IPHONEOS_DEPLOYMENT_TARGET = 12.0
 SDKROOT = iphoneos
 

--- a/samples/Configurations/Project.xcconfig
+++ b/samples/Configurations/Project.xcconfig
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 
 // Architectures
-ARCHS = i386 armv7 x86_64 arm64
+ARCHS = i386 armv7 x86_64 arm64 arm64e
 IPHONEOS_DEPLOYMENT_TARGET = 11.0
 SDKROOT = iphoneos
 


### PR DESCRIPTION
I tried this locally and inspected the output generated by building the xcode project from:
```
./generate-projects.sh --force-with-wrong-xcodegen && open FacebookSDK.xcworkspace
```

```
❯ file DerivedData/FacebookSDK-czxesabkqlyaeobatcjqwgponbxb/Build/Intermediates.noindex/FBSDKGamingServicesKit.build/Debug-iphoneos/FBSDKGamingServicesKit-Dynamic.build/Objects-normal/arm64e/Binary/FBSDKGamingServicesKit: Mach-O 64-bit dynamically linked shared library arm64e
```

I do not know how to test if the output is runnable or not. 