### PR TITLE
Fix recurring typos in GamingServicesKit, LoginKit, and tests (#1)

### DIFF
--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/AppEventsStateTests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/AppEvents/AppEventsStateTests.swift
@@ -328,7 +328,7 @@ final class AppEventsStateTests: XCTestCase {
     XCTAssertEqual(
       2,
       partiallyFullState.events.count,
-      "Should succesfully add events from another state"
+      "Should successfully add events from another state"
     )
     guard let operationalParametersFromTestState =
       partiallyFullState.events.last?["operationalParameters"] as? [AppOperationalDataType: [String: Any]] else {

--- a/FBSDKCoreKit/FBSDKCoreKitTests/Internal/BridgeAPI/ProtocolVersions/BridgeAPIProtocolWebV1Tests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/Internal/BridgeAPI/ProtocolVersions/BridgeAPIProtocolWebV1Tests.swift
@@ -228,7 +228,7 @@ final class BridgeAPIProtocolWebV1Tests: XCTestCase {
     XCTAssertEqual(
       response as? [String: String],
       [Keys.completionGesture: Values.cancel],
-      "Should indicate a cancelation when there's a cancellation error code"
+      "Should indicate a cancellation when there's a cancellation error code"
     )
   }
 }

--- a/FBSDKCoreKit/FBSDKCoreKitTests/SettingsTests.swift
+++ b/FBSDKCoreKit/FBSDKCoreKitTests/SettingsTests.swift
@@ -1131,7 +1131,7 @@ final class SettingsTests: XCTestCase {
   }
 
   func testAutoLogAppEventsEnabledFromServer_1() {
-    // set true for the server-side overriden value
+    // set true for the server-side overridden value
     let migratedAutoLogValues = ["auto_log_app_events_enabled": NSNumber(true)]
     serverConfigurationProvider.configs = ["migratedAutoLogValues": migratedAutoLogValues]
     // set false in info.plist
@@ -1139,12 +1139,12 @@ final class SettingsTests: XCTestCase {
     configureSettings()
     XCTAssertTrue(
       settings.isAutoLogAppEventsEnabled,
-      "Should favor the server-side overriden value over others"
+      "Should favor the server-side overridden value over others"
     )
   }
 
   func testAutoLogAppEventsEnabledFromServer_2() {
-    // set true for the server-side overriden value
+    // set true for the server-side overridden value
     let migratedAutoLogValues = ["auto_log_app_events_enabled": String("Some_Value")]
     serverConfigurationProvider.configs = ["migratedAutoLogValues": migratedAutoLogValues]
     configureSettings()
@@ -1180,7 +1180,7 @@ final class SettingsTests: XCTestCase {
   }
 
   func testAutoLogAppEventsEnabledFromLocal_2() {
-    // set true for the server-side overriden value
+    // set true for the server-side overridden value
     let migratedAutoLogValues = ["auto_log_app_events_default": NSNumber(true)]
     serverConfigurationProvider.configs = ["migratedAutoLogValues": migratedAutoLogValues]
     // set false in memory store

--- a/FBSDKCoreKit_Basics/FBSDKCoreKit_BasicsTests/LibAnalyzerTests.swift
+++ b/FBSDKCoreKit_Basics/FBSDKCoreKit_BasicsTests/LibAnalyzerTests.swift
@@ -28,7 +28,7 @@ final class LibAnalyzerTests: XCTestCase {
     ]
     var result = LibAnalyzer.symbolicateCallstack(callstack, methodMapping: methodMapping)
 
-    XCTAssertNotNil(result, "Should return a value if both paramaters were passed")
+    XCTAssertNotNil(result, "Should return a value if both parameters were passed")
     XCTAssertEqual(
       result,
       ["-[FBSDKWebViewAppLinkResolver appLinkFromALData:destination:]+3110632+0", "(2 DEV METHODS)"]

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GameRequestDialog.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GameRequestDialog.swift
@@ -154,7 +154,7 @@ public final class GameRequestDialog: NSObject {
     let bridgeAPIError = errorFactory.error(
       code: CoreError.errorBridgeAPIInterruption.rawValue,
       userInfo: nil,
-      message: "Error occured while interacting with Gaming Services, Failed to open bridge.",
+      message: "Error occurred while interacting with Gaming Services, Failed to open bridge.",
       underlyingError: error
     )
     handleDialogError(bridgeAPIError)

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingPayloadDelegate.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingPayloadDelegate.swift
@@ -12,14 +12,14 @@ import Foundation
 public protocol GamingPayloadDelegate: NSObjectProtocol {
   /**
    Delegate method will be triggered when a `GamingPayloadObserver` parses a url with a payload and game request ID
-   @param payload The payload recieved in the url
-   @param gameRequestID The game request ID recieved in the url
+   @param payload The payload received in the url
+   @param gameRequestID The game request ID received in the url
    */
   @objc optional func parsedGameRequestURLContaining(_ payload: GamingPayload, gameRequestID: String)
 
   /**
    Delegate method will be triggered when a `GamingPayloadObserver` parses a gaming context url with a payload and game context token ID. The current gaming context will be update with the context ID.
-   @param payload The payload recieved in the url
+   @param payload The payload received in the url
    */
   @objc optional func parsedGamingContextURLContaining(_ payload: GamingPayload)
 

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServiceCompletionHandler.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServiceCompletionHandler.swift
@@ -12,7 +12,7 @@ import Foundation
  Main completion handling of any Gaming Service (Friend Finder, Image/Video Upload).
 
  @param success whether the call to the service was considered a success.
- @param error the error that occured during the service call, if any.
+ @param error the error that occurred during the service call, if any.
  */
 public typealias GamingServiceCompletionHandler = (_ success: Bool, _ error: Error?) -> Void
 public typealias FBSDKGamingServiceCompletionHandler = GamingServiceCompletionHandler
@@ -22,7 +22,7 @@ public typealias FBSDKGamingServiceCompletionHandler = GamingServiceCompletionHa
 
  @param success whether the call to the service was considered a success.
  @param result the result that was returned by the service, if any.
- @param error the error that occured during the service call, if any.
+ @param error the error that occurred during the service call, if any.
  */
 public typealias GamingServiceResultCompletion = (_ success: Bool, _ result: [String: Any]?, _ error: Error?) -> Void
 public typealias FBSDKGamingServiceResultCompletion = GamingServiceResultCompletion

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServicesDialogError.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/GamingServicesDialogError.swift
@@ -16,7 +16,7 @@ public enum GamingServicesDialogError: Error {
   /// Indicates a failure based on missing dialog content
   case missingContent
 
-  /// Indicates error occured creating dialog deeplink
+  /// Indicates error occurred creating dialog deeplink
   case deeplinkURLCreation
 
   /// Indicates that the dialog was cancelled

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/GamingServiceController.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKit/Internal/GamingServiceController.swift
@@ -51,7 +51,7 @@ final class GamingServiceController: NSObject {
       _ErrorFactory().error(
         code: CoreError.errorBridgeAPIInterruption.rawValue,
         userInfo: nil,
-        message: "\(error != nil ? "Error" : "An unknown error") occured while interacting with Gaming Services",
+        message: "\(error != nil ? "Error" : "An unknown error") occurred while interacting with Gaming Services",
         underlyingError: error
       )
     )

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/GameRequestDialogTests.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/GameRequestDialogTests.swift
@@ -260,7 +260,7 @@ final class GameRequestDialogTests: XCTestCase {
     let expectedError = TestSDKError(
       type: .general,
       code: CoreError.errorBridgeAPIInterruption.rawValue,
-      message: "Error occured while interacting with Gaming Services, Failed to open bridge.",
+      message: "Error occurred while interacting with Gaming Services, Failed to open bridge.",
       underlyingError: error
     )
     let capturedError = try XCTUnwrap(

--- a/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/TournamentFetcherTests.swift
+++ b/FBSDKGamingServicesKit/FBSDKGamingServicesKitTests/TournamentFetcherTests.swift
@@ -95,7 +95,7 @@ final class TournamentFetcherTests: XCTestCase {
       switch result {
       case let .failure(error):
         guard case .invalidAuthToken = error else {
-          return XCTFail("Was expecting invalid auth token error, instead recieved:\(error)")
+          return XCTFail("Was expecting invalid auth token error, instead received:\(error)")
         }
 
       case .success:
@@ -115,7 +115,7 @@ final class TournamentFetcherTests: XCTestCase {
       switch result {
       case let .failure(error):
         guard case .invalidAccessToken = error else {
-          return XCTFail("Was expecting invalid access token error, instead recieved:\(error)")
+          return XCTFail("Was expecting invalid access token error, instead received:\(error)")
         }
 
       case .success:

--- a/FBSDKLoginKit/FBSDKLoginKit/LoginResult.swift
+++ b/FBSDKLoginKit/FBSDKLoginKit/LoginResult.swift
@@ -14,7 +14,7 @@ public typealias LoginResultBlock = (LoginResult) -> Void
 /// Describes the result of a login attempt.
 @frozen
 public enum LoginResult {
-  /// User succesfully logged in. Contains granted, declined permissions and access token.
+  /// User successfully logged in. Contains granted, declined permissions and access token.
   case success(granted: Set<Permission>, declined: Set<Permission>, token: AccessToken?)
   /// Login attempt was cancelled by the user.
   case cancelled


### PR DESCRIPTION
* Fix typos in GamingServicesKit and Settings tests

Correct recurring spelling mistakes across doc comments, user-facing error messages, and their coupled tests:
- "occured" -> "occurred"
- "recieved" -> "received"
- "overriden" -> "overridden"

The GameRequestDialog bridge-error message and its assertion in GameRequestDialogTests are updated together so the test keeps matching. No logic or public identifiers change.


Claude-Session: https://claude.ai/code/session_01CmNX4fpDpjkNJYpFDiktBV

* Fix additional typos in test messages and LoginResult doc

- "paramaters" -> "parameters"
- "succesfully" -> "successfully"
- "cancelation" -> "cancellation"

All changes are in XCTAssert failure messages and one doc comment; no logic, values, or public identifiers change.


Claude-Session: https://claude.ai/code/session_01CmNX4fpDpjkNJYpFDiktBV

---------

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://code.facebook.com/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
