### PR TITLE
Raise minimum iOS deployment target to 15

### DIFF
--- a/Configurations/FacebookSDK-Project.xcconfig
+++ b/Configurations/FacebookSDK-Project.xcconfig
@@ -6,7 +6,7 @@
 
 // Architectures
 ARCHS = $(ARCHS_STANDARD) arm64e
-IPHONEOS_DEPLOYMENT_TARGET = 12.0
+IPHONEOS_DEPLOYMENT_TARGET = 15.0
 SDKROOT = iphoneos
 
 // Build Options

--- a/Configurations/Platform/iOS.xcconfig
+++ b/Configurations/Platform/iOS.xcconfig
@@ -5,7 +5,7 @@
 // LICENSE file in the root directory of this source tree.
 
 SDKROOT = iphoneos
-IPHONEOS_DEPLOYMENT_TARGET = 12.0
+IPHONEOS_DEPLOYMENT_TARGET = 15.0
 
 // Supported device families (1 is iPhone, 2 is iPad, 3 is Apple TV)
 TARGETED_DEVICE_FAMILY = 1,2

--- a/FBAEMKit.podspec
+++ b/FBAEMKit.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
     s.author       = 'Facebook'
 
     s.platform     = :ios
-    s.ios.deployment_target = '12.0'
+    s.ios.deployment_target = '15.0'
 
     s.source = {
       http: "https://github.com/facebook/facebook-ios-sdk/releases/download/v#{s.version}/FacebookSDK_Dynamic.xcframework.zip",

--- a/FBSDKCoreKit.podspec
+++ b/FBSDKCoreKit.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
 
   s.platform     = :ios
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '15.0'
 
   s.source = {
       http: "https://github.com/facebook/facebook-ios-sdk/releases/download/v#{s.version}/FacebookSDK_Dynamic.xcframework.zip",

--- a/FBSDKCoreKit_Basics.podspec
+++ b/FBSDKCoreKit_Basics.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
 
   s.platform     = :ios
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '15.0'
   s.library = 'z'
 
   s.source = {

--- a/FBSDKGamingServicesKit.podspec
+++ b/FBSDKGamingServicesKit.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
 
   s.platform     = :ios
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '15.0'
 
   s.swift_version = '5.0'
 

--- a/FBSDKLoginKit.podspec
+++ b/FBSDKLoginKit.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
 
   s.platform     = :ios
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '15.0'
 
   s.source = {
     http: "https://github.com/facebook/facebook-ios-sdk/releases/download/v#{s.version}/FacebookSDK_Dynamic.xcframework.zip",

--- a/FBSDKShareKit.podspec
+++ b/FBSDKShareKit.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   s.author       = 'Facebook'
 
   s.platform     = :ios
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '15.0'
 
   s.source = {
     http: "https://github.com/facebook/facebook-ios-sdk/releases/download/v#{s.version}/FacebookSDK_Dynamic.xcframework.zip",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import Darwin.C
 
 let package = Package(
     name: "Facebook",
-    platforms: [.iOS(.v12)],
+    platforms: [.iOS("15.0")],
     products: [
         // The Kernel of the SDK. Must be included as a runtime dependency.
         .basics,


### PR DESCRIPTION
Resolves #3828.

Xcode 27 beta no longer supports iOS deployment targets below **iOS 15**. The current `.iOS(.v12)` / `s.ios.deployment_target = '12.0'` / `IPHONEOS_DEPLOYMENT_TARGET = 12.0` declarations emit a `the iOS deployment target ... is set to 12.0, but the range of supported deployment target versions is 15.0 to ...` warning when building under Xcode 27.

### Changes
- `Package.swift`: `.iOS(.v12)` → `.iOS("15.0")`
- Six podspecs (`FBAEMKit`, `FBSDKCoreKit_Basics`, `FBSDKCoreKit`, `FBSDKLoginKit`, `FBSDKGamingServicesKit`, `FBSDKShareKit`): `s.ios.deployment_target` `12.0` → `15.0`
- `Configurations/FacebookSDK-Project.xcconfig` and `Configurations/Platform/iOS.xcconfig`: `IPHONEOS_DEPLOYMENT_TARGET` `12.0` → `15.0` (the samples config was already at 15.0)

The SwiftPM change uses the string form `.iOS("15.0")` because the `.v15` enum case is unavailable at this package's `swift-tools-version:5.3`.

### Verification
Built the full `Facebook-Package` scheme (all products) clean against the **iOS 27 SDK (Xcode 27.0 beta, 27A5194q)** for `generic/platform=iOS Simulator` — `** BUILD SUCCEEDED **`, no deployment-target warnings.