### PR TITLE
Fix typos: occured to occurred and recieved to received

### DIFF
--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GameRequestDialog.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GameRequestDialog.swift
@@ -154,7 +154,7 @@ public final class GameRequestDialog: NSObject {
     let bridgeAPIError = errorFactory.error(
       code: CoreError.errorBridgeAPIInterruption.rawValue,
       userInfo: nil,
-      message: "Error occured while interacting with Gaming Services, Failed to open bridge.",
+      message: "Error occurred while interacting with Gaming Services, Failed to open bridge.",
       underlyingError: error
     )
     handleDialogError(bridgeAPIError)

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingPayloadDelegate.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingPayloadDelegate.swift
@@ -12,14 +12,14 @@ import Foundation
 public protocol GamingPayloadDelegate: NSObjectProtocol {
   /**
    Delegate method will be triggered when a `GamingPayloadObserver` parses a url with a payload and game request ID
-   @param payload The payload recieved in the url
-   @param gameRequestID The game request ID recieved in the url
+   @param payload The payload received in the url
+   @param gameRequestID The game request ID received in the url
    */
   @objc optional func parsedGameRequestURLContaining(_ payload: GamingPayload, gameRequestID: String)
 
   /**
    Delegate method will be triggered when a `GamingPayloadObserver` parses a gaming context url with a payload and game context token ID. The current gaming context will be update with the context ID.
-   @param payload The payload recieved in the url
+   @param payload The payload received in the url
    */
   @objc optional func parsedGamingContextURLContaining(_ payload: GamingPayload)
 

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingPayloadObserver.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingPayloadObserver.swift
@@ -47,11 +47,11 @@ public final class GamingPayloadObserver: NSObject {
   private func parseURLForPayloadEntryData(appLinkUrl: AppLinkURL) -> [String: String]? {
     let expectedParameters = Keys.allCases.map { $0.rawValue }
     let urlParameters = appLinkUrl.appLinkExtras
-    let recievedParameters = urlParameters?.filter { expectedParameters.contains($0.key) }
-    let containsPayload = recievedParameters?[Keys.gamingPayload.rawValue] != nil
+    let receivedParameters = urlParameters?.filter { expectedParameters.contains($0.key) }
+    let containsPayload = receivedParameters?[Keys.gamingPayload.rawValue] != nil
 
     if containsPayload, recievedParameters?.keys.count ?? 0 > 1 {
-      return recievedParameters as? [String: String]
+      return receivedParameters as? [String: String]
     }
     return [:]
   }

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServiceCompletionHandler.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServiceCompletionHandler.swift
@@ -12,7 +12,7 @@ import Foundation
  Main completion handling of any Gaming Service (Friend Finder, Image/Video Upload).
 
  @param success whether the call to the service was considered a success.
- @param error the error that occured during the service call, if any.
+ @param error the error that occurred during the service call, if any.
  */
 public typealias GamingServiceCompletionHandler = (_ success: Bool, _ error: Error?) -> Void
 public typealias FBSDKGamingServiceCompletionHandler = GamingServiceCompletionHandler
@@ -22,7 +22,7 @@ public typealias FBSDKGamingServiceCompletionHandler = GamingServiceCompletionHa
 
  @param success whether the call to the service was considered a success.
  @param result the result that was returned by the service, if any.
- @param error the error that occured during the service call, if any.
+ @param error the error that occurred during the service call, if any.
  */
 public typealias GamingServiceResultCompletion = (_ success: Bool, _ result: [String: Any]?, _ error: Error?) -> Void
 public typealias FBSDKGamingServiceResultCompletion = GamingServiceResultCompletion

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServicesDialogError.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServicesDialogError.swift
@@ -16,7 +16,7 @@ public enum GamingServicesDialogError: Error {
   /// Indicates a failure based on missing dialog content
   case missingContent
 
-  /// Indicates error occured creating dialog deeplink
+  /// Indicates error occurred creating dialog deeplink
   case deeplinkURLCreation
 
   /// Indicates that the dialog was cancelled

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/GamingServiceController.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/GamingServiceController.swift
@@ -51,7 +51,7 @@ final class GamingServiceController: NSObject {
       _ErrorFactory().error(
         code: CoreError.errorBridgeAPIInterruption.rawValue,
         userInfo: nil,
-        message: "\(error != nil ? "Error" : "An unknown error") occured while interacting with Gaming Services",
+        message: "\(error != nil ? "Error" : "An unknown error") occurred while interacting with Gaming Services",
         underlyingError: error
       )
     )

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/GameRequestDialogTests.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/GameRequestDialogTests.swift
@@ -260,7 +260,7 @@ final class GameRequestDialogTests: XCTestCase {
     let expectedError = TestSDKError(
       type: .general,
       code: CoreError.errorBridgeAPIInterruption.rawValue,
-      message: "Error occured while interacting with Gaming Services, Failed to open bridge.",
+      message: "Error occurred while interacting with Gaming Services, Failed to open bridge.",
       underlyingError: error
     )
     let capturedError = try XCTUnwrap(

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/TournamentFetcherTests.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/TournamentFetcherTests.swift
@@ -95,7 +95,7 @@ final class TournamentFetcherTests: XCTestCase {
       switch result {
       case let .failure(error):
         guard case .invalidAuthToken = error else {
-          return XCTFail("Was expecting invalid auth token error, instead recieved:\(error)")
+          return XCTFail("Was expecting invalid auth token error, instead received:\(error)")
         }
 
       case .success:
@@ -115,7 +115,7 @@ final class TournamentFetcherTests: XCTestCase {
       switch result {
       case let .failure(error):
         guard case .invalidAccessToken = error else {
-          return XCTFail("Was expecting invalid access token error, instead recieved:\(error)")
+          return XCTFail("Was expecting invalid access token error, instead received:\(error)")
         }
 
       case .success:


### PR DESCRIPTION
Fixes spelling errors in GamingServicesKit comments and test messages. Corrects "occured" to "occurred" and "recieved" to "received" across multiple files.